### PR TITLE
temporary "fix" to wrong summary_payment report

### DIFF
--- a/application/models/reports/Summary_payments.php
+++ b/application/models/reports/Summary_payments.php
@@ -14,7 +14,7 @@ class Summary_payments extends Summary_report
 
 	public function getData(array $inputs)
 	{
-		$this->db->select('sales_payments.payment_type, COUNT(DISTINCT sales_payments.sale_id) AS count, SUM(sales_items.item_unit_price*sales_items.quantity_purchased * (1 - sales_items.discount_percent / 100)) AS payment_amount');
+		$this->db->select('sales_payments.payment_type, COUNT(DISTINCT sales_payments.sale_id) AS count, SUM(sales_items.item_unit_price * sales_items.quantity_purchased * (1 - sales_items.discount_percent / 100)) AS payment_amount');
 		$this->db->from('sales_payments AS sales_payments');
 		$this->db->join('sales AS sales', 'sales.sale_id = sales_payments.sale_id');
 		$this->db->join('sales_items AS sales_items', 'sales_items.sale_id = sales_payments.sale_id', 'left');

--- a/application/models/reports/Summary_payments.php
+++ b/application/models/reports/Summary_payments.php
@@ -14,10 +14,10 @@ class Summary_payments extends Summary_report
 
 	public function getData(array $inputs)
 	{
-		$this->db->select('sales_payments.payment_type, COUNT(sales_payments.sale_id) AS count, SUM(sales_payments.payment_amount) AS payment_amount');
+		$this->db->select('sales_payments.payment_type, COUNT(DISTINCT sales_payments.sale_id) AS count, SUM(sales_items.item_unit_price*sales_items.quantity_purchased * (1 - sales_items.discount_percent / 100)) AS payment_amount');
 		$this->db->from('sales_payments AS sales_payments');
 		$this->db->join('sales AS sales', 'sales.sale_id = sales_payments.sale_id');
-		$this->db->join('sales_items AS sales_items', 'sales_items.sale_id = sales_payments.sale_id AND sales_items.line = 1', 'left');
+		$this->db->join('sales_items AS sales_items', 'sales_items.sale_id = sales_payments.sale_id', 'left');
 
 		$this->_where($inputs);
 


### PR DESCRIPTION
I still cant find a solution to this,  summary payment amount in cash is wrong, like you know it considers payment amount and it doesn't discount change, so the cash payment will be always a higher value, and if you try to discount change directly on query then it only discounts sales with 1 item, and not discounts sales with multiple items, the condition sales_items.line = 1 cause that.

This change considers item price * item qty, so at lest summary payment in cash will be acurated no matter tendered amount is, but leaves out "due sales"