### PR TITLE
Add attribute type conversion, error checking.

### DIFF
--- a/application/helpers/locale_helper.php
+++ b/application/helpers/locale_helper.php
@@ -497,4 +497,8 @@ function dateformat_bootstrap($php_format)
 	return strtr($php_format, $SYMBOLS_MATCHING);
 }
 
+function valid_datetime($datetime)
+{
+	return preg_match('/^([0-9]{2,4})-([0-1][0-9])-([0-3][0-9])(?:( [0-2][0-9]):([0-5][0-9]):([0-5][0-9]))?$/', $datetime);
+}
 ?>

--- a/application/models/Attribute.php
+++ b/application/models/Attribute.php
@@ -246,8 +246,9 @@ class Attribute extends CI_Model
 
 	private function check_data_validity($definition, $from, $to)
 	{
-		$success = TRUE;
-		
+		$success = FALSE;
+		$fail = FALSE;
+
 		if($from === TEXT)
 		{
 			if($to === DATETIME)
@@ -262,20 +263,13 @@ class Attribute extends CI_Model
 					if(!preg_match('/^([0-9]{2,4})-([0-1][0-9])-([0-3][0-9])(?:( [0-2][0-9]):([0-5][0-9]):([0-5][0-9]))?$/', $row['attribute_value']))
 					{
 						log_message('ERROR', 'item_id: ' . $row['item_id'] . ' with attribute_value: ' . $row['attribute_value'] . ' cannot be converted to datetime');
-						$success = FALSE;
+						$fail = TRUE;
 					}
 				}
-				return $success;
-			}
-			else
-			{
-				return FALSE;
+				$success = $fail ? FALSE: TRUE;
 			}
 		}
-		else
-		{
-			return FALSE;
-		}
+		return $success;
 	}
 	
 	private function convert_definition_type($definition_id, $from_type, $to_type)

--- a/application/models/Attribute.php
+++ b/application/models/Attribute.php
@@ -258,7 +258,7 @@ class Attribute extends CI_Model
 			
 			foreach($this->db->get()->result_array() as $row)
 			{
-				if(!preg_match('/^([0-9]{2,4})-([0-1][0-9])-([0-3][0-9])(?:( [0-2][0-9]):([0-5][0-9]):([0-5][0-9]))?$/', $row['attribute_value']))
+				if(valid_datetime($row['attribute_value']) === FALSE)
 				{
 					log_message('ERROR', 'item_id: ' . $row['item_id'] . ' with attribute_value: ' . $row['attribute_value'] . ' cannot be converted to datetime');
 					$success = FALSE;

--- a/application/models/Attribute.php
+++ b/application/models/Attribute.php
@@ -244,7 +244,7 @@ class Attribute extends CI_Model
 		return $this->search($search)->num_rows();
 	}
 
-	public function convert_definition_type($definition_id,$from_type,$to_type)
+	private function convert_definition_type($definition_id, $from_type, $to_type)
 	{
 		if($from_type === TEXT)
 		{
@@ -258,8 +258,8 @@ class Attribute extends CI_Model
 				$query .= 'ON ospos_attribute_values.attribute_id = ospos_attribute_links.attribute_id ';
 				$query .= 'SET attribute_datetime = attribute_value, ';
 				$query .= 'attribute_value = NULL ';
-				$query .= 'WHERE definition_id = '.$definition_id;
-				$this->db->query($query);
+				$query .= 'WHERE definition_id = ' . $this->db->escape($definition_id);
+				$success = $this->db->query($query);
 				
 				$this->db->trans_complete();
 			}
@@ -313,11 +313,11 @@ class Attribute extends CI_Model
 			$success = $this->db->update('attribute_definitions', $definition_data);
 			$definition_data['definition_id'] = $definition_id;
 		}
-		
+
 		$this->db->trans_complete();
-		
+
 		$success &= $this->db->trans_status();
-		
+
 		return $success;
 	}
 

--- a/application/views/attributes/form.php
+++ b/application/views/attributes/form.php
@@ -73,7 +73,7 @@ $(document).ready(function()
 	{
 		var definition_type = $("#definition_type option:selected").text();
 
-		if(definition_type == "DATETIME" || definition_type == "GROUP")
+		if(definition_type == "DATETIME" || (definition_type == "GROUP" && !is_new))
 		{	 
 			$('#definition_type').prop("disabled",true);	
 		} 

--- a/application/views/attributes/form.php
+++ b/application/views/attributes/form.php
@@ -19,7 +19,7 @@
 	<div class="form-group form-group-sm">
 		<?php echo form_label($this->lang->line('attributes_definition_type'), 'definition_type', array('class'=>'control-label col-xs-3')); ?>
 		<div class='col-xs-8'>
-			<?php echo form_dropdown('definition_type', DEFINITION_TYPES, array_search($definition_info->definition_type, DEFINITION_TYPES), 'id="definition_type" class="form-control" ' . ($definition_id != -1 ? 'disabled="disabled"' : ''));?>
+			<?php echo form_dropdown('definition_type', DEFINITION_TYPES, array_search($definition_info->definition_type, DEFINITION_TYPES), 'id="definition_type" class="form-control"');?>
 		</div>
 	</div>
 
@@ -69,10 +69,31 @@ $(document).ready(function()
 	var definition_id = <?php echo $definition_id; ?>;
 	var is_new = definition_id == -1;
 
+	var disable_definition_types = function()
+	{
+		var definition_type = $("#definition_type option:selected").text();
+
+		if(definition_type == "DATETIME" || definition_type == "GROUP")
+		{	 
+			$('#definition_type').prop("disabled",true);	
+		} 
+		else if(definition_type == "DROPDOWN")
+		{
+			$("#definition_type option:contains('GROUP')").hide();
+			$("#definition_type option:contains('DATETIME')").hide();
+		}
+		else
+		{
+			$("#definition_type option:contains('GROUP')").hide();
+		}
+	}
+	disable_definition_types();
+	
 	var show_hide_fields = function(event)
 	{
 	    var is_dropdown = $('#definition_type').val() !== '1';
 	    var is_no_group = $('#definition_type').val() !== '0';
+
 		$('#definition_value, #definition_list_group').parents('.form-group').toggleClass('hidden', is_dropdown);
 		$('#definition_flags').parents('.form-group').toggleClass('hidden', !is_no_group);
 	};


### PR DESCRIPTION
This is the pull request associated with #2317.  This enables conversion in the database for the following:

- TEXT -> DROPDOWN
- TEXT -> DATETIME
- DROPDOWN -> TEXT

Javascript has been implemented in the form to prevent all other conversions.  Currently DATETIME->TEXT is disabled because attribute_datetime does not have a UNIQUE constraint but attribute_value does.  It could be implemented in the future but would require a check for each attribute_datetime to see if the attribute_value already exists and then change the attribute_id in the attribute_links table for that row.  This is not a feature that we need so I'm not implementing it for now. 