### PR TITLE
Rename sales_tax_amount to sale_tax_amount

### DIFF
--- a/application/libraries/Sale_lib.php
+++ b/application/libraries/Sale_lib.php
@@ -1272,9 +1272,9 @@ class Sale_lib
 
 		if(!$this->CI->config->item('tax_included'))
 		{
-			foreach($this->CI->tax_lib->get_taxes($this->get_cart()) as $tax)
+			foreach($this->CI->tax_lib->get_taxes($this->get_cart())[0] as $tax)
 			{
-				$total = bcadd($total, $tax['sales_tax_amount']);
+				$total = bcadd($total, $tax['sale_tax_amount']);
 			}
 		}
 


### PR DESCRIPTION
After a bit of testing there were a couple of changes to Sales_lib that were needed.  This pull request applies those fixes.