### PR TITLE
Enable https for proxy offloading

### DIFF
--- a/README.md
+++ b/README.md
@@ -200,6 +200,8 @@ FAQ
 
 * If you have problems with the encryption support or you get an error please make sure `php-openssl` is installed. With PHP 7 MCrypt is deprecated so you must use OpenSSL.
 
+* If we install ospos in docker behind a proxy that performs ssloffloading, we can enable the url generated to be https instead of http, by activating the environment variable FORCE_HTTPS = 1.
+
 * If you have suhosin installed and face an issue with CSRF, please make sure you read [issue #1492](https://github.com/opensourcepos/opensourcepos/issues/1492).
 
 * If new customer or supplier fails please make sure `php-mbstring` is installed see [issue #1673](https://github.com/opensourcepos/opensourcepos/issues/1673) for more details.

--- a/application/config/config.php
+++ b/application/config/config.php
@@ -65,9 +65,15 @@ $config['db_log_enabled'] = FALSE;
 | a PHP script and you can easily do that on your own.
 |
 */
-$config['base_url'] = (isset($_SERVER['HTTPS']) && $_SERVER['HTTPS'] == 'on') ? 'https' : 'http';
-$config['base_url'] .= '://' . $_SERVER['HTTP_HOST'];
-$config['base_url'] .= str_replace(basename($_SERVER['SCRIPT_NAME']), '', $_SERVER['SCRIPT_NAME']);
+if (isset($_ENV['FORCE_HTTPS'])) {
+  $config['base_url'] = 'https';
+  $config['base_url'] .= '://' . $_SERVER['HTTP_HOST'];
+  $config['base_url'] .= str_replace(basename($_SERVER['SCRIPT_NAME']), '', $_SERVER['SCRIPT_NAME']);
+} else {
+  $config['base_url'] = (isset($_SERVER['HTTPS']) && $_SERVER['HTTPS'] == 'on') ? 'https' : 'http';
+  $config['base_url'] .= '://' . $_SERVER['HTTP_HOST'];
+  $config['base_url'] .= str_replace(basename($_SERVER['SCRIPT_NAME']), '', $_SERVER['SCRIPT_NAME']);
+}
 
 /*
 |--------------------------------------------------------------------------

--- a/application/config/config.php
+++ b/application/config/config.php
@@ -65,7 +65,8 @@ $config['db_log_enabled'] = FALSE;
 | a PHP script and you can easily do that on your own.
 |
 */
-if (isset($_ENV['FORCE_HTTPS'])) $_SERVER['HTTPS'] = 'on';
+if (isset($_ENV['FORCE_HTTPS']))
+    $_SERVER['HTTPS'] = 'on';
 
 $config['base_url'] = (isset($_SERVER['HTTPS']) && $_SERVER['HTTPS'] == 'on') ? 'https' : 'http';
 $config['base_url'] .= '://' . $_SERVER['HTTP_HOST'];

--- a/application/config/config.php
+++ b/application/config/config.php
@@ -65,15 +65,11 @@ $config['db_log_enabled'] = FALSE;
 | a PHP script and you can easily do that on your own.
 |
 */
-if (isset($_ENV['FORCE_HTTPS'])) {
-  $config['base_url'] = 'https';
-  $config['base_url'] .= '://' . $_SERVER['HTTP_HOST'];
-  $config['base_url'] .= str_replace(basename($_SERVER['SCRIPT_NAME']), '', $_SERVER['SCRIPT_NAME']);
-} else {
-  $config['base_url'] = (isset($_SERVER['HTTPS']) && $_SERVER['HTTPS'] == 'on') ? 'https' : 'http';
-  $config['base_url'] .= '://' . $_SERVER['HTTP_HOST'];
-  $config['base_url'] .= str_replace(basename($_SERVER['SCRIPT_NAME']), '', $_SERVER['SCRIPT_NAME']);
-}
+if (isset($_ENV['FORCE_HTTPS'])) $_SERVER['HTTPS'] = 'on';
+
+$config['base_url'] = (isset($_SERVER['HTTPS']) && $_SERVER['HTTPS'] == 'on') ? 'https' : 'http';
+$config['base_url'] .= '://' . $_SERVER['HTTP_HOST'];
+$config['base_url'] .= str_replace(basename($_SERVER['SCRIPT_NAME']), '', $_SERVER['SCRIPT_NAME']);
 
 /*
 |--------------------------------------------------------------------------

--- a/application/config/config.php
+++ b/application/config/config.php
@@ -65,10 +65,8 @@ $config['db_log_enabled'] = FALSE;
 | a PHP script and you can easily do that on your own.
 |
 */
-if (isset($_ENV['FORCE_HTTPS']))
-    $_SERVER['HTTPS'] = 'on';
 
-$config['base_url'] = (isset($_SERVER['HTTPS']) && $_SERVER['HTTPS'] == 'on') ? 'https' : 'http';
+$config['base_url'] = (isset($_SERVER['HTTPS']) && $_SERVER['HTTPS'] == 'on') || isset($_ENV['FORCE_HTTPS'])) ? 'https' : 'http';
 $config['base_url'] .= '://' . $_SERVER['HTTP_HOST'];
 $config['base_url'] .= str_replace(basename($_SERVER['SCRIPT_NAME']), '', $_SERVER['SCRIPT_NAME']);
 


### PR DESCRIPTION
If we install ospos in docker behind a proxy that performs ssloffloading, we can enable the url generated to be https instead of http, by activating the environment variable FORCE_HTTPS = 1.