### PR TITLE
Clear initial default for Cascade and Seq for Tax Config Tables

### DIFF
--- a/application/models/Tax_category.php
+++ b/application/models/Tax_category.php
@@ -235,8 +235,8 @@ class Tax_category extends CI_Model
 		return array('0' => array(
 			'tax_category_id' => -1,
 			'tax_category' => '',
-			'tax_group_sequence' => 0,
-			'deleted' => 0));
+			'tax_group_sequence' => '',
+			'deleted' => ''));
 	}
 
 }

--- a/application/models/Tax_jurisdiction.php
+++ b/application/models/Tax_jurisdiction.php
@@ -219,9 +219,9 @@ class Tax_jurisdiction extends CI_Model
 			'tax_group' => '',
 			'tax_type' => '1',
 			'reporting_authority' => '',
-			'tax_group_sequence' => 0,
-			'cascade_sequence' => 0,
-			'deleted' => 0));
+			'tax_group_sequence' => '',
+			'cascade_sequence' => '',
+			'deleted' => ''));
 	}
 
 }


### PR DESCRIPTION
Clear initial defaults for Cascade and Seq fields for Tax Jurisdiction and Tax Category.

This resolves an issue reported in #2566