### PR TITLE
Keep attributes selected when creating new items (#2221)

### DIFF
--- a/application/views/items/form.php
+++ b/application/views/items/form.php
@@ -452,10 +452,10 @@ $(document).ready(function()
 						// set action of item_form to url without item id, so a new one can be created
 						$('#item_form').attr('action', "<?php echo site_url('items/save/')?>");
 						// use a whitelist of fields to minimize unintended side effects
-						$(':text, :password, :file, #description, #item_form').not('.quantity, #reorder_level, #tax_name_1,' +
-							'#tax_percent_name_1, #reference_number, #name, #cost_price, #unit_price, #taxed_cost_price, #taxed_unit_price').val('');
+						$(':text, :password, :file, #description, #item_form').not('.quantity, #reorder_level, #tax_name_1, #receiving_quantity, ' +
+							'#tax_percent_name_1, #category, #reference_number, #name, #cost_price, #unit_price, #taxed_cost_price, #taxed_unit_price, #definition_name, [name^="attribute_links"]').val('');
 						// de-select any checkboxes, radios and drop-down menus
-						$(':input', '#item_form').not('#category').removeAttr('checked').removeAttr('selected');
+						$(':input', '#item_form').removeAttr('checked').removeAttr('selected');
 					}
 					else
 					{

--- a/application/views/receivings/receiving.php
+++ b/application/views/receivings/receiving.php
@@ -86,8 +86,8 @@ if (isset($success))
 				</li>
 				<li class="pull-right">
 					<button id='new_item_button' class='btn btn-info btn-sm pull-right modal-dlg'
-						data-btn-new='<?php echo $this->lang->line('common_new') ?>'
 						data-btn-submit='<?php echo $this->lang->line('common_submit') ?>'
+						data-btn-new='<?php echo $this->lang->line('common_new') ?>'
 						data-href='<?php echo site_url("items/view"); ?>'
 						title='<?php echo $this->lang->line('sales_new_item'); ?>'>
 						<span class="glyphicon glyphicon-tag">&nbsp</span><?php echo $this->lang->line('sales_new_item'); ?>
@@ -495,12 +495,12 @@ $(document).ready(function()
 		{
 			if (resource.match(/suppliers$/))
 			{
-				$("#supplier").attr("value",response.id);
+				$("#supplier").val(response.id);
 				$("#select_supplier_form").submit();
 			}
 			else
 			{
-				$("#item").attr("value",response.id);
+				$("#item").val(response.id);
 				if (stay_open)
 				{
 					$("#add_item_form").ajaxSubmit();

--- a/public/js/manage_tables.js
+++ b/public/js/manage_tables.js
@@ -38,11 +38,14 @@
 				}
 			});
 
+			var has_new_btn = "btnNew" in $(this).data();
 			$.each($(this).data(), function(name, value) {
 				var btn_class = name.split("btn");
 				if (btn_class && btn_class.length > 1) {
 					var btn_name = btn_class[1].toLowerCase();
 					var is_submit = btn_name == 'submit';
+					var is_new = btn_name === 'new';
+					var is_enter = has_new_btn ? is_new: is_submit;
 					buttons.push({
 						id: btn_name,
 						label: value,


### PR DESCRIPTION
Did some minor change that helps when entering batches of new items in receivings or sales module. The items form will stay open when a user keeps hitting 'new' or when he uses a barcode scanner to finalize an item entry every time. The barcode field will be cleared out while attribute fields remain filled.

When finished entering new items, submit has to be clicked, which will then refresh the sale register or orders view that will then contain all the new entered items with a quantity equal to 1.