### PR TITLE
Correcting positioning of the ospos.css file

### DIFF
--- a/application/views/partial/header.php
+++ b/application/views/partial/header.php
@@ -25,6 +25,7 @@
 		<!-- start css template tags -->
 		<link rel="stylesheet" type="text/css" href="css/bootstrap.autocomplete.css"/>
 		<link rel="stylesheet" type="text/css" href="css/invoice.css"/>
+		<link rel="stylesheet" type="text/css" href="css/ospos.css"/>
 		<link rel="stylesheet" type="text/css" href="css/ospos_print.css"/>
 		<link rel="stylesheet" type="text/css" href="css/popupbox.css"/>
 		<link rel="stylesheet" type="text/css" href="css/receipt.css"/>
@@ -75,7 +76,6 @@
 		<link rel="stylesheet" type="text/css" href="dist/jquery-ui/jquery-ui.min.css"/>
 		<link rel="stylesheet" type="text/css" href="dist/opensourcepos.min.css?rel=c729835075"/>
 		<!-- end mincss template tags -->
-		<link rel="stylesheet" type="text/css" href="css/ospos.css"/>
 		<!-- start minjs template tags -->
 		<script type="text/javascript" src="dist/opensourcepos.min.js?rel=b9e3a39941"></script>
 		<!-- end minjs template tags -->


### PR DESCRIPTION
I wasn't aware of the need to build the project before css changes would take effect nor that I could just add `?debug=true` to the URL to see changes.  I've put the line back in its original position and it works without other changes.