### PR TITLE
Allow receipt item name to be wrapped.

### DIFF
--- a/public/css/ospos_print.css
+++ b/public/css/ospos_print.css
@@ -27,11 +27,6 @@
 		text-align:center;
 	}
 
-	#receipt_items td
-	{
-		white-space:nowrap;
-	}
-
 	/* Hide links in table for printing */
 	table.innertable
 	{


### PR DESCRIPTION
I believe this should resolve the issue with the item name on the receipt not wrapping and instead moving content off of the page.