### PR TITLE
Add support for item kit costing

### DIFF
--- a/application/controllers/Sales.php
+++ b/application/controllers/Sales.php
@@ -2,6 +2,9 @@
 
 require_once("Secure_Controller.php");
 
+define('PRICE_MODE_STANDARD', 0);
+define('PRICE_MODE_KIT', 1);
+
 class Sales extends Secure_Controller
 {
 	public function __construct()
@@ -400,8 +403,7 @@ class Sales extends Secure_Controller
 			$item_kit_id = $pieces[1];
 			$item_kit_info = $this->Item_kit->get_info($item_kit_id);
 			$kit_item_id = $item_kit_info->kit_item_id;
-			$price_option = $item_kit_info->price_option;
-			$stock_type = $item_kit_info->stock_type;
+			$kit_price_option = $item_kit_info->price_option;
 			$kit_print_option = $item_kit_info->print_option; // 0-all, 1-priced, 2-kit-only
 
 			if($item_kit_info->kit_discount_percent != 0 && $item_kit_info->kit_discount_percent > $discount)
@@ -414,7 +416,7 @@ class Sales extends Secure_Controller
 
 			if(!empty($kit_item_id))
 			{
-				if(!$this->sale_lib->add_item($kit_item_id, $quantity, $item_location, $discount, $price, NULL, NULL, NULL, $print_option, $stock_type))
+				if(!$this->sale_lib->add_item($kit_item_id, $quantity, $item_location, $discount, PRICE_MODE_STANDARD))
 				{
 					$data['error'] = $this->lang->line('sales_unable_to_add_item');
 				}
@@ -426,7 +428,7 @@ class Sales extends Secure_Controller
 
 			// Add item kit items to order
 			$stock_warning = NULL;
-			if(!$this->sale_lib->add_item_kit($item_id_or_number_or_item_kit_or_receipt, $item_location, $discount, $price_option, $kit_print_option, $stock_warning))
+			if(!$this->sale_lib->add_item_kit($item_id_or_number_or_item_kit_or_receipt, $item_location, $discount, $kit_price_option, $kit_print_option, $stock_warning))
 			{
 				$data['error'] = $this->lang->line('sales_unable_to_add_item');
 			}
@@ -437,7 +439,7 @@ class Sales extends Secure_Controller
 		}
 		else
 		{
-			if(!$this->sale_lib->add_item($item_id_or_number_or_item_kit_or_receipt, $quantity, $item_location, $discount))
+			if(!$this->sale_lib->add_item($item_id_or_number_or_item_kit_or_receipt, $quantity, $item_location, $discount, PRICE_MODE_STANDARD))
 			{
 				$data['error'] = $this->lang->line('sales_unable_to_add_item');
 			}
@@ -972,6 +974,8 @@ class Sales extends Secure_Controller
 
 		// Returns 'subtotal', 'total', 'cash_total', 'payment_total', 'amount_due', 'cash_amount_due', 'payments_cover_total'
 		$totals = $this->sale_lib->get_totals();
+		$data['item_count'] = $totals['item_count'];
+		$data['total_units'] = $totals['total_units'];
 		$data['subtotal'] = $totals['subtotal'];
 		$data['total'] = $totals['total'];
 		$data['payments_total'] = $totals['payment_total'];

--- a/application/language/en-US/sales_lang.php
+++ b/application/language/en-US/sales_lang.php
@@ -97,6 +97,7 @@ $lang["sales_print_after_sale"] = "Print after Sale";
 $lang["sales_quantity"] = "Quantity";
 $lang["sales_quantity_less_than_reorder_level"] = "Warning: Desired Quantity is below Reorder Level for that Item.";
 $lang["sales_quantity_less_than_zero"] = "Warning: Desired Quantity is insufficient. You can still process the sale, but audit your inventory.";
+$lang["sales_quantity_of_items"] = "Quantity of %1 Items";
 $lang["sales_quote"] = "Quote";
 $lang["sales_quote_number"] = "Quote Number";
 $lang["sales_quote_number_duplicate"] = "Quote Number must be unique.";

--- a/application/libraries/Sale_lib.php
+++ b/application/libraries/Sale_lib.php
@@ -387,7 +387,7 @@ class Sale_lib
 
 	/**
 	 * Returns 'subtotal', 'total', 'cash_total', 'payment_total', 'amount_due', 'cash_amount_due', 'paid_in_full'
-	 * 'subtotal', 'discounted_subtotal', 'tax_exclusive_subtotal'
+	 * 'subtotal', 'discounted_subtotal', 'tax_exclusive_subtotal', 'item_count', 'total_units'
 	 */
 	public function get_totals()
 	{
@@ -399,9 +399,16 @@ class Sale_lib
 		$subtotal = 0;
 		$total = 0;
 		$total_discount = 0;
+		$item_count = 0;
+		$total_units = 0;
 
 		foreach($this->get_cart() as $item)
 		{
+			if($item['stock_type']== HAS_STOCK)
+			{
+				$item_count++;
+				$total_units += $item['quantity'];
+			}
 			$discount_amount = $this->get_item_discount($item['quantity'], $item['price'], $item['discount']);
 			$total_discount = bcadd($total_discount, $discount_amount);
 
@@ -477,6 +484,9 @@ class Sale_lib
 		{
 			$totals['payments_cover_total'] = $current_due < $threshold;
 		}
+
+		$totals['item_count'] = $item_count;
+		$totals['total_units'] = $total_units;
 
 		return $totals;
 	}
@@ -645,7 +655,7 @@ class Sale_lib
 		$this->CI->session->unset_userdata('sales_rewards_remainder');
 	}
 
-	public function add_item(&$item_id, $quantity = 1, $item_location, $discount = 0, $price = NULL, $description = NULL, $serialnumber = NULL, $include_deleted = FALSE, $print_option = '0', $stock_type = HAS_STOCK)
+	public function add_item(&$item_id, $quantity = 1, $item_location, $discount = 0, $price_mode = PRICE_MODE_STANDARD, $kit_price_option = NULL, $kit_print_option = NULL, $price_override = NULL, $description = NULL, $serialnumber = NULL, $include_deleted = FALSE )
 	{
 		$item_info = $this->CI->Item->get_info_by_id_or_number($item_id);
 
@@ -657,6 +667,51 @@ class Sale_lib
 		}
 
 		$item_id = $item_info->item_id;
+		$item_type = $item_info->item_type;
+		$stock_type = $item_info->stock_type;
+
+		if($price_mode == PRICE_MODE_STANDARD)
+		{
+			$price = $item_info->unit_price;
+			$cost_price = $item_info->cost_price;
+		}
+		elseif($price_mode == PRICE_MODE_KIT)
+		{
+			if($kit_price_option == PRICE_OPTION_ALL)
+			{
+				$price = $item_info->unit_price;
+				$cost_price = $item_info->cost_price;
+			}
+			elseif($kit_price_option == PRICE_OPTION_KIT  && $item_type == ITEM_KIT)
+			{
+				$price = $item_info->unit_price;
+				$cost_price = $item_info->cost_price;
+			}
+			elseif($kit_price_option == PRICE_OPTION_KIT_STOCK && $stock_type == HAS_STOCK)
+			{
+				$price = $item_info->unit_price;
+				$cost_price = $item_info->cost_price;
+			}
+			else
+			{
+				$price = 0.00;
+				$cost_price = 0.00;
+			}
+		}
+		else
+		{
+			$price= 0.00;
+			$cost_price = 0.00;
+		}
+		if($price_override != NULL)
+		{
+			$price = $price_override;
+		}
+
+		if($price == 0.00)
+		{
+			$discount = 0.00;
+		}
 
 		// Serialization and Description
 
@@ -697,21 +752,28 @@ class Sale_lib
 		$insertkey = $maxkey + 1;
 		//array/cart records are identified by $insertkey and item_id is just another field.
 
-		if(is_null($price))
+		if ($price_mode == PRICE_MODE_KIT)
 		{
-			$price = $item_info->unit_price;
+			if($kit_print_option == PRINT_ALL)
+			{
+				$print_option_selected = PRINT_YES;
+			}
+			elseif($kit_print_option == PRINT_KIT && $item_type == ITEM_KIT)
+			{
+				$print_option_selected = PRINT_YES;
+			}
+			elseif($kit_print_option == PRINT_PRICED && $price > 0)
+			{
+				$print_option_selected = PRINT_YES;
+			}
+			else
+			{
+				$print_option_selected = PRINT_NO;
+			}
 		}
-		elseif($price == 0)
+		else
 		{
-			$price = 0.00;
-			$discount = 0.00;
-		}
-
-		// For print purposes this simpifies line selection
-		// 0 will print, 2 will not print.   The decision about 1 is made here
-		if($print_option == PRINT_PRICED)
-		{
-			$print_option = ($price == 0) ? PRINT_KIT : PRINT_ALL;
+			$print_option_selected = PRINT_YES;
 		}
 
 		$total = $this->get_item_total($quantity, $price, $discount);
@@ -734,9 +796,10 @@ class Sale_lib
 					'discount' => $discount,
 					'in_stock' => $this->CI->Item_quantity->get_item_quantity($item_id, $item_location)->quantity,
 					'price' => $price,
+					'cost_price' => $cost_price,
 					'total' => $total,
 					'discounted_total' => $discounted_total,
-					'print_option' => $print_option,
+					'print_option' => $print_option_selected,
 					'stock_type' => $stock_type,
 					'tax_category_id' => $item_info->tax_category_id
 				)
@@ -850,13 +913,13 @@ class Sale_lib
 
 		foreach($this->CI->Sale->get_sale_items_ordered($sale_id)->result() as $row)
 		{
-			$this->add_item($row->item_id, -$row->quantity_purchased, $row->item_location, $row->discount_percent, $row->item_unit_price, $row->description, $row->serialnumber, TRUE, $row->print_option, $row->print_option);
+			$this->add_item($row->item_id, -$row->quantity_purchased, $row->item_location, $row->discount_percent, PRICE_MODE_STANDARD,null, null, $row->item_unit_price, $row->description, $row->serialnumber, TRUE);
 		}
 
 		$this->set_customer($this->CI->Sale->get_customer($sale_id)->person_id);
 	}
 
-	public function add_item_kit($external_item_kit_id, $item_location, $discount, $price_option, $kit_print_option, &$stock_warning)
+	public function add_item_kit($external_item_kit_id, $item_location, $discount, $kit_price_option, $kit_print_option, &$stock_warning)
 	{
 		//KIT #
 		$pieces = explode(' ', $external_item_kit_id);
@@ -865,40 +928,7 @@ class Sale_lib
 
 		foreach($this->CI->Item_kit_items->get_info($item_kit_id) as $item_kit_item)
 		{
-			if($price_option == PRICE_ALL) // all
-			{
-				$price = null;
-			}
-			elseif($price_option == PRICE_KIT) // item kit only
-			{
-				$price = 0;
-			}
-			elseif($price_option == PRICE_KIT_ITEMS) // item kit plus stock items (assuming materials)
-			{
-				if($item_kit_item['stock_type'] == ITEM) // stock item
-				{
-					$price = null;
-				}
-				else
-				{
-					$price = 0;
-				}
-			}
-
-			if($kit_print_option == PRINT_ALL)
-			{
-				$print_option = PRINT_ALL;
-			}
-			elseif($kit_print_option == PRINT_PRICED) // priced
-			{
-				$print_option = PRINT_PRICED; // print if price not zero
-			}
-			elseif($kit_print_option == PRINT_KIT) // kit only if price is not zero
-			{
-				$print_option = PRINT_KIT; // Do not include in list
-			}
-
-			$result &= $this->add_item($item_kit_item['item_id'], $item_kit_item['quantity'], $item_location, $discount, $price, null, null, null, $print_option, $item_kit_item['stock_type']);
+			$result &= $this->add_item($item_kit_item['item_id'], $item_kit_item['quantity'], $item_location, $discount, PRICE_MODE_KIT, $kit_price_option, $kit_print_option, NULL, NULL, NULL, NULL);
 
 			if($stock_warning == null)
 			{
@@ -916,7 +946,7 @@ class Sale_lib
 
 		foreach($this->CI->Sale->get_sale_items_ordered($sale_id)->result() as $row)
 		{
-			$this->add_item($row->item_id, $row->quantity_purchased, $row->item_location, $row->discount_percent, $row->item_unit_price, $row->description, $row->serialnumber, TRUE, $row->print_option);
+			$this->add_item($row->item_id, $row->quantity_purchased, $row->item_location, $row->discount_percent, PRICE_MODE_STANDARD, null, null, $row->item_unit_price, $row->description, $row->serialnumber, TRUE);
 		}
 
 		foreach($this->CI->Sale->get_sale_payments($sale_id)->result() as $row)
@@ -942,8 +972,7 @@ class Sale_lib
 		$this->empty_cart();
 		foreach($this->CI->Sale->get_sale_items_ordered($sale_id)->result() as $row)
 		{
-			$this->add_item($row->item_id, $row->quantity_purchased, $row->item_location, $row->discount_percent, $row->item_unit_price,
-				$row->description, $row->serialnumber, TRUE, $row->print_option, $row->stock_type);
+			$this->add_item($row->item_id, $row->quantity_purchased, $row->item_location, $row->discount_percent, PRICE_MODE_STANDARD, NULL, NULL, $row->item_unit_price, $row->description, $row->serialnumber, TRUE);
 		}
 
 		return $this->CI->session->userdata('sales_cart');

--- a/application/models/Item.php
+++ b/application/models/Item.php
@@ -10,9 +10,18 @@ define('PRINT_ALL', 0);
 define('PRINT_PRICED', 1);
 define('PRINT_KIT', 2);
 
+define('PRINT_YES', 0);
+define('PRINT_NO', 1);
+
 define('PRICE_ALL', 0);
 define('PRICE_KIT', 1);
 define('PRICE_KIT_ITEMS', 2);
+
+define('PRICE_OPTION_ALL', 0);
+define('PRICE_OPTION_KIT', 1);
+define('PRICE_OPTION_KIT_STOCK', 2);
+
+
 /**
  * Item class
  */
@@ -393,7 +402,7 @@ class Item extends CI_Model
 
 		$this->db->trans_complete();
 
-		$success &= $this->db->trans_status();
+		$success &= $this->db->trans_();
 
 		return $success;
 	}
@@ -428,7 +437,7 @@ class Item extends CI_Model
 
 		$this->db->trans_complete();
 
-		$success &= $this->db->trans_status();
+		$success &= $this->db->trans_();
 
 		return $success;
 	}

--- a/application/models/Sale.php
+++ b/application/models/Sale.php
@@ -633,7 +633,7 @@ class Sale extends CI_Model
 				'serialnumber'		=> character_limiter($item['serialnumber'], 30),
 				'quantity_purchased'=> $item['quantity'],
 				'discount_percent'	=> $item['discount'],
-				'item_cost_price'	=> $cur_item_info->cost_price,
+				'item_cost_price'	=> $item['cost_price'],
 				'item_unit_price'	=> $item['price'],
 				'item_location'		=> $item['item_location'],
 				'print_option'		=> $item['print_option']

--- a/application/views/sales/register.php
+++ b/application/views/sales/register.php
@@ -348,6 +348,10 @@ if(isset($success))
 		?>
 
 		<table class="sales_table_100" id="sale_totals">
+            <tr>
+                <th style="width: 55%;"><?php echo $this->lang->line('sales_quantity_of_items',$item_count); ?></th>
+                <th style="width: 45%; text-align: right;"><?php echo $total_units; ?></th>
+            </tr>
 			<tr>
 				<th style="width: 55%;"><?php echo $this->lang->line('sales_sub_total'); ?></th>
 				<th style="width: 45%; text-align: right;"><?php echo to_currency($subtotal); ?></th>


### PR DESCRIPTION
This provides support for being able to specific a cost at an item kit level.  It includes a major refactoring of the logic in order to simplify the code.  Hopefully it is now a little easier to incorporate changes.

A bonus feature is that I added a stock item total to the sales register.  In a sale where there are service charges as well as stock sales, the count only includes stock items.  The information can easily be made available for custom sales receipts and/or invoices if anyone needs it.  But I'm guessing that most sites don't need to filter out service items.