### PR TITLE
Fix issue with renaming stock locations

### DIFF
--- a/application/controllers/Config.php
+++ b/application/controllers/Config.php
@@ -550,11 +550,13 @@ class Config extends Secure_Controller
 			if(strstr($key, 'stock_location'))
 			{
 				$location_id = preg_replace("/.*?_(\d+)$/", "$1", $key);
-				$not_to_delete[] = $location_id;
+
 				// save or update
 				$location_data = array('location_name' => $value);
 				if($this->Stock_location->save($location_data, $location_id))
 				{
+					$location_id = $this->Stock_location->get_location_id($value);
+					$not_to_delete[] = $location_id;
 					$this->_clear_session_state();
 				}
 			}


### PR DESCRIPTION
I'm having a little problem with setting up a "current master" test environment built on the current state of the 3.2 development, but I tested these changes in my purchasing development test environment and it certainly behaves better than it used to.
