### PR TITLE
Fix temporal dependency in migration

### DIFF
--- a/application/migrations/20170502221506_sales_tax_data.php
+++ b/application/migrations/20170502221506_sales_tax_data.php
@@ -36,9 +36,9 @@ class Migration_Sales_Tax_Data extends CI_Migration
 	private function upgrade_tax_history_for_sale($sale_id)
 	{
 		$CI =& get_instance();
-		$tax_decimals = $CI->config->config['tax_decimals'];
-		$tax_included = $CI->config->config['tax_included'];
-		$customer_sales_tax_support = $CI->config->config['customer_sales_tax_support'];
+		$tax_decimals = $CI->Appconfig->get('tax_decimals', 2);
+		$tax_included = $CI->Appconfig->get('tax_included', 0);
+		$customer_sales_tax_support = $CI->Appconfig->get('customer_sales_tax_support', 0);
 
 		if($tax_included)
 		{

--- a/application/models/Appconfig.php
+++ b/application/models/Appconfig.php
@@ -22,7 +22,7 @@ class Appconfig extends CI_Model
 		return $this->db->get();
 	}
 
-	public function get($key)
+	public function get($key, $default = '')
 	{
 		$query = $this->db->get_where('app_config', array('key' => $key), 1);
 
@@ -31,7 +31,7 @@ class Appconfig extends CI_Model
 			return $query->row()->value;
 		}
 
-		return '';
+		return $default;
 	}
 
 	public function save($key, $value)


### PR DESCRIPTION
Found this issue recurring on migrating from old versions to the latest.

I think the issue here is that the config array is loaded only once after the controller is constructed. The values are added in scope of one run and thus my suspicion is that new values do not end up in the $Ci->config->config assoc array. 

That's why I replaced this call with a call to AppConfig (which actually will go to the db every time)