### PR TITLE
WIP: part1 fix bug #2452 in right way due there's no need of

### DIFF
--- a/application/controllers/Items.php
+++ b/application/controllers/Items.php
@@ -612,20 +612,20 @@ class Items extends Secure_Controller
 
 			if($success && $upload_success)
 			{
-				$message = $this->xss_clean($this->lang->line('items_successful_' . ($new_item ? 'adding' : 'updating')) . ' ' . $item_data['name']);
+				$message = $this->lang->line('items_successful_' . ($new_item ? 'adding' : 'updating') . ' ' . strip_tags($item_data['name']) );
 
 				echo json_encode(array('success' => TRUE, 'message' => $message, 'id' => $item_id));
 			}
 			else
 			{
-				$message = $this->xss_clean($upload_success ? $this->lang->line('items_error_adding_updating') . ' ' . $item_data['name'] : strip_tags($this->upload->display_errors()));
+				$message = $upload_success ? $this->lang->line('items_error_adding_updating') . ' ' . strip_tags($item_data['name']) : strip_tags($this->upload->display_errors());
 
 				echo json_encode(array('success' => FALSE, 'message' => $message, 'id' => $item_id));
 			}
 		}
 		else // failure
 		{
-			$message = $this->xss_clean($this->lang->line('items_error_adding_updating') . ' ' . $item_data['name']);
+			$message = $this->lang->line('items_error_adding_updating') . ' ' . strip_tags($item_data['name']);
 
 			echo json_encode(array('success' => FALSE, 'message' => $message, 'id' => -1));
 		}


### PR DESCRIPTION
The issue is that in the lines around 610 the response coded in json occurs if the information was saved or failed, this is an output a response to the user, the only data that comes from "outside" is the input of the description (and that prevously was cleaned from xss) .. is the only place where the xss code would come, so the first thing I see is that it is not necessary to treat the entire character string of the message but only that of the name of the item, the second is that instead of applying the xss simply removed the html characters .i'll explain my arguments why are secure and allowed:

**Think about it .. @jekkos , @objecttothis and @daN4cat :  the xss filtering was already applied before saving in the database, the data that comes in the name would be cracked only by the technique of "man in the middle" or similar .. so therefore I just have to protect of possible html codes since sql will not occur (if I click again on edit item this will bring the info of the db .. not the interface)** of course.. so much "bla bla bla" for something obvius: unnecessary code, this pull will property fixed the #2452 

1. we already know that this can allow some form of xss? *not at all*, i'll use only in the "name" of the resulting problem.. not in all the message that comes from the lang file.. the lang file are internally.. to property crack the attacker must be inside of the opensourcepos installation so this are nonsense, if are inside there's no salvation..
2. so then i applied only a `strip_tags($item_data['name'])` in the messsage and remove the xss cleaning.. (due the reason previously explained there's no sense) that's all, solution recommended in the issue are nonsense,, due response from opensourcepos team are "set to false the xss clean" let ALL the opensourcepos system without protection.. 
3. due the line are just a message of response.. the only xss posibilities are just html codes.. so this hack can be improved with a config flag (permit not allowed chars in the items descriptions), i can later after disscuss that commit more changes to peermit that...