### PR TITLE
linked expenses with suppliers

### DIFF
--- a/application/controllers/Expenses.php
+++ b/application/controllers/Expenses.php
@@ -128,7 +128,7 @@ class Expenses extends Secure_Controller
 
 		$expense_data = array(
 			'date' => $date_formatter->format('Y-m-d H:i:s'),
-			'supplier_name' => $this->input->post('supplier_name'),
+			'supplier_id' => $this->input->post('supplier_id'),
 			'supplier_tax_code' => $this->input->post('supplier_tax_code'),
 			'amount' => parse_decimals($this->input->post('amount')),
 			'tax_amount' => parse_decimals($this->input->post('tax_amount')),

--- a/application/language/en-US/expenses_lang.php
+++ b/application/language/en-US/expenses_lang.php
@@ -43,3 +43,5 @@ $lang["expenses_supplier_name"] = "Supplier";
 $lang["expenses_supplier_tax_code"] = "Tax Code";
 $lang["expenses_tax_amount"] = "Tax";
 $lang["expenses_update"] = "Update Expense";
+$lang["expenses_start_typing_supplier_name"] = "Start Typing Supplier's name...";
+$lang["expenses_supplier_required"] = "Please select a valid Supplier";

--- a/application/language/es/expenses_lang.php
+++ b/application/language/es/expenses_lang.php
@@ -43,3 +43,5 @@ $lang["expenses_supplier_name"] = "Proveedor";
 $lang["expenses_supplier_tax_code"] = "Codigo Imp";
 $lang["expenses_tax_amount"] = "Imp";
 $lang["expenses_update"] = "Actualizar Gasto";
+$lang["expenses_start_typing_supplier_name"] = "Empieza a escribir el nombre del proveedor...";
+$lang["expenses_supplier_required"] = "Selecciona un Proveedor válido";

--- a/application/migrations/20180819195000_expenses_supplier_id.php
+++ b/application/migrations/20180819195000_expenses_supplier_id.php
@@ -1,0 +1,97 @@
+<?php if (!defined('BASEPATH')) exit('No direct script access allowed');
+
+class Migration_Expenses_Supplier_Id extends CI_Migration
+{
+	public function __construct()
+	{
+		parent::__construct();
+	}
+
+	public function up()
+	{
+		$this->add_supplier_id();
+		$this->link_suppliers();
+		if($this->there_are_unknown_suppliers()) {
+			$this->save_name_in_description();
+			$unknown_supplier_id = $this->create_unknown_supplier();
+			$this->link_unknown_supplier($unknown_supplier_id);
+		}
+		$this->create_foreign_key();
+		$this->delete_supplier_name();
+	}
+
+	public function down()
+	{
+
+	}
+
+	private function add_supplier_id()
+	{
+		$query	= "ALTER TABLE `ospos_expenses` ";
+		$query .= "ADD COLUMN `supplier_id` int(10) NOT NULL;";
+		$this->db->query($query);
+	}
+
+	private function link_suppliers()
+	{
+		$query	= "UPDATE `ospos_expenses` ";
+		$query .= "INNER JOIN `ospos_suppliers` ";
+		$query .= "ON `ospos_expenses`.`supplier_name` = `ospos_suppliers`.`company_name` ";
+		$query .= "SET `ospos_expenses`.`supplier_id` = `ospos_suppliers`.`person_id`;";
+		$this->db->query($query);
+	}
+
+	private function there_are_unknown_suppliers()
+	{
+		$query	= "SELECT COUNT(*) AS amount ";
+		$query .= "FROM `ospos_expenses` ";
+		$query .= "WHERE `supplier_id` = 0;";
+		$result = $this->db->query($query);
+		$amount = $result->row()->amount;
+		return $amount > 0;
+	}
+
+	private function save_name_in_description()
+	{
+		$query	= "UPDATE `ospos_expenses` ";
+		$query .= "SET `description` = CONCAT(`description`, CONCAT('\nSupplier name: ', `supplier_name`)) ";
+		$query .= "WHERE `supplier_id` = 0;";
+		$this->db->query($query);
+	}
+
+	private function create_unknown_supplier()
+	{
+		$query	= "INSERT INTO `ospos_people` (`first_name`, `last_name`, `comments`) ";
+		$query .= "VALUES ('Unknown', 'Supplier', 'This supplier was added automatically by OSPOS. It is associated with expenses whose supplier is unknown. Before deleting this supplier, correct the expenses associated with it by heading to the Expenses section and selecting the appropriate supplier for each expense. In order to determine the original supplier, you can look at the supplier\'s name in each expense\'s description field.');";
+		$this->db->query($query);
+		$id = $this->db->insert_id();
+		$query	= "INSERT INTO `ospos_suppliers` (`person_id`, `company_name`) ";
+		$query .= "VALUES (" . $id . ", 'Unknown Supplier');";
+		$this->db->query($query);
+		return $id;
+	}
+
+	private function link_unknown_supplier($unknown_supplier_id)
+	{
+		$query	= "UPDATE `ospos_expenses` ";
+		$query .= "SET `supplier_id` = " . $unknown_supplier_id . " ";
+		$query .= "WHERE `supplier_id`= 0;";
+		$this->db->query($query);
+	}
+
+	private function create_foreign_key()
+	{
+		$query	= "ALTER TABLE `ospos_expenses` ";
+		$query .= "ADD CONSTRAINT `ospos_expenses_ibfk_3` FOREIGN KEY (`supplier_id`) REFERENCES `ospos_suppliers` (`person_id`);";
+		$this->db->query($query);
+	}
+
+	private function delete_supplier_name()
+	{
+		$query	= "ALTER TABLE `ospos_expenses` ";
+		$query .= "DROP COLUMN `supplier_name`;";
+		$this->db->query($query);
+	}
+
+}
+?>

--- a/application/models/Expense.php
+++ b/application/models/Expense.php
@@ -71,7 +71,7 @@ class Expense extends CI_Model
 			$this->db->select('
 				expenses.expense_id,
 				MAX(expenses.date) AS date,
-				MAX(expenses.supplier_name) AS supplier_name,
+				MAX(suppliers.company_name) AS supplier_name,
 				MAX(expenses.supplier_tax_code) AS supplier_tax_code,
 				MAX(expenses.amount) AS amount,
 				MAX(expenses.tax_amount) AS tax_amount,
@@ -86,6 +86,7 @@ class Expense extends CI_Model
 		$this->db->from('expenses AS expenses');
 		$this->db->join('people AS employees', 'employees.person_id = expenses.employee_id', 'LEFT');
 		$this->db->join('expense_categories AS expense_categories', 'expense_categories.expense_category_id = expenses.expense_category_id', 'LEFT');
+		$this->db->join('suppliers AS suppliers', 'suppliers.person_id = expenses.supplier_id', 'INNER');
 
 		$this->db->group_start();
 			$this->db->like('employees.first_name', $search);
@@ -162,7 +163,8 @@ class Expense extends CI_Model
 		$this->db->select('
 			expenses.expense_id AS expense_id,
 			expenses.date AS date,
-			expenses.supplier_name AS supplier_name,
+			suppliers.company_name AS supplier_name,
+			expenses.supplier_id AS supplier_id,
 			expenses.supplier_tax_code AS supplier_tax_code,
 			expenses.amount AS amount,
 			expenses.tax_amount AS tax_amount,
@@ -178,6 +180,7 @@ class Expense extends CI_Model
 		$this->db->from('expenses AS expenses');
 		$this->db->join('people AS employees', 'employees.person_id = expenses.employee_id', 'LEFT');
 		$this->db->join('expense_categories AS expense_categories', 'expense_categories.expense_category_id = expenses.expense_category_id', 'LEFT');
+		$this->db->join('suppliers AS suppliers', 'suppliers.person_id = expenses.supplier_id', 'INNER');
 		$this->db->where('expense_id', $expense_id);
 
 		$query = $this->db->get();
@@ -195,6 +198,8 @@ class Expense extends CI_Model
 			{
 				$expenses_obj->$field = '';
 			}
+
+			$expenses_obj->supplier_name = '';
 
 			return $expenses_obj;
 		}

--- a/application/views/expenses/form.php
+++ b/application/views/expenses/form.php
@@ -25,14 +25,24 @@
 		</div>
 
 		<div class="form-group form-group-sm">
-			<?php echo form_label($this->lang->line('expenses_supplier_name'), 'supplier_name', array('class'=>'control-label col-xs-3')); ?>
+			<?php echo form_label($this->lang->line('expenses_supplier_name'), 'supplier_name', array('class'=>'control-label col-xs-3 required')); ?>
 			<div class='col-xs-6'>
 				<?php echo form_input(array(
 						'name'=>'supplier_name',
 						'id'=>'supplier_name',
 						'class'=>'form-control input-sm',
-						'value'=>$expenses_info->supplier_name)
+						'value'=>$this->lang->line('expenses_start_typing_supplier_name'))
+					);
+					echo form_input(array(
+						'type'=>'hidden',
+						'name'=>'supplier_id',
+						'id'=>'supplier_id')
 						);?>
+			</div>
+			<div class="col-xs-2">
+				<a id="remove_supplier_button" class="btn btn-danger btn-sm" title="Remove Supplier">
+					<span class="glyphicon glyphicon-remove"></span>
+				</a>
 			</div>
 		</div>
 
@@ -187,6 +197,46 @@ $(document).ready(function()
 		}
 	}
 
+	$('#supplier_name').click(function() {
+		$(this).attr('value','');
+	});
+
+	$('#supplier_name').autocomplete({
+		source: '<?php echo site_url("suppliers/suggest"); ?>',
+		minChars:0,
+		delay:10,
+		select: function (event, ui) {
+			$('#supplier_id').val(ui.item.value);
+			$(this).val(ui.item.label);
+			$(this).attr('readonly', 'readonly');
+			$('#remove_supplier_button').css('display', 'inline-block');
+			return false;
+		}
+	});
+
+	$('#supplier_name').blur(function() {
+		$(this).attr('value',"<?php echo $this->lang->line('expenses_start_typing_supplier_name'); ?>");
+	});
+
+	$('#remove_supplier_button').css('display', 'none');
+
+	$('#remove_supplier_button').click(function() {
+		$('#supplier_id').val('');
+		$('#supplier_name').removeAttr('readonly');
+		$('#supplier_name').val('');
+		$(this).css('display', 'none');
+	});
+
+	<?php
+		if(!empty($expenses_info->expense_id)) {
+	?>
+			$('#supplier_id').val('<?php echo $expenses_info->supplier_id ?>');
+			$('#supplier_name').val('<?php echo $expenses_info->supplier_name ?>');
+			$('#supplier_name').attr('readonly', 'readonly');
+			$('#remove_supplier_button').css('display', 'inline-block');
+	<?php
+		}
+	?>
 	$('#expenses_edit_form').validate($.extend({
 		submitHandler: function(form) {
 			$(form).ajaxSubmit({
@@ -201,6 +251,8 @@ $(document).ready(function()
 
 		errorLabelContainer: '#error_message_box',
 
+		ignore: '',
+
 		rules:
 		{
 			category: 'required',
@@ -208,6 +260,7 @@ $(document).ready(function()
 			{
 				required: true
 			},
+			supplier_id: 'required',
 			amount:
 			{
 				required: true,
@@ -227,6 +280,7 @@ $(document).ready(function()
 				required: "<?php echo $this->lang->line('expenses_date_required'); ?>"
 
 			},
+			supplier_id: "<?php echo $this->lang->line('expenses_supplier_required'); ?>",
 			amount:
 			{
 				required: "<?php echo $this->lang->line('expenses_amount_required'); ?>",

--- a/public/css/bootstrap.autocomplete.css
+++ b/public/css/bootstrap.autocomplete.css
@@ -3,7 +3,7 @@
     position: absolute;
     top: 100%;
     left: 0;
-    z-index: 1000;
+    z-index: 1050;
     float: left;
     display: none;
     min-width: 160px;


### PR DESCRIPTION
This pull request corresponds to the second implementation step in #2088.

Since this pull request changes the database structure, follow these steps to be able to revert the changes:

1 - Create a copy of the database before the change:

    $ mysqldump -u admin -p ospos > ospos.sql

2 - Clone the `expenses_supplier_id` branch from my repository:

    $ git clone https://github.com/emi-silva/opensourcepos.git -b expenses_supplier_id

3 - Log in. The migration should run automatically.

4 - Test the changes.

5 - Revert to the previous version of the database:

    $ mysql -u admin -p
    > drop database ospos;
    > create database ospos;
    > exit;
    $ mysql -u admin -p ospos < ospos.sql