### PR TITLE
Insure that the receiving_quantity is not zero

### DIFF
--- a/application/migrations/sqlscripts/3.2.0_to_3.2.1.sql
+++ b/application/migrations/sqlscripts/3.2.0_to_3.2.1.sql
@@ -19,3 +19,8 @@ INSERT INTO `ospos_app_config` (`key`, `value`) VALUES
 
 INSERT INTO `ospos_app_config` (`key`, `value`) VALUES
 ('print_delay_autoreturn', '0');
+
+
+-- Insure that the receiving quantity is not zero
+
+UPDATE ospos_receivings_items SET receiving_quantity = 1 WHERE receiving_quantity = 0;


### PR DESCRIPTION
This is a simple change to add an update statement to the 3.2.0 to 3.2.1 migration script.  If it finds a zero receiving quantity then it will set it to zero.