### PR TITLE
Correct errors in redirect with advanced install

### DIFF
--- a/.htaccess
+++ b/.htaccess
@@ -2,7 +2,7 @@
   <IfModule mod_rewrite.c>
     RewriteEngine On
     RewriteCond %{REQUEST_URI} !^public$
-    RewriteRule ^(.*)$ %{REQUEST_URI}public/ [R=301,L]
+    RewriteRule "^(.*)$" "/public/" [R=301,L]
   </IfModule>
 
 # disable directory browsing


### PR DESCRIPTION
See #1491 
This should cover the following scenarios
1- Install is in the root folder (www.example.com)
2- Install is in a subfolder (www.example.com/pos/)
3- Install is in an subdomain or subdomain and subfolder (pos.example.com or pos.example.com/abc)
4- User attempts to navigate to other subfolders (www.example.com/vendor).

In each case the expected behavior is to redirect to URI/public as an external redirect with no errors.

When testing PLEASE clear your browser cache/history and restart your browser.  Most browsers have a bad habit of caching errors and then you don't know if you are getting a cached error or the current results.