### PR TITLE
Insert Try->Catch clause (#1616)

### DIFF
--- a/application/helpers/locale_helper.php
+++ b/application/helpers/locale_helper.php
@@ -195,7 +195,6 @@ function parse_decimals($number)
     }
     catch (Exception $e)
     {
-    	echo 'Caught exception: ', $e->getMessage(), "\n";
     }
 }
 

--- a/application/helpers/locale_helper.php
+++ b/application/helpers/locale_helper.php
@@ -189,7 +189,14 @@ function parse_decimals($number)
         $fmt->setAttribute(\NumberFormatter::GROUPING_SEPARATOR_SYMBOL, '');
     }
 
-    return $fmt->parse($number);
+    try
+    {
+    	return $fmt->parse($number);
+    }
+    catch (Exception $e)
+    {
+    	echo 'Caught exception: ', $e->getMessage(), "\n";
+    }
 }
 
 /*

--- a/application/helpers/locale_helper.php
+++ b/application/helpers/locale_helper.php
@@ -195,6 +195,7 @@ function parse_decimals($number)
     }
     catch (Exception $e)
     {
+		return FALSE;
     }
 }
 


### PR DESCRIPTION
Force an error message on mis-formatted numbers rather than the blank
screen caused by an uncaught exception.

#1616 