### PR TITLE
Fix issue with deleted items not being included in reprinted receipts.

### DIFF
--- a/application/libraries/Sale_lib.php
+++ b/application/libraries/Sale_lib.php
@@ -698,7 +698,7 @@ class Sale_lib
 
 	public function add_item(&$item_id, $quantity = 1, $item_location, $discount = 0, $discount_type = 0, $price_mode = PRICE_MODE_STANDARD, $kit_price_option = NULL, $kit_print_option = NULL, $price_override = NULL, $description = NULL, $serialnumber = NULL, $include_deleted = FALSE, $print_option = NULL )
 	{
-		$item_info = $this->CI->Item->get_info_by_id_or_number($item_id);
+		$item_info = $this->CI->Item->get_info_by_id_or_number($item_id, $include_deleted);
 
 		//make sure item exists
 		if(empty($item_info))
@@ -883,7 +883,7 @@ class Sale_lib
 		//make sure item exists
 		if($item_id != -1)
 		{
-			$item_info = $this->CI->Item->get_info_by_id_or_number($item_id);
+			$item_info = $this->CI->Item->get_info_by_id_or_number($item_id, TRUE);
 
 			if($item_info->stock_type == HAS_STOCK)
 			{
@@ -1001,7 +1001,7 @@ class Sale_lib
 
 		foreach($this->CI->Item_kit_items->get_info($item_kit_id) as $item_kit_item)
 		{
-			$result &= $this->add_item($item_kit_item['item_id'], $item_kit_item['quantity'], $item_location, $discount, $discount_type, PRICE_MODE_KIT, $kit_price_option, $kit_print_option, NULL, NULL, NULL, NULL);
+			$result &= $this->add_item($item_kit_item['item_id'], $item_kit_item['quantity'], $item_location, $discount, $discount_type, PRICE_MODE_KIT, $kit_price_option, $kit_print_option, NULL, NULL, NULL, FALSE);
 
 			if($stock_warning == NULL)
 			{

--- a/application/models/Item.php
+++ b/application/models/Item.php
@@ -321,7 +321,7 @@ class Item extends CI_Model
 	/*
 	Gets information about a particular item by item id or number
 	*/
-	public function get_info_by_id_or_number($item_id)
+	public function get_info_by_id_or_number($item_id, $include_deleted = TRUE)
 	{
 		$this->db->from('items');
 
@@ -337,6 +337,11 @@ class Item extends CI_Model
 		}
 
 		$this->db->group_end();
+
+		if(!$include_deleted)
+		{
+			$this->db->where("items.deleted = '0'");
+		}
 
 		// limit to only 1 so there is a result in case two are returned
 		// due to barcode and item_id clash


### PR DESCRIPTION
Here is a permanent fix to the "deleted item missing from reprinted receipt".  

The other fix allowed deleted items to be added to a sale if the items were added by item id or by number. But it provided a simple manual code fix that allowed receipts to be correctly reprinted.

This more comprehensive fix will not allow deleted items to be added to a new sale while allowing deleted items to be included in a reprinted sale.