### PR TITLE
Correcting Round-up and Round-down bug

### DIFF
--- a/application/models/enums/Rounding_mode.php
+++ b/application/models/enums/Rounding_mode.php
@@ -52,13 +52,13 @@ class Rounding_mode
 	{
 		if($rounding_mode == Rounding_mode::ROUND_UP)
 		{
-			$fig = (int) str_pad('1', $decimals, '0');
-			$rounded_total = (ceil($amount * $fig) / $fig);
+			$fig = pow(10,$decimals);
+			$rounded_total = (ceil($fig*$amount) + ceil($fig*$amount - ceil($fig*$amount)))/$fig;
 		}
 		elseif($rounding_mode == Rounding_mode::ROUND_DOWN)
 		{
-			$fig = (int) str_pad('1', $decimals, '0');
-			$rounded_total = (floor($amount * $fig) / $fig);
+			$fig = pow(10,$decimals);
+			$rounded_total = (floor($fig*$amount) + floor($fig*$amount - floor($fig*$amount)))/$fig;
 		}
 		elseif($rounding_mode == Rounding_mode::HALF_FIVE)
 		{


### PR DESCRIPTION
Former code ignored precision and just rounded up or down to the nearest integer.  This code rounds up or down to the precision in cash decimals.