### PR TITLE
fix typo in url in bintray config

### DIFF
--- a/deployment.json
+++ b/deployment.json
@@ -4,7 +4,7 @@
         "repo": "opensourcepos",
         "subject": "jekkos",
         "website_url": "https://www.github.com/opensourcepos/opensourcepos",
-        "issue_tracker_url": "https://github.com/opensourcepos/opensourcepo/issues",
+        "issue_tracker_url": "https://github.com/opensourcepos/opensourcepos/issues",
         "vcs_url": "https://github.com/opensourcepos/opensourcepos.git",
         "github_use_tag_release_notes": true,
         "github_release_notes_file": "WHATS_NEW.txt",


### PR DESCRIPTION
Was looking around in the travis/bintray files and noticed this small typo, the issues url on the bintray page is fine so no idea what this affects (if anything)