### PR TITLE
Change newlines into html breaks (invoice template)

### DIFF
--- a/application/controllers/Sales.php
+++ b/application/controllers/Sales.php
@@ -520,7 +520,7 @@ class Sales extends Secure_Controller
 		$employee_info = $this->Employee->get_info($employee_id);
 		$data['employee'] = $employee_info->first_name . ' ' . mb_substr($employee_info->last_name, 0, 1);
 
-		$data['company_info'] = implode("<br/>", array(
+		$data['company_info'] = implode("\n", array(
 			$this->config->item('address'),
 			$this->config->item('phone')
 		));
@@ -888,7 +888,7 @@ class Sales extends Secure_Controller
 			$data['customer_address'] = $customer_info->address_1;
 			if(!empty($customer_info->zip) || !empty($customer_info->city))
 			{
-				$data['customer_location'] = $customer_info->zip . ' ' . $customer_info->city . ', ' . $customer_info->state;
+				$data['customer_location'] = $customer_info->zip . ' ' . $customer_info->city . "\n" . $customer_info->state;
 			}
 			else
 			{
@@ -913,11 +913,12 @@ class Sales extends Secure_Controller
 				$data['customer_total'] = empty($cust_stats) ? 0 : $cust_stats->total;
 			}
 
-			$data['customer_info'] = implode("<br/>", array(
+			$data['customer_info'] = implode("\n", array(
 				$data['customer'],
 				$data['customer_address'],
 				$data['customer_location']
 			));
+
 			if($data['customer_account_number'])
 			{
 				$data['customer_info'] .= "\n" . $this->lang->line('sales_account_number') . ": " . $data['customer_account_number'];
@@ -988,7 +989,7 @@ class Sales extends Secure_Controller
 		$data['quote_number'] = $sale_info['quote_number'];
 		$data['sale_status'] = $sale_info['sale_status'];
 
-		$data['company_info'] = implode("<br/>", array(
+		$data['company_info'] = implode("\n", array(
 			$this->config->item('address'),
 			$this->config->item('phone')
 		));

--- a/application/views/sales/invoice.php
+++ b/application/views/sales/invoice.php
@@ -51,7 +51,7 @@ $(document).ready(function()
 			if(isset($customer))
 			{
 			?>
-				<div id="customer"><?php echo $customer_info ?></div>
+				<div id="customer"><?php echo nl2br($customer_info) ?></div>
 			<?php
 			}
 			?>
@@ -79,7 +79,7 @@ $(document).ready(function()
 	</div>
 
 	<div id="block2">
-		<div id="company-title"><?php echo $company_info ?></div>
+		<div id="company-title"><?php echo nl2br($company_info) ?></div>
 		<table id="meta">
 			<tr>
 				<td class="meta-head"><?php echo $this->lang->line('sales_invoice_number');?> </td>

--- a/application/views/sales/invoice_email.php
+++ b/application/views/sales/invoice_email.php
@@ -28,14 +28,14 @@
 				?>
 			</td>
 			<td id="customer-title">
-				<div id="customer"><?php if(isset($customer)) { echo $customer_info; } ?></div>
+				<div id="customer"><?php if(isset($customer)) { echo nl2br($customer_info); } ?></div>
 			</td>
 		</tr>
 		<tr>
 			<td id="company-title">
 				<div id="company">
 				<?php echo $this->config->item('company'); ?><br/>
-				<?php echo $company_info; ?>
+				<?php echo nl2br($company_info); ?>
 				</div>
 			</td>
 			<td id="meta">
@@ -139,8 +139,8 @@
 	<div id="terms">
 		<div id="sale_return_policy">
 			<h5>
-				<textarea rows="5" cols="6"><?php echo nl2br($this->config->item('payment_message')); ?></textarea>
-				<textarea rows="5" cols="6"><?php echo $this->lang->line('sales_comments') . ': ' . (empty($comments) ? $this->config->item('invoice_default_comments') : $comments); ?></textarea>
+				<div><?php echo nl2br($this->config->item('payment_message')); ?></div>
+				<div><?php echo $this->lang->line('sales_comments') . ': ' . (empty($comments) ? $this->config->item('invoice_default_comments') : $comments); ?></div>
 			</h5>
 			<?php echo nl2br($this->config->item('return_policy')); ?>
 		</div>


### PR DESCRIPTION
Some minor changes to the invoice template

* Found that some templates still use textarea for their variables. This doesn't look very nice in a generated PDF and so I removed the last remniscants in the sale invoice email template.
* Some of them use the `pre` tag which I think means the rendered contents does not need any html markup for line breaks. This also holds for most email templates (work order, quote, etc)
* Some of them use a regular div. In this case I think the contents should be rendered using `nl2br`