### PR TITLE
[WIP] Credit Receivings

### DIFF
--- a/application/models/Receiving.php
+++ b/application/models/Receiving.php
@@ -221,7 +221,8 @@ class Receiving extends CI_Model
 			$this->lang->line('sales_cash') => $this->lang->line('sales_cash'),
 			$this->lang->line('sales_check') => $this->lang->line('sales_check'),
 			$this->lang->line('sales_debit') => $this->lang->line('sales_debit'),
-			$this->lang->line('sales_credit') => $this->lang->line('sales_credit')
+			$this->lang->line('sales_credit') => $this->lang->line('sales_credit'),
+			$this->lang->line('sales_due') => $this->lang->line('sales_due')
 		);
 	}
 


### PR DESCRIPTION
**Note**: this is a work in progress. Any suggestions welcome.

In the organic store where I'm currently working, receivings aren't usually paid for immediately. Instead, they're paid on a _factura vencida_ basis, which means that, when the supplier brings new products to the store, she only gets paid for the products she had brought last time.

So we need a way to pay for receivings on credit. Here's my plan to implement this new feature:

- [x] 1. In the receivings module, add a new payment type called "Due", just like in the sales module.
- [ ] 2. Modify the expenses module so that its "suppliers" field is associated with actual suppliers in the database, i.e., add a foreign key from `ospos_expenses` to `ospos_suppliers` and display a dropdown list with the suppliers, just like in the receivings module. This way, you can register payments to your suppliers.
- [ ] 3. Generate an expenses receipt, visually similar to a sales receipt, every time you create a new expense.
- [ ] 4. Create a new report called Accounting, where you can see a list of suppliers and their balances. Balances are calculated by querying their receivings due and the expenses associated to them. The more you owe them, the higher their balance.

What do you guys think? I'm gonna be working on this as my main activity for the next month or so. I'll be delighted to hear from you. I'm an experienced full stack programmer, although fairly new to open source.