### PR TITLE
Support updates to payments

### DIFF
--- a/application/libraries/Sale_lib.php
+++ b/application/libraries/Sale_lib.php
@@ -485,15 +485,18 @@ class Sale_lib
 		$totals['prediscount_subtotal'] = $prediscount_subtotal;
 		$totals['total_discount'] = $total_discount;
 		$totals['subtotal'] = $subtotal;
+		$sales_tax = 0;
 
 		foreach($taxes as $tax_excluded)
 		{
 			if($tax_excluded['tax_type'] == Tax_lib::TAX_TYPE_EXCLUDED)
 			{
 				$total = bcadd($total, $tax_excluded['sale_tax_amount']);
+				$sales_tax = bcadd($sales_tax, $tax_excluded['sale_tax_amount']);
 			}
 		}
 		$totals['total'] = $total;
+		$totals['tax_total'] = $sales_tax;
 
 		if($cash_rounding)
 		{

--- a/application/migrations/20190427100000_paymenttracking.php
+++ b/application/migrations/20190427100000_paymenttracking.php
@@ -1,0 +1,20 @@
+<?php if (!defined('BASEPATH')) exit('No direct script access allowed');
+
+class Migration_PaymentTracking extends CI_Migration
+{
+	public function __construct()
+	{
+		parent::__construct();
+	}
+
+	public function up()
+	{
+		execute_script(APPPATH . 'migrations/sqlscripts/3.3.0_paymenttracking.sql');
+	}
+
+	public function down()
+	{
+
+	}
+}
+?>

--- a/application/migrations/sqlscripts/3.3.0_paymenttracking.sql
+++ b/application/migrations/sqlscripts/3.3.0_paymenttracking.sql
@@ -1,0 +1,26 @@
+-- Improve payment tracking
+
+RENAME TABLE ospos_sales_payments TO ospos_sales_payments_backup;
+
+CREATE TABLE `ospos_sales_payments` (
+  `payment_id` int(11) NOT NULL AUTO_INCREMENT,
+  `sale_id` int(10) NOT NULL,
+  `payment_type` varchar(40) NOT NULL,
+  `payment_amount` decimal(15,2) NOT NULL,
+  `payment_user` int(11) NOT NULL DEFAULT 0,
+  `payment_date` timestamp NOT NULL DEFAULT CURRENT_TIMESTAMP,
+  `reference_code` varchar(40) NOT NULL DEFAULT '',
+  PRIMARY KEY (`payment_id`),
+  KEY `payment_sale` (`sale_id`, `payment_type`)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8;
+
+INSERT INTO ospos_sales_payments (sale_id, payment_type, payment_amount, payment_user)
+SELECT payments.sale_id, payments.payment_type, payments.payment_amount, sales.employee_id
+FROM ospos_sales_payments_backup AS payments
+JOIN ospos_sales AS sales ON payments.sale_id = sales.sale_id
+ORDER BY payments.sale_id, payments.payment_type;
+
+DROP TABLE IF EXISTS ospos_sales_payments_backup;
+
+ALTER TABLE `ospos_sales_payments`
+  ADD CONSTRAINT `ospos_sales_payments_ibfk_1` FOREIGN KEY (`sale_id`) REFERENCES `ospos_sales` (`sale_id`);

--- a/application/models/reports/Summary_payments.php
+++ b/application/models/reports/Summary_payments.php
@@ -162,8 +162,8 @@ class Summary_payments extends Summary_report
 		);
 
 		$this->db->query('UPDATE ' . $this->db->dbprefix('sumpay_items_temp') . ' AS sumpay_items '
-			. 'SET trans_amount = trans_amount + (SELECT total_taxes FROM ' . $this->db->dbprefix('sumpay_taxes_temp')
-			. ' AS sumpay_taxes WHERE sumpay_items.sale_id = sumpay_taxes.sale_id)');
+			. 'SET trans_amount = trans_amount + IFNULL((SELECT total_taxes FROM ' . $this->db->dbprefix('sumpay_taxes_temp')
+			. ' AS sumpay_taxes WHERE sumpay_items.sale_id = sumpay_taxes.sale_id),0)');
 
 		$this->db->query('CREATE TEMPORARY TABLE IF NOT EXISTS ' . $this->db->dbprefix('sumpay_payments_temp') .
 			' (INDEX(sale_id))

--- a/application/views/sales/form.php
+++ b/application/views/sales/form.php
@@ -15,7 +15,7 @@
 				<?php echo form_input(array('name'=>'date','value'=>to_datetime(strtotime($sale_info['sale_time'])), 'class'=>'datetime form-control input-sm'));?>
 			</div>
 		</div>
-		
+
 		<?php
 		if($this->config->item('invoice_enable') == TRUE)
 		{
@@ -35,6 +35,31 @@
 		}
 		?>
 
+		<?php
+		if($balance_due)
+		{
+		?>
+			<div class="form-group form-group-sm">
+				<?php echo form_label($this->lang->line('sales_payment'), 'payment_new', array('class'=>'control-label col-xs-3')); ?>
+				<div class='col-xs-4'>
+					<?php echo form_dropdown('payment_type_new', $new_payment_options, $payment_type_new, array('id'=>'payment_types_new', 'class'=>'form-control')); ?>
+				</div>
+				<div class='col-xs-4'>
+					<div class="input-group input-group-sm">
+						<?php if(!currency_side()): ?>
+							<span class="input-group-addon input-sm"><b><?php echo $this->config->item('currency_symbol'); ?></b></span>
+						<?php endif; ?>
+						<?php echo form_input(array('name'=>'payment_amount_new', 'value'=>$payment_amount_new, 'id'=>'payment_amount_new', 'class'=>'form-control input-sm'));?>
+						<?php if (currency_side()): ?>
+							<span class="input-group-addon input-sm"><b><?php echo $this->config->item('currency_symbol'); ?></b></span>
+						<?php endif; ?>
+					</div>
+				</div>
+			</div>
+		<?php
+		}
+		?>
+
 		<?php 
 		$i = 0;
 		foreach($payments as $row)
@@ -44,6 +69,7 @@
 				<?php echo form_label($this->lang->line('sales_payment'), 'payment_'.$i, array('class'=>'control-label col-xs-3')); ?>
 				<div class='col-xs-4'>
 						<?php // no editing of Gift Card payments as it's a complex change ?>
+						<?php echo form_hidden('payment_id_'.$i, $row->payment_id); ?>
 						<?php if( !empty(strstr($row->payment_type, $this->lang->line('sales_giftcard'))) ): ?>
 							<?php echo form_input(array('name'=>'payment_type_'.$i, 'value'=>$row->payment_type, 'id'=>'payment_type_'.$i, 'class'=>'form-control input-sm', 'readonly'=>'true'));?>
 						<?php else: ?>


### PR DESCRIPTION
Okay, this is a rather trivial change that allows payments to be adjusted "post sale".

You simply go to Daily Sales to locate the invoice containing the payments to be adjusted and click on the "Update" icon.  You will be presented with the the Update form which now has a place to enter a payment adjustment.

Of course, there are a couple of problems I have with this entire process.  Payments are not transaction oriented by which I mean that if I add a payment transaction there isn't a record of the transaction written.  Instead the transaction is added to the collection of sales payments.  Since the key to the sales_payments table is the payment type there can only be one entry per payment type - so additional payments for a sale that all have the same payment type are accumulated into one record that reflects that payment type.

That's the negative side of this change.  The positive side is that you can now update the balance due for each sale if payments are received after the sale.

There are numerous improvements that can be made, but I wanted to offer this as both something that will allow some sites to temporarily "get by" and as a prototype for discussions about what future improvements might be necessary so that the job of payment tracking is done right.