### PR TITLE
Suspending Work Order lost work order number

### DIFF
--- a/application/libraries/Sale_lib.php
+++ b/application/libraries/Sale_lib.php
@@ -958,6 +958,7 @@ class Sale_lib
 		$this->set_customer($this->CI->Sale->get_customer($sale_id)->person_id);
 		$this->set_employee($this->CI->Sale->get_employee($sale_id)->person_id);
 		$this->set_quote_number($this->CI->Sale->get_quote_number($sale_id));
+		$this->set_work_order_number($this->CI->Sale->get_work_order_number($sale_id));
 		$this->set_sale_type($this->CI->Sale->get_sale_type($sale_id));
 		$this->set_comment($this->CI->Sale->get_comment($sale_id));
 		$this->set_dinner_table($this->CI->Sale->get_dinner_table($sale_id));

--- a/application/models/Sale.php
+++ b/application/models/Sale.php
@@ -1311,6 +1311,26 @@ class Sale extends CI_Model
 	}
 
 	/**
+	 * Gets the work order number for the selected sale
+	 */
+	public function get_work_order_number($sale_id)
+	{
+		$this->db->from('sales');
+		$this->db->where('sale_id', $sale_id);
+
+		$row = $this->db->get()->row();
+
+		if($row != NULL)
+		{
+			return $row->work_order_number;
+		}
+		else
+		{
+			return NULL;
+		}
+	}
+
+	/**
 	 * Gets the quote_number for the selected sale
 	 */
 	public function get_comment($sale_id)


### PR DESCRIPTION
I tested a scenario where I suspended a work order instead of clicking on the work order button (which also suspends it but after suspending it will display the work order document).

In the "suspend only" scenario it failed to retain the original work order number.

This pull request will fix that problem.