### PR TITLE
Remove unneeded app_config entry

### DIFF
--- a/database/3.0.2_to_3.1.1.sql
+++ b/database/3.0.2_to_3.1.1.sql
@@ -310,8 +310,7 @@ INSERT INTO `ospos_app_config` (`key`, `value`) VALUES
 -- add Barcode formats and other missing keys
 
 INSERT INTO `ospos_app_config` (`key`, `value`) VALUES
-('barcode_formats', '[]'),
-('receiving_calculate_average_price', '0');
+('barcode_formats', '[]');
 
 -- replace old tokens in ospos_app_config
 


### PR DESCRIPTION
this entry is automatically created on first save, so is not needed to manually be entered.