### PR TITLE
fix typo with lang string

### DIFF
--- a/application/controllers/Sales.php
+++ b/application/controllers/Sales.php
@@ -464,7 +464,7 @@ class Sales extends Secure_Controller
 		$quantity = parse_decimals($this->input->post('quantity'));
 		$discount = parse_decimals($this->input->post('discount'));
 		$discount_type = $this->input->post('discount_type');
-		
+
 		$item_location = $this->input->post('location');
 		$discounted_total = $this->input->post('discounted_total') != '' ? $this->input->post('discounted_total') : NULL;
 
@@ -793,7 +793,7 @@ class Sales extends Secure_Controller
 		{
 			$to = $sale_data['customer_email'];
 			$number = $sale_data[$type."_number"];
-			$subject = $this->lang->line("sales_$type") . ' ' . $number;
+			$subject = $this->lang->line("sales" . $type) . ' ' . $number;
 
 			$text = $this->config->item('invoice_email_message');
 			$tokens = array(new Token_invoice_sequence($sale_data['invoice_number']),

--- a/application/controllers/Sales.php
+++ b/application/controllers/Sales.php
@@ -793,7 +793,7 @@ class Sales extends Secure_Controller
 		{
 			$to = $sale_data['customer_email'];
 			$number = $sale_data[$type."_number"];
-			$subject = $this->lang->line("sales" . $type) . ' ' . $number;
+			$subject = $this->lang->line("sales_" . $type) . ' ' . $number;
 
 			$text = $this->config->item('invoice_email_message');
 			$tokens = array(new Token_invoice_sequence($sale_data['invoice_number']),


### PR DESCRIPTION
**Related**: https://github.com/opensourcepos/opensourcepos/pull/2425

Hi Folks, related to above PR, same issue - in the initial PR I didn't notice the subject also had the same issue with lang string.

Summary of fix:
Occurrence of `$this->lang->line("sales_$type")` is not valid and has been changed to `$this->lang->line("sales_" . $type)`

Did a quick search and couldn't find any others

Cheers,
Josh