### PR TITLE
Fix barcode import (#2515)

### DIFF
--- a/application/helpers/importfile_helper.php
+++ b/application/helpers/importfile_helper.php
@@ -62,9 +62,6 @@ function get_csv_file($file_name)
 	
 	if(($csv_file = fopen($file_name,'r')) !== FALSE)
 	{
-		//Skip Byte-Order Mark
-		fseek($csv_file, 3);
-		
 		while (($data = fgetcsv($csv_file)) !== FALSE)
 		{
 			$line_array[] = $data;


### PR DESCRIPTION
Fix for the barcode import issue. For some reason first three characters are skipped, and that's why we fail to match the column header (it sees 'code' instead of 'Barcode').

@daN4cat any idea why the byte order marker snippet was added? Is it ok to remove or should it be kept in a specific case?