### PR TITLE
Dt performance patch 1

### DIFF
--- a/application/controllers/Items.php
+++ b/application/controllers/Items.php
@@ -26,6 +26,10 @@ class Items extends Secure_Controller
 			'is_serialized' => $this->lang->line('items_serialized_items'),
 			'no_description' => $this->lang->line('items_no_description_items'),
 			'search_custom' => $this->lang->line('items_search_attributes'),
+//NEED XLATION                  'has_transactions' => $this->lang->line('items_search_custom_items'),  // dmt
+//NEED XLATION                  'no_transactions' => $this->lang->line('items_search_custom_items'),   // dmt
+			'has_transactions' => "Has Transactions during Range",                          //dmt
+			'no_transactions' => "No Transactions during Range",                            //dmt
 			'is_deleted' => $this->lang->line('items_is_deleted'),
 			'temporary' => $this->lang->line('items_temp'));
 
@@ -55,6 +59,8 @@ class Items extends Secure_Controller
 						'is_serialized' => FALSE,
 						'no_description' => FALSE,
 						'search_custom' => FALSE,
+						'has_transactions' => FALSE,	//dmt
+						'no_transactions' => FALSE,	//dmt
 						'is_deleted' => FALSE,
 						'temporary' => FALSE,
 						'definition_ids' => array_keys($definition_names));
@@ -63,9 +69,15 @@ class Items extends Secure_Controller
 		$filledup = array_fill_keys($this->input->get('filters'), TRUE);
 		$filters = array_merge($filters, $filledup);
 
+// CI attempts to prefix the SQL directive when prefix is enabled  //dmt
+//  This ONLY necessary if dbprefix is being used and can be removed if it isn't
+$dmthold_prefix = $this->db->dbprefix;  //dmt
+$this->db->set_dbprefix(''); //dmt
 		$items = $this->Item->search($search, $filters, $limit, $offset, $sort, $order);
 
 		$total_rows = $this->Item->get_found_rows($search, $filters);
+$this->db->set_dbprefix($dmthold_prefix); //dmt
+
 
 		$data_rows = array();
 		foreach($items->result() as $item)

--- a/application/models/Customer.php
+++ b/application/models/Customer.php
@@ -100,7 +100,7 @@ class Customer extends Person
 	{
 		// create a temporary table to contain all the sum and average of items
 		$this->db->query('CREATE TEMPORARY TABLE IF NOT EXISTS ' . $this->db->dbprefix('sales_items_temp') .
-			' (INDEX(sale_id))
+			' (INDEX(sale_id)) ENGINE=MEMORY
 			(
 				SELECT
 					sales.sale_id AS sale_id,


### PR DESCRIPTION
Upload version 2.  I have no idea how from a bad repo - I just forked 2 days ago!

THIS MOD REQUIRES DATABASE CHANGE:
create index trxbydate ospos_inventory (trans_date);

This is the commented version, with a lot of "commented" code in case re-instatement is necessary,
as well as give a better idea of the changes.

Query times on mine (62,000 items, 1.07 million inventory transactions) drops from
62.5 + 31.6 seconds (94.1) on opening to a typical 0.62 seconds on opening + .05 if transactions are queried.

Searching by date through ospos_inventory is NOT required or done on initial load, but only if selected in the options box. Option added for transactions in date range AND no transactions in date range.

Ideally the checkmarks would be mutually exclusive, but has_transactions has precedence.

** Uses SQL_CALC_FOUND_ROWS to populate next query FOUND_ROWS() to eliminate time required to count the records again - saving typically .32 of a second. (was 32 seconds)
** has to turn off dbprefix temporarily in controller to convince CodeIgniter that it isn't a table needing pre-fixing.

I look forward to your comments!
Dan