### PR TITLE
Fix invoice auto numbering for first invoice

### DIFF
--- a/application/models/Sale.php
+++ b/application/models/Sale.php
@@ -449,13 +449,17 @@ class Sale extends CI_Model
 	/**
 	 * Gets total of invoice rows
 	 */
-	public function get_invoice_count()
-	{
-		$this->db->from('sales');
-		$this->db->where('invoice_number IS NOT NULL');
+    public function get_invoice_count()
+    {
+        $this->db->from('sales');
+        $this->db->where('invoice_number IS NOT NULL');
 
-		return $this->db->count_all_results();
-	}
+        if ($this->db->count_all_results() == 0) {
+            return 1;
+        }else{
+            $this->db->count_all_results();
+        }
+    }
 
 	/**
 	 * Gets sale by invoice number


### PR DESCRIPTION
Hi team,

Discovered an issue on our modified fork and confirmed its the same on the latest opensourcepos build.

Basically when creating an invoice using the 'Invoice' sales mode, if its the first invoice (ever) it will have an invoice number of #0 - this is causing issues as the first invoice to be added will not be view able on the daily sales page.

My fix is to start the first invoice at #1 rather than #0, I discovered the method for working out the next invoice is by counting the number of sales with an invoice_number value (in this case 0) and then using that.

My PR might not be the best way to handle this but it worked for me - basically if there are 0 invoices in the sales it will return 1 otherwise it will return the count (normal behavior).

**Screenshot of issue**: https://imgur.com/r8nDKPq

As you can see above, I generated an invoice using the invoice sale mode and it was assigned invoice 0 however I cant see the invoice button on the daily sales. With this pr fix it will generate invoice 1 and be functioning as normal.

Thanks
J