### PR TITLE
docker-compose with nginx reverse proxy and letsencrypt certbot

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -32,3 +32,7 @@ vendor/
 *.log
 .env
 package-lock.json
+!/docker/.env
+/docker/data/database/db/*
+/docker/data/certbot/conf/*
+/docker/data/ospos/app/*

--- a/.travis.yml
+++ b/.travis.yml
@@ -20,7 +20,7 @@ script:
   - sed -i "s/'\(dev\)'/'$rev'/g" application/config/config.php
   - docker run --rm -it -v $(pwd):/app -w /app digitallyseamless/nodejs-bower-grunt
     sh -c "npm install && bower install && grunt package"
-  - docker-compose build
+  - /bin/bash docker/install-local.sh
 env:
   - TAG=$(echo ${TRAVIS_BRANCH} | sed s/feature\\///)
 after_success: '[ -n ${DOCKER_USERNAME} ] && docker login -u="$DOCKER_USERNAME" -p="$DOCKER_PASSWORD"

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,6 @@
-FROM php:7.2.18-apache
+FROM php:7.2-apache
 MAINTAINER jekkos
+
 RUN apt-get update && DEBIAN_FRONTEND=noninteractive apt-get install -y \
     libicu-dev \
     libgd-dev \

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM php:7.2-apache
+FROM php:7.3-apache
 MAINTAINER jekkos
 
 RUN apt-get update && DEBIAN_FRONTEND=noninteractive apt-get install -y \

--- a/database/Dockerfile
+++ b/database/Dockerfile
@@ -1,4 +1,4 @@
-FROM debian:jessie
+FROM alpine
 MAINTAINER jekkos
 
 ADD database.sql /docker-entrypoint-initdb.d/database.sql

--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -9,32 +9,37 @@ services:
         build:
             context: database/
             dockerfile: Dockerfile
-    php:
+
+    ospos:
         build:
             context: .
             dockerfile: Dockerfile.dev
-        links:
-            - mysql
+        container_name: ospos
+        restart: always
+        depends_on:
+          - mysql
         ports:
-            - "80:80"
+          - "80:80"
         volumes:
-            - .:/app
+          - .:/app
         environment:
-            - PHP_TIMEZONE=UTC
-            - MYSQL_USERNAME=admin
-            - MYSQL_PASSWORD=pointofsale
-            - MYSQL_DB_NAME=ospos
-            - MYSQL_HOST_NAME=mysql
-            - XDEBUG_CONFIG=remote_host=172.17.0.1
+          - PHP_TIMEZONE=UTC
+          - MYSQL_USERNAME=admin
+          - MYSQL_PASSWORD=pointofsale
+          - MYSQL_DB_NAME=ospos
+          - MYSQL_HOST_NAME=mysql
+          - XDEBUG_CONFIG=remote_host=172.17.0.1
 
     mysql:
         image: mariadb:10.1.21
-        environment:
-            - MYSQL_ROOT_PASSWORD=pointofsale
-            - MYSQL_DATABASE=ospos
-            - MYSQL_USER=admin
-            - MYSQL_PASSWORD=pointofsale
+        container_name: mysql
+        restart: always
         ports:
-            - "3306:3306"
+          - "3306:3306"
         volumes_from:
-            - sqlscript
+          - sqlscript
+        environment:
+          - MYSQL_ROOT_PASSWORD=pointofsale
+          - MYSQL_DATABASE=ospos
+          - MYSQL_USER=admin
+          - MYSQL_PASSWORD=pointofsale

--- a/docker-compose.test.yml
+++ b/docker-compose.test.yml
@@ -5,32 +5,38 @@ services:
         build:
             context: .
             dockerfile: Dockerfile.test
+
     sqlscript:
         build:
             context: database/
             dockerfile: Dockerfile
-    php:
+
+    ospos:
         build:
             context: .
             dockerfile: Dockerfile
-        links:
-            - mysql
+        container_name: ospos
+        restart: always
+        depends_on:
+          - mysql
         ports:
-            - "80:80"
+          - "80:80"
         environment:
-            - MYSQL_USERNAME=admin
-            - MYSQL_PASSWORD=pointofsale
-            - MYSQL_DB_NAME=ospos
-            - MYSQL_HOST_NAME=mysql
+          - MYSQL_USERNAME=admin
+          - MYSQL_PASSWORD=pointofsale
+          - MYSQL_DB_NAME=ospos
+          - MYSQL_HOST_NAME=mysql
 
     mysql:
         image: mysql:5.7
-        environment:
-            - MYSQL_ROOT_PASSWORD=pointofsale
-            - MYSQL_DATABASE=ospos
-            - MYSQL_USER=admin
-            - MYSQL_PASSWORD=pointofsale
+        container_name: mysql
+        restart: always
         ports:
-            - "3306:3306"
+          - "3306:3306"
         volumes:
-            - ./database/database.sql:/docker-entrypoint-initdb.d/database.sql
+          - ./database/database.sql:/docker-entrypoint-initdb.d/database.sql
+        environment:
+          - MYSQL_ROOT_PASSWORD=pointofsale
+          - MYSQL_DATABASE=ospos
+          - MYSQL_USER=admin
+          - MYSQL_PASSWORD=pointofsale

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -5,7 +5,8 @@ volumes:
         driver: local
 
 networks:
-    ospos_net:
+    app_net:
+    db_net:
 
 services:
     sqlscript:
@@ -13,55 +14,92 @@ services:
             context: database/
             dockerfile: Dockerfile
 
-    php:
+    ospos:
         build:
             context: .
             dockerfile: Dockerfile
-        container_name: php
+        container_name: ospos
         restart: always
         depends_on:
-           - mysql
-        ports:
-            - "80:80"
+          - mysql
+        expose:
+          - "80"
         networks:
-            - ospos_net
+          - app_net
+          - db_net
         volumes:
-            - uploads:/app/public/uploads
+          - uploads:/app/public/uploads
         environment:
-            - FORCE_HTTPS=false
-            - PHP_TIMEZONE=UTC
-            - MYSQL_USERNAME=admin
-            - MYSQL_PASSWORD=pointofsale
-            - MYSQL_DB_NAME=ospos
-            - MYSQL_HOST_NAME=mysql
+          - FORCE_HTTPS=true
+          - PHP_TIMEZONE=UTC
+          - MYSQL_USERNAME=${OSPOS_MYSQL_USERNAME}
+          - MYSQL_PASSWORD=${OSPOS_MYSQL_PASSWORD}
+          - MYSQL_DB_NAME=ospos
+          - MYSQL_HOST_NAME=mysql
 
     mysql:
-        image: mariadb:10.3.9
+        image: mariadb:10.3
         container_name: mysql
         restart: always
-        ports:
-            - "3306:3306"
+        expose:
+          - "3306"
         networks:
-            - ospos_net
+          - db_net
         volumes_from:
-            - sqlscript
+          - sqlscript
         environment:
-            - MYSQL_ROOT_PASSWORD=pointofsale
-            - MYSQL_DATABASE=ospos
-            - MYSQL_USER=admin
-            - MYSQL_PASSWORD=pointofsale
+          - MYSQL_ROOT_PASSWORD=${OSPOS_MYSQL_ROOT_PASSWORD}
+          - MYSQL_DATABASE=ospos
+          - MYSQL_USER=${OSPOS_MYSQL_USERNAME}
+          - MYSQL_PASSWORD=${OSPOS_MYSQL_PASSWORD}
 
-#    phpmyadmin:
-#        image: phpmyadmin/phpmyadmin
-#        container_name: phpmyadmin
-#        restart: always
-#        depends_on:
-#           - mysql
-#        ports:
-#           - "8000:80"
-#        networks:
-#            - ospos_net
-#        environment:
-#            - MYSQL_USERNAME=admin
-#            - MYSQL_ROOT_PASSWORD=pointofsale
-#            - PMA_HOST=mysql
+    phpmyadmin:
+        image: phpmyadmin/phpmyadmin
+        container_name: phpmyadmin
+        restart: always
+        depends_on:
+          - mysql
+        expose:
+          - "80"
+        networks:
+          - app_net
+          - db_net
+        environment:
+          - MYSQL_USERNAME=${OSPOS_MYSQL_USERNAME}
+          - MYSQL_ROOT_PASSWORD=${OSPOS_MYSQL_ROOT_PASSWORD}
+          - PMA_HOST=mysql
+
+    nginx:
+        image: nginx:1.15-alpine
+        container_name: nginx
+        restart: always
+        depends_on:
+          - ospos
+          - phpmyadmin
+          - certbot
+        volumes:
+          - ./docker/data/nginx/nginx.tmpl:/etc/nginx/nginx.tmpl:ro
+          - ./docker/data/nginx/error_log.log:/etc/nginx/error_log.log
+          - ./docker/data/certbot/conf:/etc/letsencrypt:ro
+          - ./docker/data/certbot/www:/var/www/certbot:ro
+        ports:
+          - "80:80"
+          - "443:443"
+          - "8000:8000"
+        networks:
+          - app_net
+        environment:
+          - WEB_DOMAIN=${OSPOS_DOMAIN_NAME}
+          - ESC=$$
+        command: "/bin/sh -c 'envsubst < /etc/nginx/nginx.tmpl > /etc/nginx/nginx.conf & while :; do sleep 6h & wait $${!}; nginx -s reload; done & nginx -g \"daemon off;\"'"
+
+    certbot:
+        image: certbot/certbot
+        container_name: certbot
+        restart: always
+        volumes:
+          - ./docker/data/certbot/conf:/etc/letsencrypt
+          - ./docker/data/certbot/www:/var/www/certbot
+        networks:
+          - app_net
+        entrypoint: "/bin/sh -c 'trap exit TERM; while :; do certbot renew; sleep 12h & wait $${!}; done;'"

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -3,6 +3,8 @@ version: '2'
 volumes:
     uploads:
         driver: local
+    logs:
+        driver: local
 
 networks:
     app_net:
@@ -29,6 +31,7 @@ services:
           - db_net
         volumes:
           - uploads:/app/public/uploads
+          - logs:/app/application/logs
         environment:
           - FORCE_HTTPS=true
           - PHP_TIMEZONE=UTC

--- a/docker/.env
+++ b/docker/.env
@@ -1,0 +1,10 @@
+OSPOS_MYSQL_USERNAME=admin
+OSPOS_MYSQL_PASSWORD=pointofsale
+OSPOS_MYSQL_ROOT_PASSWORD=ospos_mysql
+# Set a valid domain name if you use Letsencrypt
+OSPOS_DOMAIN_NAME=ospos.ospos
+# Set a valid email address if you use Letsencrypt
+OSPOS_CONTACT_EMAIL=admion@ospos.ospos
+# Set to 1 if you're testing your setup with Letsencrypt 
+# to avoid hitting request limits, otherwise set 0
+OSPOS_STAGING=1

--- a/docker/.env
+++ b/docker/.env
@@ -4,7 +4,7 @@ OSPOS_MYSQL_ROOT_PASSWORD=ospos_mysql
 # Set a valid domain name if you use Letsencrypt
 OSPOS_DOMAIN_NAME=ospos.ospos
 # Set a valid email address if you use Letsencrypt
-OSPOS_CONTACT_EMAIL=admion@ospos.ospos
+OSPOS_CONTACT_EMAIL=admin@ospos.ospos
 # Set to 1 if you're testing your setup with Letsencrypt 
 # to avoid hitting request limits, otherwise set 0
 OSPOS_STAGING=1

--- a/docker/data/nginx/nginx.tmpl
+++ b/docker/data/nginx/nginx.tmpl
@@ -1,0 +1,69 @@
+worker_processes auto;
+
+events {
+    worker_connections 1024;
+}
+
+http {
+
+	error_log /etc/nginx/error_log.log warn;
+
+	server {
+		listen               80;
+		server_name          ${WEB_DOMAIN};
+		server_tokens        off;
+
+		location /.well-known/acme-challenge/ {
+			root /var/www/certbot;
+		}
+
+		location / {
+			return 301 https://${ESC}host${ESC}request_uri;
+		}
+	}
+
+	server {
+		listen               443 ssl;
+		server_name          ${WEB_DOMAIN};
+		server_tokens        off;
+		
+		client_max_body_size 10M;
+
+		ssl_certificate /etc/letsencrypt/live/ospos.ospos/fullchain.pem;
+		ssl_certificate_key /etc/letsencrypt/live/ospos.ospos/privkey.pem;
+		include /etc/letsencrypt/options-ssl-nginx.conf;
+		ssl_dhparam /etc/letsencrypt/ssl-dhparams.pem;
+
+		location / {
+			proxy_pass          http://ospos:80;
+			proxy_redirect      off;
+			proxy_set_header    Host                ${ESC}host;
+			proxy_set_header    X-Real-IP           ${ESC}remote_addr;
+			proxy_set_header    X-Forwarded-For     ${ESC}proxy_add_x_forwarded_for;
+			proxy_set_header    X-Forwarded-Host    ${ESC}server_name;
+			proxy_set_header    X-Forwarded-Proto   ${ESC}scheme;
+		}
+	}
+
+	server {
+		listen               8000 ssl;
+		server_name          ${WEB_DOMAIN};
+		server_tokens        off;
+
+		ssl_certificate /etc/letsencrypt/live/ospos.ospos/fullchain.pem;
+		ssl_certificate_key /etc/letsencrypt/live/ospos.ospos/privkey.pem;
+		include /etc/letsencrypt/options-ssl-nginx.conf;
+		ssl_dhparam /etc/letsencrypt/ssl-dhparams.pem;
+
+		location / {
+			proxy_pass          http://phpmyadmin:80;
+			proxy_redirect      off;
+			proxy_set_header    Host                ${ESC}host;
+			proxy_set_header    X-Real-IP           ${ESC}remote_addr;
+			proxy_set_header    X-Forwarded-For     ${ESC}proxy_add_x_forwarded_for;
+			proxy_set_header    X-Forwarded-Host    ${ESC}server_name;
+			proxy_set_header    X-Forwarded-Proto   ${ESC}scheme;
+		}
+	}
+
+}

--- a/docker/init-letsencrypt.sh
+++ b/docker/init-letsencrypt.sh
@@ -1,0 +1,75 @@
+#!/bin/bash
+
+domains=(${OSPOS_DOMAIN_NAME})
+rsa_key_size=4096
+data_path="./data/certbot"
+email="${OSPOS_CONTACT_EMAIL}"
+staging=${OSPOS_STAGING}
+
+if [ -d "$data_path" ]; then
+  read -p "Existing data found for $domains. Continue and replace existing certificate? (y/N) " decision
+  if [ "$decision" != "Y" ] && [ "$decision" != "y" ]; then
+    exit
+  fi
+fi
+
+
+if [ ! -e "$data_path/conf/options-ssl-nginx.conf" ] || [ ! -e "$data_path/conf/ssl-dhparams.pem" ]; then
+  echo "### Downloading recommended TLS parameters ..."
+  mkdir -p "$data_path/conf"
+  curl -s https://raw.githubusercontent.com/certbot/certbot/master/certbot-nginx/certbot_nginx/options-ssl-nginx.conf > "$data_path/conf/options-ssl-nginx.conf"
+  curl -s https://raw.githubusercontent.com/certbot/certbot/master/certbot/ssl-dhparams.pem > "$data_path/conf/ssl-dhparams.pem"
+  echo
+fi
+
+echo "### Creating dummy certificate for $domains ..."
+path="/etc/letsencrypt/live/$domains"
+mkdir -p "$data_path/conf/live/$domains"
+docker-compose run --rm --entrypoint "\
+  openssl req -x509 -nodes -newkey rsa:1024 -days 1\
+    -keyout '$path/privkey.pem' \
+    -out '$path/fullchain.pem' \
+    -subj '/CN=localhost'" certbot
+echo
+
+
+echo "### Starting nginx ..."
+docker-compose up --force-recreate -d nginx
+echo
+
+echo "### Deleting dummy certificate for $domains ..."
+docker-compose run --rm --entrypoint "\
+  rm -Rf /etc/letsencrypt/live/$domains && \
+  rm -Rf /etc/letsencrypt/archive/$domains && \
+  rm -Rf /etc/letsencrypt/renewal/$domains.conf" certbot
+echo
+
+
+echo "### Requesting Let's Encrypt certificate for $domains ..."
+#Join $domains to -d args
+domain_args=""
+for domain in "${domains[@]}"; do
+  domain_args="$domain_args -d $domain"
+done
+
+# Select appropriate email arg
+case "$email" in
+  "") email_arg="--register-unsafely-without-email" ;;
+  *) email_arg="--email $email" ;;
+esac
+
+# Enable staging mode if needed
+if [ $staging != "0" ]; then staging_arg="--staging"; fi
+
+docker-compose run --rm --entrypoint "\
+  certbot certonly --webroot -w /var/www/certbot \
+    $staging_arg \
+    $email_arg \
+    $domain_args \
+    --rsa-key-size $rsa_key_size \
+    --agree-tos \
+    --force-renewal" certbot
+echo
+
+echo "### Reloading nginx ..."
+docker-compose exec nginx nginx -s reload

--- a/docker/init-letsencrypt.sh
+++ b/docker/init-letsencrypt.sh
@@ -1,6 +1,8 @@
 #!/bin/bash
 
-domains=(${OSPOS_DOMAIN_NAME})
+. ./.env
+
+domains=${OSPOS_DOMAIN_NAME}
 rsa_key_size=4096
 data_path="./data/certbot"
 email="${OSPOS_CONTACT_EMAIL}"

--- a/docker/init-selfcert.sh
+++ b/docker/init-selfcert.sh
@@ -1,0 +1,41 @@
+#!/bin/bash
+
+domains=(${OSPOS_DOMAIN_NAME})
+rsa_key_size=4096
+data_path="./data/certbot"
+
+if [ -d "$data_path" ]; then
+  read -p "Existing data found for $domains. Continue and replace existing certificate? (y/N) " decision
+  if [ "$decision" != "Y" ] && [ "$decision" != "y" ]; then
+    exit
+  fi
+fi
+
+
+if [ ! -e "$data_path/conf/options-ssl-nginx.conf" ] || [ ! -e "$data_path/conf/ssl-dhparams.pem" ]; then
+  echo "### Downloading recommended TLS parameters ..."
+  mkdir -p "$data_path/conf"
+  curl -s https://raw.githubusercontent.com/certbot/certbot/master/certbot-nginx/certbot_nginx/options-ssl-nginx.conf > "$data_path/conf/options-ssl-nginx.conf"
+  curl -s https://raw.githubusercontent.com/certbot/certbot/master/certbot/ssl-dhparams.pem > "$data_path/conf/ssl-dhparams.pem"
+  echo
+fi
+
+
+echo "### Creating dummy certificate for $domains ..."
+path="/etc/letsencrypt/live/$domains"
+mkdir -p "$data_path/conf/live/$domains"
+docker-compose run --rm --entrypoint "\
+  openssl req -x509 -nodes -newkey rsa:1024 -days 1\
+    -keyout '$path/privkey.pem' \
+    -out '$path/fullchain.pem' \
+    -subj '/CN=localhost'" certbot
+echo
+
+
+echo "### Starting nginx ..."
+docker-compose up --force-recreate -d nginx
+echo
+
+
+#echo "### Reloading nginx ..."
+#docker-compose exec nginx nginx -s reload

--- a/docker/init-selfcert.sh
+++ b/docker/init-selfcert.sh
@@ -1,6 +1,8 @@
 #!/bin/bash
 
-domains=(${OSPOS_DOMAIN_NAME})
+. ./.env
+
+domains=${OSPOS_DOMAIN_NAME}
 rsa_key_size=4096
 data_path="./data/certbot"
 

--- a/docker/install-local.sh
+++ b/docker/install-local.sh
@@ -1,0 +1,15 @@
+#!/bin/bash
+
+cd docker
+
+# load local environment variables
+if [ ! -e ".env" ]; then
+  echo "The .env (environment variables) file is missing"
+  exit 1
+fi
+
+. ./.env
+
+docker-compose build
+
+/bin/bash ./init-selfcert.sh

--- a/docker/install-server.sh
+++ b/docker/install-server.sh
@@ -1,0 +1,15 @@
+#!/bin/bash
+
+cd docker
+
+# load local environment variables
+if [ ! -e ".env" ]; then
+  echo "The .env (environment variables) file is missing"
+  exit 1
+fi
+
+. ./.env
+
+docker-compose build
+
+/bin/bash ./init-letsencrypt.sh

--- a/docker/uninstall.sh
+++ b/docker/uninstall.sh
@@ -1,0 +1,7 @@
+#!/bin/bash
+
+cd docker
+
+. ./.env
+
+docker-compose down


### PR DESCRIPTION
Here the docker-compose enhancement to add a nginx reverse proxy with SSL termination based on a Letsencrypt certificate.
The certbot docker image manages the SSL certificate refresh every 3 months.

To run locally you need to use the init-selfcert.sh script.
If you want to try the Letsencrypt SSL, you need to use the init-letsencrypt.sh script.

Please note that myPhpAdmin is enabled on port 8000. If not required the nginx forward rule needs to be commented out.

I didn't touch the docker-compose.dev and .test as I'm not sure how those are used.

@jekkos the issue I had was fixed setting FORCE_HTTPS=true in the environment: docker-compose.yml file.