### PR TITLE
fix empty reports

### DIFF
--- a/application/migrations/20190712150200_fix_empty_reports.php
+++ b/application/migrations/20190712150200_fix_empty_reports.php
@@ -1,0 +1,30 @@
+<?php if (!defined('BASEPATH')) exit('No direct script access allowed');
+
+class Migration_fix_empty_reports extends CI_Migration
+{
+	public function __construct()
+	{
+		parent::__construct();
+	}
+
+	public function up()
+	{
+		$this->db->select('location_name');
+		$this->db->from('stock_locations');
+		$this->db->where('location_id', 1);
+		$this->db->limit(1);
+		$location_name = $this->db->get()->result_array()[0]['location_name'];
+
+		$location_name = str_replace(' ', '_', $location_name);
+		$this->db->set('location_id',1);
+		$this->db->where('permission_id','receivings_' . $location_name);
+		$this->db->or_where('permission_id', 'sales_' . $location_name);
+		$this->db->update('permissions');
+	}
+
+	public function down()
+	{
+
+	}
+}
+?>

--- a/application/views/reports/date_input.php
+++ b/application/views/reports/date_input.php
@@ -70,7 +70,7 @@ if(isset($error))
 	?>
 
 	<?php	
-	if (!empty($stock_locations) && count($stock_locations) > 1)
+	if (!empty($stock_locations) && count($stock_locations) > 2)
 	{
 	?>
 		<div class="form-group form-group-sm">


### PR DESCRIPTION
This corrects an error in a previous migration (2.3_to_2.3.1.sql) that assigned a null value to receivings_stock and sales_stock for the location_id when it should have been the location_id of that particular stock_location.