### PR TITLE
This fixes the improper display of the tax group

### DIFF
--- a/application/libraries/Tax_lib.php
+++ b/application/libraries/Tax_lib.php
@@ -81,7 +81,6 @@ class Tax_lib
 					foreach($tax_info as $tax)
 					{
 						// This computes tax for each line item and adds it to the tax type total
-						$tax_group = (float)$tax['percent'] . '% ' . $tax['name'];
 						$tax_basis = $this->CI->sale_lib->get_item_total($item['quantity'], $item['price'], $item['discount'], TRUE);
 						$tax_amount = 0.0;
 
@@ -99,7 +98,7 @@ class Tax_lib
 						if($tax_amount <> 0)
 						{
 							$tax_group_sequence++;
-							$this->update_taxes($taxes, $tax_type, $tax_group, $tax['percent'], $tax_basis, $tax_amount, $tax_group_sequence, Rounding_mode::HALF_UP, -1, $tax['name']);
+							$this->update_taxes($taxes, $tax_type, $tax['name'], $tax['percent'], $tax_basis, $tax_amount, $tax_group_sequence, Rounding_mode::HALF_UP, -1, $tax['name']);
 							$tax_group_sequence += 1;
 						}
 						$items_taxes_detail = array();
@@ -161,7 +160,7 @@ class Tax_lib
 	*/
 	public function update_taxes(&$taxes, $tax_type, $tax_group, $tax_rate, $tax_basis, $item_tax_amount, $tax_group_sequence, $rounding_code, $sale_id, $name = '', $tax_code_id = NULL, $jurisdiction_id = NULL,$tax_category_id = NULL  )
 	{
-		$tax_group_index = $this->clean('X' . $tax_group);
+		$tax_group_index = $this->clean('X' . (float)$tax_rate . '% ' . $tax_group);
 
 		if(!array_key_exists($tax_group_index, $taxes))
 		{
@@ -336,12 +335,10 @@ class Tax_lib
 					$cascade_tax_amount = $cascade_tax_amount + $tax_amount;
 				}
 
-				$tax_group = (float)$tax_rate . '% ' . $tax['tax_group'];
-
 				if($tax_amount != 0)
 				{
 
-					$this->update_taxes($taxes, $tax_type, $tax_group, $tax_rate, $tax_basis, $tax_amount, $tax['tax_group_sequence'], $rounding_code, $sale_id, $tax['tax_group'], $tax_code_id, $tax['rate_jurisdiction_id'], $item['tax_category_id']);
+					$this->update_taxes($taxes, $tax_type, $tax['tax_group'], $tax_rate, $tax_basis, $tax_amount, $tax['tax_group_sequence'], $rounding_code, $sale_id, $tax['tax_group'], $tax_code_id, $tax['rate_jurisdiction_id'], $item['tax_category_id']);
 				}
 
 				$item_taxes_detail = array();

--- a/application/models/Sale.php
+++ b/application/models/Sale.php
@@ -729,6 +729,7 @@ class Sale extends CI_Model
 	{
 		foreach($sales_taxes as $line=>$sales_tax)
 		{
+			$sales_tax['tax_group'] = (float)$sales_tax['tax_rate'] . '% ' . $sales_tax['tax_group'];
 			$sales_tax['sale_id'] = $sale_id;
 			$this->db->insert('sales_taxes', $sales_tax);
 		}

--- a/application/views/sales/invoice.php
+++ b/application/views/sales/invoice.php
@@ -180,7 +180,7 @@ $(document).ready(function()
 		?>
 			<tr>
 				<td colspan="<?php echo $invoice_columns-3; ?>" class="blank"> </td>
-				<td colspan="2" class="total-line"><textarea rows="5" cols="6"><?php echo $tax['tax_group']; ?></textarea></td>
+				<td colspan="2" class="total-line"><textarea rows="5" cols="6"><?php echo (float)$tax['tax_rate'] . '% ' . $tax['tax_group']; ?></textarea></td>
 				<td class="total-value"><textarea rows="5" cols="6" id="taxes"><?php echo to_currency_tax($tax['sale_tax_amount']); ?></textarea></td>
 			</tr>
 		<?php

--- a/application/views/sales/invoice_email.php
+++ b/application/views/sales/invoice_email.php
@@ -120,7 +120,7 @@
 		?>
 			<tr>
 				<td colspan="<?php echo $invoice_columns-3; ?>" class="blank"> </td>
-				<td colspan="2" class="total-line"><?php echo $tax['tax_group']; ?></td>
+				<td colspan="2" class="total-line"><?php echo (float)$tax['tax_rate'] . '% ' . $tax['tax_group']; ?></td>
 				<td id="taxes" class="total-value"><?php echo to_currency_tax($tax['sale_tax_amount']); ?></td>
 			</tr>
 		<?php

--- a/application/views/sales/quote.php
+++ b/application/views/sales/quote.php
@@ -168,7 +168,7 @@ if (isset($error_message))
 		?>
 			<tr>
 				<td colspan="<?php echo $quote_columns-3; ?>" class="blank"> </td>
-				<td colspan="2" class="total-line"><textarea rows="5" cols="6"><?php echo $tax['tax_group']; ?></textarea></td>
+				<td colspan="2" class="total-line"><textarea rows="5" cols="6"><?php echo (float)$tax['tax_rate'] . '% ' . $tax['tax_group']; ?></textarea></td>
 				<td class="total-value"><textarea rows="5" cols="6" id="taxes"><?php echo to_currency_tax($tax['sale_tax_amount']); ?></textarea></td>
 			</tr>
 		<?php

--- a/application/views/sales/quote_email.php
+++ b/application/views/sales/quote_email.php
@@ -120,7 +120,7 @@
 		?>
 			<tr>
 				<td colspan="<?php echo $quote_columns-3; ?>" class="blank"> </td>
-				<td colspan="2" class="total-line"><?php echo $tax['tax_group']; ?></td>
+				<td colspan="2" class="total-line"><?php echo (float)$tax['tax_rate'] . '% ' . $tax['tax_group']; ?></td>
 				<td id="taxes" class="total-value"><?php echo to_currency_tax($tax['sale_tax_amount']); ?></td>
 			</tr>
 		<?php

--- a/application/views/sales/receipt_default.php
+++ b/application/views/sales/receipt_default.php
@@ -143,7 +143,7 @@
 			{
 			?>
 				<tr>
-					<td colspan="3" class="total-value"><?php echo $tax['tax_group']; ?>:</td>
+					<td colspan="3" class="total-value"><?php echo (float)$tax['tax_rate'] . '% ' . $tax['tax_group']; ?>:</td>
 					<td class="total-value"><?php echo to_currency_tax($tax['sale_tax_amount']); ?></td>
 				</tr>
 			<?php

--- a/application/views/sales/receipt_email.php
+++ b/application/views/sales/receipt_email.php
@@ -135,7 +135,7 @@
 			{
 			?>
 				<tr>
-					<td colspan="3" style="text-align:right;"><?php echo $tax['tax_group']; ?>:</td>
+					<td colspan="3" style="text-align:right;"><?php echo (float)$tax['tax_rate'] . '% ' . $tax['tax_group']; ?>:</td>
 					<td style="text-align:right;"><?php echo to_currency_tax($tax['sale_tax_amount']); ?></td>
 				</tr>
 			<?php

--- a/application/views/sales/receipt_short.php
+++ b/application/views/sales/receipt_short.php
@@ -141,7 +141,7 @@
 			{
 			?>
 				<tr>
-					<td colspan="2" class="total-value"><?php echo $tax['tax_group']; ?>:</td>
+					<td colspan="2" class="total-value"><?php echo (float)$tax['tax_rate'] . '% ' . $tax['tax_group']; ?>:</td>
 					<td class="total-value"><?php echo to_currency_tax($tax['sale_tax_amount']); ?></td>
 				</tr>
 			<?php

--- a/application/views/sales/register.php
+++ b/application/views/sales/register.php
@@ -422,7 +422,7 @@ if(isset($success))
 			{
 			?>
 				<tr>
-					<th style='width: 55%;'><?php echo $tax['tax_group']; ?></th>
+					<th style='width: 55%;'><?php echo (float)$tax['tax_rate'] . '% ' . $tax['tax_group']; ?></th>
 					<th style="width: 45%; text-align: right;"><?php echo to_currency_tax($tax['sale_tax_amount']); ?></th>
 				</tr>
 			<?php

--- a/application/views/sales/tax_invoice.php
+++ b/application/views/sales/tax_invoice.php
@@ -183,7 +183,7 @@ $(document).ready(function()
 		?>
 			<tr>
 				<td colspan="<?php echo $invoice_columns-3; ?>" class="blank"> </td>
-				<td colspan="2" class="total-line"><textarea rows="5" cols="6"><?php echo $tax['tax_group']; ?></textarea></td>
+				<td colspan="2" class="total-line"><textarea rows="5" cols="6"><?php echo (float)$tax['tax_rate'] . '% ' . $tax['tax_group']; ?></textarea></td>
 				<td class="total-value"><textarea rows="5" cols="6" id="taxes"><?php echo to_currency_tax($tax['sale_tax_amount']); ?></textarea></td>
 			</tr>
 		<?php

--- a/application/views/sales/work_order.php
+++ b/application/views/sales/work_order.php
@@ -156,7 +156,7 @@ if(isset($error_message))
 				?>
 				<tr>
 					<td colspan="3" class="blank"> </td>
-					<td colspan="2" class="total-line"><textarea rows="5" cols="6"><?php echo $tax['tax_group']; ?></textarea></td>
+					<td colspan="2" class="total-line"><textarea rows="5" cols="6"><?php echo (float)$tax['tax_rate'] . '% ' . $tax['tax_group']; ?></textarea></td>
 					<td class="total-value"><textarea rows="5" cols="6" id="taxes"><?php echo to_currency_tax($tax['sale_tax_amount']); ?></textarea></td>
 				</tr>
 				<?php


### PR DESCRIPTION
The error is triggered by the percent sign being followed by a particular sequence of characters.