### PR TITLE
Remove the redundancy of cart resequencing for POS receipts.

### DIFF
--- a/application/controllers/Sales.php
+++ b/application/controllers/Sales.php
@@ -802,10 +802,6 @@ class Sales extends Secure_Controller
 			else
 			{
 				$data['barcode'] = $this->barcode_lib->generate_receipt_barcode($data['sale_id']);
-
-				// Reload (sorted) and filter the cart line items for printing purposes
-				$data['cart'] = $this->get_filtered($this->sale_lib->get_cart_reordered($data['sale_id_num']));
-
 				$this->load->view('sales/receipt', $data);
 				$this->sale_lib->clear_all();
 			}

--- a/application/libraries/Sale_lib.php
+++ b/application/libraries/Sale_lib.php
@@ -1046,17 +1046,6 @@ class Sale_lib
 		return $this->CI->session->userdata('sale_id');
 	}
 
-	public function get_cart_reordered($sale_id)
-	{
-		$this->empty_cart();
-		foreach($this->CI->Sale->get_sale_items_ordered($sale_id)->result() as $row)
-		{
-			$this->add_item($row->item_id, $row->quantity_purchased, $row->item_location, $row->discount, $row->discount_type, PRICE_MODE_STANDARD, NULL, NULL, $row->item_unit_price, $row->description, $row->serialnumber, $sale_id, TRUE, $row->print_option);
-		}
-
-		return $this->CI->session->userdata('sales_cart');
-	}
-
 	public function clear_all()
 	{
 		$this->CI->session->set_userdata('sale_id', -1);


### PR DESCRIPTION
When I made my first changes to OSPOS I was hesitant to touch anything other than what I absolutely knew I had to change.  So when I reworked the cart resorting and filtering logic that takes place prior to the actual printing of the invoice in order to avoid re-retrieving from the database at the last second I could not bring myself to delete what was taking place for POS receipts.

This pull request will finally remove that line of code and thus improve the performance a bit (probably not noticeable but it's the right thing to do in order to keep the code clean).

It would be nice to have this included in the 3.3.0 release.  It should be low risk since this is already being done for invoices, quotes, and work orders.