### PR TITLE
fix typo with lang string w/ variable

### DIFF
--- a/application/controllers/Sales.php
+++ b/application/controllers/Sales.php
@@ -805,7 +805,7 @@ class Sales extends Secure_Controller
 			$html = $this->load->view("sales/" . $type . "_email", $sale_data, TRUE);
 			// load pdf helper
 			$this->load->helper(array('dompdf', 'file'));
-			$filename = sys_get_temp_dir() . '/' . $this->lang->line("sales_$type") . '-' . str_replace('/', '-', $number) . '.pdf';
+			$filename = sys_get_temp_dir() . '/' . $this->lang->line("sales_" . $type) . '-' . str_replace('/', '-', $number) . '.pdf';
 			if(file_put_contents($filename, pdf_create($html)) !== FALSE)
 			{
 				$result = $this->email_lib->sendEmail($to, $subject, $text, $filename);


### PR DESCRIPTION
Hi guys,

In the `send_pdf()` function in the Sales controller there is a filename string:

`$filename = sys_get_temp_dir() . '/' . $this->lang->line("sales_$type") . '-' . str_replace('/', '-', $number) . '.pdf';`

However `$this->lang->line("sales_$type")` is not valid and should be `$this->lang->line("sales_" . $type)`

Quick PR to change it

Thanks
Josh