### PR TITLE
Event generator (obsolete with CI4 Events)

### DIFF
--- a/application/controllers/Customers.php
+++ b/application/controllers/Customers.php
@@ -11,7 +11,9 @@ class Customers extends Persons
 		parent::__construct('customers');
 
 		$this->load->library('mailchimp_lib');
-
+		$this->load->library('events');
+		$this->load->event('integrations');
+		
 		$CI =& get_instance();
 
 		$this->_list_id = $CI->encryption->decrypt($CI->Appconfig->get('mailchimp_list_id'));
@@ -269,24 +271,33 @@ class Customers extends Persons
 
 		if($this->Customer->save_customer($person_data, $customer_data, $customer_id))
 		{
-			// save customer to Mailchimp selected list
+		//Save customer to Mailchimp selected list
 			$this->mailchimp_lib->addOrUpdateMember($this->_list_id, $email, $first_name, $last_name, $this->input->post('mailchimp_status'), array('vip' => $this->input->post('mailchimp_vip') != NULL));
 
-			// New customer
+		// New customer
 			if($customer_id == -1)
 			{
 				echo json_encode(array('success' => TRUE,
 								'message' => $this->lang->line('customers_successful_adding') . ' ' . $first_name . ' ' . $last_name,
 								'id' => $this->xss_clean($customer_data['person_id'])));
+				$event_failures = Events::Trigger('event_create', array("type"=> "CUSTOMERS", "data" => $customer_data), 'string');
 			}
-			else // Existing customer
+		//Existing customer
+			else
 			{
 				echo json_encode(array('success' => TRUE,
 								'message' => $this->lang->line('customers_successful_updating') . ' ' . $first_name . ' ' . $last_name,
 								'id' => $customer_id));
+				$event_failures = Events::Trigger('event_update', array("type"=> "CUSTOMERS", "data" => $customer_data), 'string');
+			}
+			
+			if($event_failures)
+			{
+			    log_message("ERROR","Third-Party Integration failed during Customer create or update: $event_failures");
 			}
 		}
-		else // Failure
+	//Failure
+		else
 		{
 			echo json_encode(array('success' => FALSE,
 							'message' => $this->lang->line('customers_error_adding_updating') . ' ' . $first_name . ' ' . $last_name,
@@ -328,13 +339,21 @@ class Customers extends Persons
 		{
 			if($this->Customer->delete($info->person_id))
 			{
-				// remove customer from Mailchimp selected list
+			//Remove customer from Mailchimp selected list
 				$this->mailchimp_lib->removeMember($this->_list_id, $info->email);
 
+			//Event triggers for Third-Party Integrations
+				$event_failures = Events::Trigger('event_delete', array("type"=> "CUSTOMERS", "data" => $customers_to_delete), 'string');
+				
 				$count++;
 			}
 		}
-
+		
+		if($event_failures)
+		{
+		    log_message("ERROR","Third-Party Integration failed during Customer delete: $event_failures");
+		}
+		
 		if($count == count($customers_to_delete))
 		{
 			echo json_encode(array('success' => TRUE,

--- a/application/controllers/Customers.php
+++ b/application/controllers/Customers.php
@@ -280,7 +280,7 @@ class Customers extends Persons
 				echo json_encode(array('success' => TRUE,
 								'message' => $this->lang->line('customers_successful_adding') . ' ' . $first_name . ' ' . $last_name,
 								'id' => $this->xss_clean($customer_data['person_id'])));
-				$event_failures = Events::Trigger('event_create', array("type"=> "CUSTOMERS", "data" => $customer_data), 'string');
+				Events::Trigger('event_create', array("type"=> "CUSTOMERS", "data" => $customer_data), 'string');
 			}
 		//Existing customer
 			else
@@ -288,12 +288,7 @@ class Customers extends Persons
 				echo json_encode(array('success' => TRUE,
 								'message' => $this->lang->line('customers_successful_updating') . ' ' . $first_name . ' ' . $last_name,
 								'id' => $customer_id));
-				$event_failures = Events::Trigger('event_update', array("type"=> "CUSTOMERS", "data" => $customer_data), 'string');
-			}
-			
-			if($event_failures)
-			{
-			    log_message("ERROR","Third-Party Integration failed during Customer create or update: $event_failures");
+				Events::Trigger('event_update', array("type"=> "CUSTOMERS", "data" => $customer_data), 'string');
 			}
 		}
 	//Failure
@@ -343,17 +338,12 @@ class Customers extends Persons
 				$this->mailchimp_lib->removeMember($this->_list_id, $info->email);
 
 			//Event triggers for Third-Party Integrations
-				$event_failures = Events::Trigger('event_delete', array("type"=> "CUSTOMERS", "data" => $customers_to_delete), 'string');
+				Events::Trigger('event_delete', array("type"=> "CUSTOMERS", "data" => $customers_to_delete), 'string');
 				
 				$count++;
 			}
 		}
-		
-		if($event_failures)
-		{
-		    log_message("ERROR","Third-Party Integration failed during Customer delete: $event_failures");
-		}
-		
+
 		if($count == count($customers_to_delete))
 		{
 			echo json_encode(array('success' => TRUE,

--- a/application/controllers/Giftcards.php
+++ b/application/controllers/Giftcards.php
@@ -7,6 +7,9 @@ class Giftcards extends Secure_Controller
 	public function __construct()
 	{
 		parent::__construct('giftcards');
+
+		$this->load->library('events');
+		$this->load->event('integrations');
 	}
 
 	public function index()
@@ -110,16 +113,25 @@ class Giftcards extends Secure_Controller
 			//New giftcard
 			if($giftcard_id == -1)
 			{
-				echo json_encode(array('success' => TRUE, 'message' => $this->lang->line('giftcards_successful_adding') . ' ' .
-								$giftcard_data['giftcard_number'], 'id' => $giftcard_data['giftcard_id']));
+			    echo json_encode(array('success' => TRUE, 'message' => $this->lang->line('giftcards_successful_adding') . ' ' .
+			        $giftcard_data['giftcard_number'], 'id' => $giftcard_data['giftcard_id']));
+			    $event_failures = Events::Trigger('event_create', array("type"=> "GIFTCARDS", "data" => $giftcard_data), 'string');
 			}
-			else //Existing giftcard
+			//Existing giftcard
+			else
 			{
-				echo json_encode(array('success' => TRUE, 'message' => $this->lang->line('giftcards_successful_updating') . ' ' .
-								$giftcard_data['giftcard_number'], 'id' => $giftcard_id));
+			    echo json_encode(array('success' => TRUE, 'message' => $this->lang->line('giftcards_successful_updating') . ' ' .
+			        $giftcard_data['giftcard_number'], 'id' => $giftcard_id));
+			    $event_failures = Events::Trigger('event_update', array("type"=> "GIFTCARDS", "data" => $giftcard_data), 'string');
+			}
+			
+			if($event_failures)
+			{
+			    log_message("ERROR","Third-Party Integration failed during CSV Import: $event_failures");
 			}
 		}
-		else //failure
+	//failure
+		else
 		{
 			$giftcard_data = $this->xss_clean($giftcard_data);
 			
@@ -142,6 +154,13 @@ class Giftcards extends Secure_Controller
 		{
 			echo json_encode(array('success' => TRUE, 'message' => $this->lang->line('giftcards_successful_deleted') . ' ' .
 							count($giftcards_to_delete).' '.$this->lang->line('giftcards_one_or_multiple')));
+			
+			$event_failures = Events::Trigger('event_delete', array("type"=> "GIFTCARDS", "data" => $giftcards_to_delete), 'string');
+			
+			if($event_failures)
+			{
+			    log_message("ERROR","Third-Party Integration failed during giftcard(s) delete: $event_failures");
+			}
 		}
 		else
 		{

--- a/application/controllers/Giftcards.php
+++ b/application/controllers/Giftcards.php
@@ -113,21 +113,16 @@ class Giftcards extends Secure_Controller
 			//New giftcard
 			if($giftcard_id == -1)
 			{
-			    echo json_encode(array('success' => TRUE, 'message' => $this->lang->line('giftcards_successful_adding') . ' ' .
-			        $giftcard_data['giftcard_number'], 'id' => $giftcard_data['giftcard_id']));
-			    $event_failures = Events::Trigger('event_create', array("type"=> "GIFTCARDS", "data" => $giftcard_data), 'string');
+				echo json_encode(array('success' => TRUE, 'message' => $this->lang->line('giftcards_successful_adding') . ' ' .
+					$giftcard_data['giftcard_number'], 'id' => $giftcard_data['giftcard_id']));
+				Events::Trigger('event_create', array("type"=> "GIFTCARDS", "data" => $giftcard_data), 'string');
 			}
 			//Existing giftcard
 			else
 			{
-			    echo json_encode(array('success' => TRUE, 'message' => $this->lang->line('giftcards_successful_updating') . ' ' .
-			        $giftcard_data['giftcard_number'], 'id' => $giftcard_id));
-			    $event_failures = Events::Trigger('event_update', array("type"=> "GIFTCARDS", "data" => $giftcard_data), 'string');
-			}
-			
-			if($event_failures)
-			{
-			    log_message("ERROR","Third-Party Integration failed during CSV Import: $event_failures");
+				echo json_encode(array('success' => TRUE, 'message' => $this->lang->line('giftcards_successful_updating') . ' ' .
+					$giftcard_data['giftcard_number'], 'id' => $giftcard_id));
+				Events::Trigger('event_update', array("type"=> "GIFTCARDS", "data" => $giftcard_data), 'string');
 			}
 		}
 	//failure
@@ -155,12 +150,7 @@ class Giftcards extends Secure_Controller
 			echo json_encode(array('success' => TRUE, 'message' => $this->lang->line('giftcards_successful_deleted') . ' ' .
 							count($giftcards_to_delete).' '.$this->lang->line('giftcards_one_or_multiple')));
 			
-			$event_failures = Events::Trigger('event_delete', array("type"=> "GIFTCARDS", "data" => $giftcards_to_delete), 'string');
-			
-			if($event_failures)
-			{
-			    log_message("ERROR","Third-Party Integration failed during giftcard(s) delete: $event_failures");
-			}
+			Events::Trigger('event_delete', array("type"=> "GIFTCARDS", "data" => $giftcards_to_delete), 'string');
 		}
 		else
 		{

--- a/application/controllers/Item_kits.php
+++ b/application/controllers/Item_kits.php
@@ -177,19 +177,14 @@ class Item_kits extends Secure_Controller
 			{
 				echo json_encode(array('success' => $success,
 					'message' => $this->lang->line('item_kits_successful_adding').' '.$item_kit_data['name'], 'id' => $item_kit_id));
-				$event_failures = Events::Trigger('event_create', array("type"=> "ITEM_KITS", "data" => $item_kit_data), 'string');
+				Events::Trigger('event_create', array("type"=> "ITEM_KITS", "data" => $item_kit_data), 'string');
 
 			}
 			else
 			{
 				echo json_encode(array('success' => $success,
 					'message' => $this->lang->line('item_kits_successful_updating').' '.$item_kit_data['name'], 'id' => $item_kit_id));
-				$event_failures = Events::Trigger('event_update', array("type"=> "ITEM_KITS", "data" => $item_kit_data), 'string');
-			}
-
-			if($event_failures)
-			{
-			    log_message("ERROR","Third-Party Integration failed during create or import: $event_failures");
+				Events::Trigger('event_update', array("type"=> "ITEM_KITS", "data" => $item_kit_data), 'string');
 			}
 		}
 		else//failure
@@ -211,12 +206,7 @@ class Item_kits extends Secure_Controller
 								'message' => $this->lang->line('item_kits_successful_deleted').' '.count($item_kits_to_delete).' '.$this->lang->line('item_kits_one_or_multiple')));
 
 		//Event triggers for Third-Party Integrations
-			$event_failures = Events::Trigger('event_delete', array("type"=> "ITEM_KITS", "data" => $item_kits_to_delete), 'string');
-			
-			if($event_failures)
-			{
-			    log_message("ERROR","Third-Party Integration failed during Item Kit delete: $event_failures");
-			}
+			Events::Trigger('event_delete', array("type"=> "ITEM_KITS", "data" => $item_kits_to_delete), 'string');
 		}
 		else
 		{

--- a/application/controllers/Items.php
+++ b/application/controllers/Items.php
@@ -7,19 +7,21 @@ class Items extends Secure_Controller
 	public function __construct()
 	{
 		parent::__construct('items');
-
+		
 		$this->load->library('item_lib');
+		$this->load->library('events');
+		$this->load->event('integrations');
 	}
-
+	
 	public function index()
 	{
 		$this->session->set_userdata('allow_temp_items', 0);
-
+		
 		$data['table_headers'] = $this->xss_clean(get_items_manage_table_headers());
-
+		
 		$data['stock_location'] = $this->xss_clean($this->item_lib->get_item_location());
 		$data['stock_locations'] = $this->xss_clean($this->Stock_location->get_allowed_locations());
-
+		
 		// filters that will be loaded in the multiselect dropdown
 		$data['filters'] = array('empty_upc' => $this->lang->line('items_empty_upc_items'),
 			'low_inventory' => $this->lang->line('items_low_inventory_items'),
@@ -28,10 +30,10 @@ class Items extends Secure_Controller
 			'search_custom' => $this->lang->line('items_search_attributes'),
 			'is_deleted' => $this->lang->line('items_is_deleted'),
 			'temporary' => $this->lang->line('items_temp'));
-
+		
 		$this->load->view('items/manage', $data);
 	}
-
+	
 	/*
 	 Returns Items table data rows. This will be called with AJAX.
 	 */
@@ -42,11 +44,11 @@ class Items extends Secure_Controller
 		$offset = $this->input->get('offset');
 		$sort = $this->input->get('sort');
 		$order = $this->input->get('order');
-
+		
 		$this->item_lib->set_item_location($this->input->get('stock_location'));
-
+		
 		$definition_names = $this->Attribute->get_definitions_by_flags(Attribute::SHOW_IN_ITEMS);
-
+		
 		$filters = array('start_date' => $this->input->get('start_date'),
 			'end_date' => $this->input->get('end_date'),
 			'stock_location_id' => $this->item_lib->get_item_location(),
@@ -58,15 +60,15 @@ class Items extends Secure_Controller
 			'is_deleted' => FALSE,
 			'temporary' => FALSE,
 			'definition_ids' => array_keys($definition_names));
-
+		
 		// check if any filter is set in the multiselect dropdown
 		$filledup = array_fill_keys($this->input->get('filters'), TRUE);
 		$filters = array_merge($filters, $filledup);
-
+		
 		$items = $this->Item->search($search, $filters, $limit, $offset, $sort, $order);
-
+		
 		$total_rows = $this->Item->get_found_rows($search, $filters);
-
+		
 		$data_rows = array();
 		foreach($items->result() as $item)
 		{
@@ -76,19 +78,19 @@ class Items extends Secure_Controller
 				$this->_update_pic_filename($item);
 			}
 		}
-
+		
 		echo json_encode(array('total' => $total_rows, 'rows' => $data_rows));
 	}
-
+	
 	public function pic_thumb($pic_filename)
 	{
 		$this->load->helper('file');
 		$this->load->library('image_lib');
-
+		
 		// in this context, $pic_filename always has .ext
 		$ext = pathinfo($pic_filename, PATHINFO_EXTENSION);
 		$images = glob('./uploads/item_pics/' . $pic_filename);
-
+		
 		// make sure we pick only the file name, without extension
 		$base_path = './uploads/item_pics/' . pathinfo($pic_filename, PATHINFO_FILENAME);
 		if(sizeof($images) > 0)
@@ -111,7 +113,7 @@ class Items extends Secure_Controller
 			$this->output->set_output(file_get_contents($thumb_path));
 		}
 	}
-
+	
 	/*
 	 Gives search suggestions based on what is being searched for
 	 */
@@ -119,75 +121,75 @@ class Items extends Secure_Controller
 	{
 		$suggestions = $this->xss_clean($this->Item->get_search_suggestions($this->input->post_get('term'),
 			array('search_custom' => $this->input->post('search_custom'), 'is_deleted' => $this->input->post('is_deleted') != NULL), FALSE));
-
+		
 		echo json_encode($suggestions);
 	}
-
+	
 	public function suggest()
 	{
 		$suggestions = $this->xss_clean($this->Item->get_search_suggestions($this->input->post_get('term'),
 			array('search_custom' => FALSE, 'is_deleted' => FALSE), TRUE));
-
+		
 		echo json_encode($suggestions);
 	}
-
-
+	
+	
 	public function suggest_low_sell()
 	{
 		$suggestions = $this->xss_clean($this->Item->get_low_sell_suggestions($this->input->post_get('name')));
-
+		
 		echo json_encode($suggestions);
 	}
-
-
+	
+	
 	public function suggest_kits()
 	{
 		$suggestions = $this->xss_clean($this->Item->get_kit_search_suggestions($this->input->post_get('term'),
 			array('search_custom' => FALSE, 'is_deleted' => FALSE), TRUE));
-
+		
 		echo json_encode($suggestions);
 	}
-
+	
 	/*
 	 Gives search suggestions based on what is being searched for
 	 */
 	public function suggest_category()
 	{
 		$suggestions = $this->xss_clean($this->Item->get_category_suggestions($this->input->get('term')));
-
+		
 		echo json_encode($suggestions);
 	}
-
+	
 	/*
 	 Gives search suggestions based on what is being searched for
 	 */
 	public function suggest_location()
 	{
 		$suggestions = $this->xss_clean($this->Item->get_location_suggestions($this->input->get('term')));
-
+		
 		echo json_encode($suggestions);
 	}
-
+	
 	public function get_row($item_ids)
 	{
 		$item_infos = $this->Item->get_multiple_info(explode(":", $item_ids), $this->item_lib->get_item_location());
-
+		
 		$result = array();
 		foreach($item_infos->result() as $item_info)
 		{
 			$result[$item_info->item_id] = $this->xss_clean(get_item_data_row($item_info));
 		}
-
+		
 		echo json_encode($result);
 	}
-
+	
 	public function view($item_id = -1)
 	{
 		if($item_id == -1)
 		{
 			$data = array();
 		}
-
+		
 		// allow_temp_items is set in the index function of items.php or sales.php
 		$data['allow_temp_item'] = $this->session->userdata('allow_temp_items');
 		$data['item_tax_info'] = $this->xss_clean($this->Item_taxes->get_info($item_id));
@@ -196,19 +198,19 @@ class Items extends Secure_Controller
 		$data['item_kit_disabled'] = !$this->Employee->has_grant('item_kits', $this->Employee->get_logged_in_employee_info()->person_id);
 		$data['definition_values'] = $this->Attribute->get_attributes_by_item($item_id);
 		$data['definition_names'] = $this->Attribute->get_definition_names();
-
+		
 		foreach($data['definition_values'] as $definition_id => $definition)
 		{
 			unset($data['definition_names'][$definition_id]);
 		}
-
+		
 		$item_info = $this->Item->get_info($item_id);
-
+		
 		foreach(get_object_vars($item_info) as $property => $value)
 		{
 			$item_info->$property = $this->xss_clean($value);
 		}
-
+		
 		if($data['allow_temp_item'] == 1)
 		{
 			if($item_id != -1)
@@ -226,15 +228,15 @@ class Items extends Secure_Controller
 				$data['allow_temp_item'] = 1;
 			}
 		}
-
+		
 		$use_destination_based_tax = (boolean)$this->config->item('use_destination_based_tax');
 		$data['include_hsn'] = $this->config->item('include_hsn') == '1';
-
+		
 		if($item_id == -1)
 		{
 			$data['default_tax_1_rate'] = $this->config->item('default_tax_1_rate');
 			$data['default_tax_2_rate'] = $this->config->item('default_tax_2_rate');
-
+			
 			$item_info->receiving_quantity = 1;
 			$item_info->reorder_level = 1;
 			$item_info->item_type = ITEM; // standard
@@ -255,7 +257,7 @@ class Items extends Secure_Controller
 										&& !($this->config->item('derive_sale_quantity') == '1'));
 
 		$data['item_info'] = $item_info;
-
+		
 		$suppliers = array('' => $this->lang->line('items_none'));
 		foreach($this->Supplier->get_all()->result_array() as $row)
 		{
@@ -263,7 +265,7 @@ class Items extends Secure_Controller
 		}
 		$data['suppliers'] = $suppliers;
 		$data['selected_supplier'] = $item_info->supplier_id;
-
+		
 		if($data['include_hsn'])
 		{
 			$data['hsn_code'] = $item_info->hsn_code;
@@ -272,7 +274,7 @@ class Items extends Secure_Controller
 		{
 			$data['hsn_code'] = '';
 		}
-
+		
 		if($use_destination_based_tax)
 		{
 			$data['use_destination_based_tax'] = TRUE;
@@ -297,7 +299,7 @@ class Items extends Secure_Controller
 			$data['tax_categories'] = array();
 			$data['tax_category'] = '';
 		}
-
+		
 		$data['logo_exists'] = $item_info->pic_filename != '';
 		$ext = pathinfo($item_info->pic_filename, PATHINFO_EXTENSION);
 		if($ext == '')
@@ -315,15 +317,15 @@ class Items extends Secure_Controller
 		foreach($stock_locations as $location)
 		{
 			$location = $this->xss_clean($location);
-
+			
 			$quantity = $this->xss_clean($this->Item_quantity->get_item_quantity($item_id, $location['location_id'])->quantity);
 			$quantity = ($item_id == -1) ? 0 : $quantity;
 			$location_array[$location['location_id']] = array('location_name' => $location['location_name'], 'quantity' => $quantity);
 			$data['stock_locations'] = $location_array;
 		}
-
+		
 		$data['selected_low_sell_item_id'] = $item_info->low_sell_item_id;
-
+		
 		if($item_id != -1 && $item_info->item_id != $item_info->low_sell_item_id)
 		{
 			$low_sell_item_info = $this->Item->get_info($item_info->low_sell_item_id);
@@ -333,10 +335,10 @@ class Items extends Secure_Controller
 		{
 			$data['selected_low_sell_item'] = '';
 		}
-
+		
 		$this->load->view('items/form', $data);
 	}
-
+	
 	public function inventory($item_id = -1)
 	{
 		$item_info = $this->Item->get_info($item_id);
@@ -345,21 +347,21 @@ class Items extends Secure_Controller
 			$item_info->$property = $this->xss_clean($value);
 		}
 		$data['item_info'] = $item_info;
-
+		
 		$data['stock_locations'] = array();
 		$stock_locations = $this->Stock_location->get_undeleted_all()->result_array();
 		foreach($stock_locations as $location)
 		{
 			$location = $this->xss_clean($location);
 			$quantity = $this->xss_clean($this->Item_quantity->get_item_quantity($item_id, $location['location_id'])->quantity);
-
+			
 			$data['stock_locations'][$location['location_id']] = $location['location_name'];
 			$data['item_quantities'][$location['location_id']] = $quantity;
 		}
-
+		
 		$this->load->view('items/form_inventory', $data);
 	}
-
+	
 	public function count_details($item_id = -1)
 	{
 		$item_info = $this->Item->get_info($item_id);
@@ -368,62 +370,62 @@ class Items extends Secure_Controller
 			$item_info->$property = $this->xss_clean($value);
 		}
 		$data['item_info'] = $item_info;
-
+		
 		$data['stock_locations'] = array();
 		$stock_locations = $this->Stock_location->get_undeleted_all()->result_array();
 		foreach($stock_locations as $location)
 		{
 			$location = $this->xss_clean($location);
 			$quantity = $this->xss_clean($this->Item_quantity->get_item_quantity($item_id, $location['location_id'])->quantity);
-
+			
 			$data['stock_locations'][$location['location_id']] = $location['location_name'];
 			$data['item_quantities'][$location['location_id']] = $quantity;
 		}
-
+		
 		$this->load->view('items/form_count_details', $data);
 	}
-
+	
 	public function generate_barcodes($item_ids)
 	{
 		$this->load->library('barcode_lib');
-
+		
 		$item_ids = explode(':', $item_ids);
 		$result = $this->Item->get_multiple_info($item_ids, $this->item_lib->get_item_location())->result_array();
 		$config = $this->barcode_lib->get_barcode_config();
-
+		
 		$data['barcode_config'] = $config;
-
+		
 		// check the list of items to see if any item_number field is empty
 		foreach($result as &$item)
 		{
 			$item = $this->xss_clean($item);
-
+			
 			// update the barcode field if empty / NULL with the newly generated barcode
 			if(empty($item['item_number']) && $this->config->item('barcode_generate_if_empty'))
 			{
 				// get the newly generated barcode
 				$barcode_instance = Barcode_lib::barcode_instance($item, $config);
 				$item['item_number'] = $barcode_instance->getData();
-
+				
 				$save_item = array('item_number' => $item['item_number']);
-
+				
 				// update the item in the database in order to save the barcode field
 				$this->Item->save($save_item, $item['item_id']);
 			}
 		}
 		$data['items'] = $result;
-
+		
 		// display barcodes
 		$this->load->view('barcodes/barcode_sheet', $data);
 	}
-
+	
 	public function attributes($item_id)
 	{
 		$data['item_id'] = $item_id;
 		$definition_ids = json_decode($this->input->post('definition_ids'), TRUE);
 		$data['definition_values'] = $this->Attribute->get_attributes_by_item($item_id) + $this->Attribute->get_values_by_definitions($definition_ids);
 		$data['definition_names'] = $this->Attribute->get_definition_names();
-
+		
 		foreach($data['definition_values'] as $definition_id => $definition_value)
 		{
 			$attribute_value = $this->Attribute->get_attribute_value($item_id, $definition_id);
@@ -432,32 +434,32 @@ class Items extends Secure_Controller
 			$values['attribute_id'] = $attribute_id;
 			$values['attribute_value'] = $attribute_value;
 			$values['selected_value'] = '';
-
+			
 			if ($definition_value['definition_type'] == DROPDOWN)
 			{
 				$values['values'] = $this->Attribute->get_definition_values($definition_id);
 				$link_value = $this->Attribute->get_link_value($item_id, $definition_id);
 				$values['selected_value'] = (empty($link_value)) ? '' : $link_value->attribute_id;
 			}
-
+			
 			if (!empty($definition_ids[$definition_id]))
 			{
 				$values['selected_value'] = $definition_ids[$definition_id];
 			}
-
+			
 			unset($data['definition_names'][$definition_id]);
 		}
-
+		
 		$this->load->view('attributes/item', $data);
 	}
-
+	
 	public function bulk_edit()
 	{
 		$suppliers = array('' => $this->lang->line('items_none'));
 		foreach($this->Supplier->get_all()->result_array() as $row)
 		{
 			$row = $this->xss_clean($row);
-
+			
 			$suppliers[$row['person_id']] = $row['company_name'];
 		}
 		$data['suppliers'] = $suppliers;
@@ -465,29 +467,29 @@ class Items extends Secure_Controller
 			'' => $this->lang->line('items_do_nothing'),
 			1  => $this->lang->line('items_change_all_to_allow_alt_desc'),
 			0  => $this->lang->line('items_change_all_to_not_allow_allow_desc'));
-
+		
 		$data['serialization_choices'] = array(
 			'' => $this->lang->line('items_do_nothing'),
 			1  => $this->lang->line('items_change_all_to_serialized'),
 			0  => $this->lang->line('items_change_all_to_unserialized'));
-
+		
 		$this->load->view('items/form_bulk', $data);
 	}
-
+	
 	public function save($item_id = -1)
 	{
 		$upload_success = $this->_handle_image_upload();
 		$upload_data = $this->upload->data();
-
+		
 		$receiving_quantity = parse_decimals($this->input->post('receiving_quantity'));
 		$item_type = $this->input->post('item_type') == NULL ? ITEM : $this->input->post('item_type');
-
+		
 		if($receiving_quantity == '0' && $item_type!= ITEM_TEMP)
 		{
 			$receiving_quantity = '1';
 		}
 		$default_pack_name = $this->lang->line('items_default_pack_name');
-
+		
 		//Save item data
 		$item_data = array(
 			'name' => $this->input->post('name'),
@@ -509,14 +511,14 @@ class Items extends Secure_Controller
 			'deleted' => $this->input->post('is_deleted') != NULL,
 			'hsn_code' => $this->input->post('hsn_code') == NULL ? '' : $this->input->post('hsn_code')
 		);
-
+		
 		if($item_data['item_type'] == ITEM_TEMP)
 		{
 			$item_data['stock_type'] = HAS_NO_STOCK;
 			$item_data['receiving_quantity'] = 0;
 			$item_data['reorder_level'] = 0;
 		}
-
+		
 		$x = $this->input->post('tax_category_id');
 		if(!isset($x))
 		{
@@ -526,7 +528,7 @@ class Items extends Secure_Controller
 		{
 			$item_data['tax_category_id'] = $this->input->post('tax_category_id') == '' ? NULL : $this->input->post('tax_category_id');
 		}
-
+		
 		if(!empty($upload_data['orig_name']))
 		{
 			// XSS file image sanity check
@@ -535,9 +537,9 @@ class Items extends Secure_Controller
 				$item_data['pic_filename'] = $upload_data['raw_name'];
 			}
 		}
-
+		
 		$employee_id = $this->Employee->get_logged_in_employee_info()->person_id;
-
+		
 		if($this->Item->save($item_data, $item_id))
 		{
 			$success = TRUE;
@@ -548,9 +550,9 @@ class Items extends Secure_Controller
 				$item_id = $item_data['item_id'];
 				$new_item = TRUE;
 			}
-
+			
 			$use_destination_based_tax = (boolean)$this->config->item('use_destination_based_tax');
-
+			
 			if(!$use_destination_based_tax)
 			{
 				$items_taxes_data = array();
@@ -567,7 +569,7 @@ class Items extends Secure_Controller
 				}
 				$success &= $this->Item_taxes->save($items_taxes_data, $item_id);
 			}
-
+			
 			//Save item quantity
 			$stock_locations = $this->Stock_location->get_undeleted_all()->result_array();
 			foreach($stock_locations as $location)
@@ -580,13 +582,13 @@ class Items extends Secure_Controller
 				$location_detail = array('item_id' => $item_id,
 					'location_id' => $location['location_id'],
 					'quantity' => $updated_quantity);
-
-
+				
+				
 				$item_quantity = $this->Item_quantity->get_item_quantity($item_id, $location['location_id']);
 				if($item_quantity->quantity != $updated_quantity || $new_item)
 				{
 					$success &= $this->Item_quantity->save($location_detail, $item_id, $location['location_id']);
-
+					
 					$inv_data = array(
 						'trans_date' => date('Y-m-d H:i:s'),
 						'trans_items' => $item_id,
@@ -595,11 +597,11 @@ class Items extends Secure_Controller
 						'trans_comment' => $this->lang->line('items_manually_editing_of_quantity'),
 						'trans_inventory' => $updated_quantity - $item_quantity->quantity
 					);
-
+					
 					$success &= $this->Inventory->insert($inv_data);
 				}
 			}
-
+			
 			// Save item attributes
 			$attribute_links = $this->input->post('attribute_links') != NULL ? $this->input->post('attribute_links') : array();
 			$attribute_ids = $this->input->post('attribute_ids');
@@ -613,34 +615,49 @@ class Items extends Secure_Controller
 				}
 				$this->Attribute->save_link($item_id, $definition_id, $attribute_id);
 			}
-
+			
 			if($success && $upload_success)
 			{
 				$message = $this->xss_clean($this->lang->line('items_successful_' . ($new_item ? 'adding' : 'updating')) . ' ' . $item_data['name']);
-
+				
 				echo json_encode(array('success' => TRUE, 'message' => $message, 'id' => $item_id));
+				
+			//Event triggers for Third-Party Integrations
+				if($new_item)
+				{
+					$event_failures &= Events::Trigger('event_create',$item_data,'string');
+				}
+				else
+				{
+					$event_failures &= Events::Trigger('event_update',$item_data,'string');
+				}
+				
+				if($event_failures)
+				{
+					log_message("ERROR","Third-Party Integration failed during item save: $event_failures");
+				}
 			}
 			else
 			{
 				$message = $this->xss_clean($upload_success ? $this->lang->line('items_error_adding_updating') . ' ' . $item_data['name'] : strip_tags($this->upload->display_errors()));
-
+				
 				echo json_encode(array('success' => FALSE, 'message' => $message, 'id' => $item_id));
 			}
 		}
 		else // failure
 		{
 			$message = $this->xss_clean($this->lang->line('items_error_adding_updating') . ' ' . $item_data['name']);
-
+			
 			echo json_encode(array('success' => FALSE, 'message' => $message, 'id' => -1));
 		}
 	}
-
+	
 	public function check_item_number()
 	{
 		$exists = $this->Item->item_number_exists($this->input->post('item_number'), $this->input->post('item_id'));
 		echo !$exists ? 'true' : 'false';
 	}
-
+	
 	/*
 	 If adding a new item check to see if an item kit with the same name as the item already exists.
 	 */
@@ -656,11 +673,11 @@ class Items extends Secure_Controller
 		}
 		echo !$exists ? 'true' : 'false';
 	}
-
+	
 	private function _handle_image_upload()
 	{
 		/* Let files be uploaded with their original name */
-
+		
 		// load upload library
 		$config = array('upload_path' => './uploads/item_pics/',
 			'allowed_types' => 'gif|jpg|png',
@@ -670,18 +687,18 @@ class Items extends Secure_Controller
 		);
 		$this->load->library('upload', $config);
 		$this->upload->do_upload('item_image');
-
+		
 		return strlen($this->upload->display_errors()) == 0 || !strcmp($this->upload->display_errors(), '<p>'.$this->lang->line('upload_no_file_selected').'</p>');
 	}
-
+	
 	public function remove_logo($item_id)
 	{
 		$item_data = array('pic_filename' => NULL);
 		$result = $this->Item->save($item_data, $item_id);
-
+		
 		echo json_encode(array('success' => $result));
 	}
-
+	
 	public function save_inventory($item_id = -1)
 	{
 		$employee_id = $this->Employee->get_logged_in_employee_info()->person_id;
@@ -695,9 +712,9 @@ class Items extends Secure_Controller
 			'trans_comment' => $this->input->post('trans_comment'),
 			'trans_inventory' => parse_decimals($this->input->post('newquantity'))
 		);
-
+		
 		$this->Inventory->insert($inv_data);
-
+		
 		//Update stock quantity
 		$item_quantity = $this->Item_quantity->get_item_quantity($item_id, $location_id);
 		$item_quantity_data = array(
@@ -705,26 +722,26 @@ class Items extends Secure_Controller
 			'location_id' => $location_id,
 			'quantity' => $item_quantity->quantity + parse_decimals($this->input->post('newquantity'))
 		);
-
+		
 		if($this->Item_quantity->save($item_quantity_data, $item_id, $location_id))
 		{
 			$message = $this->xss_clean($this->lang->line('items_successful_updating') . ' ' . $cur_item_info->name);
-
+			
 			echo json_encode(array('success' => TRUE, 'message' => $message, 'id' => $item_id));
 		}
 		else//failure
 		{
 			$message = $this->xss_clean($this->lang->line('items_error_adding_updating') . ' ' . $cur_item_info->name);
-
+			
 			echo json_encode(array('success' => FALSE, 'message' => $message, 'id' => -1));
 		}
 	}
-
+	
 	public function bulk_update()
 	{
 		$items_to_update = $this->input->post('item_ids');
 		$item_data = array();
-
+		
 		foreach($_POST as $key => $value)
 		{
 			//This field is nullable, so treat it differently
@@ -737,7 +754,7 @@ class Items extends Secure_Controller
 				$item_data["$key"] = $value;
 			}
 		}
-
+		
 		//Item data could be empty if tax information is being updated
 		if(empty($item_data) || $this->Item->update_multiple($item_data, $items_to_update))
 		{
@@ -751,16 +768,16 @@ class Items extends Secure_Controller
 				if(!empty($tax_names[$k]) && is_numeric($tax_percents[$k]))
 				{
 					$tax_updated = TRUE;
-
+					
 					$items_taxes_data[] = array('name' => $tax_names[$k], 'percent' => $tax_percents[$k]);
 				}
 			}
-
+			
 			if($tax_updated)
 			{
 				$this->Item_taxes->save_multiple($items_taxes_data, $items_to_update);
 			}
-
+			
 			echo json_encode(array('success' => TRUE, 'message' => $this->lang->line('items_successful_bulk_edit'), 'id' => $this->xss_clean($items_to_update)));
 		}
 		else
@@ -768,22 +785,30 @@ class Items extends Secure_Controller
 			echo json_encode(array('success' => FALSE, 'message' => $this->lang->line('items_error_updating_multiple')));
 		}
 	}
-
+	
 	public function delete()
 	{
 		$items_to_delete = $this->input->post('ids');
-
+		
 		if($this->Item->delete_list($items_to_delete))
 		{
 			$message = $this->lang->line('items_successful_deleted') . ' ' . count($items_to_delete) . ' ' . $this->lang->line('items_one_or_multiple');
 			echo json_encode(array('success' => TRUE, 'message' => $message));
+			
+			//Event triggers for Third-Party Integrations
+			$event_failures &= Events::Trigger('event_delete',$items_to_delete,'string');
+			
+			if($event_failures)
+			{
+				log_message("ERROR","Third-Party Integration failed during item delete: $event_failures");
+			}
 		}
 		else
 		{
 			echo json_encode(array('success' => FALSE, 'message' => $this->lang->line('items_cannot_be_deleted')));
 		}
 	}
-
+	
 	/*
 	 Items import from csv spreadsheet
 	 */
@@ -800,7 +825,7 @@ class Items extends Secure_Controller
 	{
 		$this->load->view('items/form_csv_import', NULL);
 	}
-
+	
 	/**
 	 * Imports items from CSV formatted file.
 	 */
@@ -817,13 +842,13 @@ class Items extends Secure_Controller
 				$line_array	= get_csv_file($_FILES['file_path']['tmp_name']);
 				$failCodes	= array();
 				$keys		= $line_array[0];
-
+				
 				$this->db->trans_begin();
 				for($i = 1; $i < count($line_array); $i++)
 				{
 					$invalidated	= FALSE;
 					$line 			= array_combine($keys,$this->xss_clean($line_array[$i]));	//Build a XSS-cleaned associative array with the row to use to assign values
-
+					
 					if(!empty($line))
 					{
 						$item_data = array(
@@ -839,15 +864,15 @@ class Items extends Secure_Controller
 							'hsn_code'				=> $line['HSN'],
 							'pic_filename'			=> $line['item_image']
 						);
-
+						
 						$item_number 				= $line['Barcode'];
-
+						
 						if($item_number != '')
 						{
 							$item_data['item_number'] = $item_number;
 							$invalidated = $this->Item->item_number_exists($item_number);
 						}
-
+						
 						//Sanity check of data
 						if(!$invalidated)
 						{
@@ -858,13 +883,28 @@ class Items extends Secure_Controller
 					{
 						$invalidated = TRUE;
 					}
-
+					
 					//Save to database
 					if(!$invalidated && $this->Item->save($item_data))
 					{
 						$this->save_tax_data($line, $item_data);
 						$this->save_inventory_quantities($line, $item_data);
 						$this->save_attribute_data($line, $item_data);
+						
+						//Event triggers for Third-Party Integrations
+						if($this->Item->item_number_exists($item_number))
+						{
+							$event_failures &= Events::Trigger('event_update',$item_data,'string');
+						}
+						else
+						{
+							$event_failures &= Events::Trigger('event_create',$item_data,'string');
+						}
+						
+						if($event_failures)
+						{
+							log_message("ERROR","Third-Party Integration failed during CSV Import: $event_failures");
+						}
 					}
 					else //insert or update item failure
 					{
@@ -873,7 +913,7 @@ class Items extends Secure_Controller
 						log_message("ERROR","CSV Item import failed on line ". $failed_row .". This item was not imported.");
 					}
 				}
-
+				
 				if(count($failCodes) > 0)
 				{
 					$message = $this->lang->line('items_csv_import_partially_failed', count($failCodes), implode(', ', $failCodes));
@@ -892,7 +932,7 @@ class Items extends Secure_Controller
 			}
 		}
 	}
-
+	
 	/**
 	 * Checks the entire line of data for errors
 	 *
@@ -910,13 +950,13 @@ class Items extends Secure_Controller
 			$item_data['cost_price'],
 			$item_data['unit_price']
 		);
-
+		
 		if(in_array('',$check_for_empty,true))
 		{
 			log_message("ERROR","Empty required value");
 			return TRUE;	//Return fail on empty required fields
 		}
-
+		
 		//Build array of fields to check for numerics
 		$check_for_numeric_values = array(
 			$item_data['cost_price'],
@@ -926,15 +966,15 @@ class Items extends Secure_Controller
 			$line['Tax 1 Percent'],
 			$line['Tax 2 Percent']
 		);
-
+		
 		//Add in Stock Location values to check for numeric
 		$allowed_locations	= $this->Stock_location->get_allowed_locations();
-
+		
 		foreach($allowed_locations as $location_id => $location_name)
 		{
 			$check_for_numeric_values[] = $line['location_'. $location_name];
 		}
-
+		
 		//Check for non-numeric values which require numeric
 		foreach($check_for_numeric_values as $value)
 		{
@@ -944,10 +984,10 @@ class Items extends Secure_Controller
 				return TRUE;
 			}
 		}
-
+		
 		//Check Attribute Data
 		$definition_names = $this->Attribute->get_definition_names();
-
+		
 		foreach($definition_names as $definition_name)
 		{
 			if(!empty($line['attribute_' . $definition_name]))
@@ -955,12 +995,12 @@ class Items extends Secure_Controller
 				$attribute_data 	= $this->Attribute->get_definition_by_name($definition_name)[0];
 				$attribute_type		= $attribute_data['definition_type'];
 				$attribute_value 	= $line['attribute_' . $definition_name];
-
+				
 				if($attribute_type == 'DROPDOWN')
 				{
 					$dropdown_values 	= $this->Attribute->get_definition_values($attribute_data['definition_id']);
 					$dropdown_values[] 	= '';
-
+					
 					if(in_array($attribute_value, $dropdown_values) === FALSE)
 					{
 						log_message("ERROR","Value: '$attribute_value' is not an acceptable DROPDOWN value");
@@ -985,10 +1025,10 @@ class Items extends Secure_Controller
 				}
 			}
 		}
-
+		
 		return FALSE;
 	}
-
+	
 	/**
 	 * @param line
 	 * @param failCodes
@@ -997,7 +1037,7 @@ class Items extends Secure_Controller
 	private function save_attribute_data($line, $item_data)
 	{
 		$definition_names = $this->Attribute->get_definition_names();
-
+		
 		foreach($definition_names as $definition_name)
 		{
 			if(!empty($line['attribute_' . $definition_name]))
@@ -1005,7 +1045,7 @@ class Items extends Secure_Controller
 				//Create attribute value
 				$attribute_data = $this->Attribute->get_definition_by_name($definition_name)[0];
 				$status = $this->Attribute->save_value($line['attribute_' . $definition_name], $attribute_data['definition_id'], $item_data['item_id'], FALSE, $attribute_data['definition_type']);
-
+				
 				if($status === FALSE)
 				{
 					return FALSE;
@@ -1013,7 +1053,7 @@ class Items extends Secure_Controller
 			}
 		}
 	}
-
+	
 	/**
 	 * Saves inventory quantities for the row in the appropriate stock locations.
 	 *
@@ -1027,7 +1067,7 @@ class Items extends Secure_Controller
 		$emp_info			= $this->Employee->get_info($employee_id);
 		$comment			= $this->lang->line('items_inventory_CSV_import_quantity');
 		$allowed_locations	= $this->Stock_location->get_allowed_locations();
-
+		
 		foreach($allowed_locations as $location_id => $location_name)
 		{
 			$item_quantity_data = array(
@@ -1041,7 +1081,7 @@ class Items extends Secure_Controller
 				'trans_comment' => $comment,
 				'trans_location' => $location_id,
 			);
-
+			
 			if(!empty($line['location_' . $location_name]))
 			{
 				$item_quantity_data['quantity'] = $line['location_' . $location_name];
@@ -1060,7 +1100,7 @@ class Items extends Secure_Controller
 			}
 		}
 	}
-
+	
 	/**
 	 * Saves the tax data found in the line of the CSV items import file
 	 *
@@ -1069,24 +1109,24 @@ class Items extends Secure_Controller
 	private function save_tax_data($line, $item_data)
 	{
 		$items_taxes_data = array();
-
+		
 		if(is_numeric($line['Tax 1 Percent']) && $line['Tax 1 Name'] != '')
 		{
 			$items_taxes_data[] = array('name' => $line['Tax 1 Name'], 'percent' => $line['Tax 1 Percent'] );
 		}
-
+		
 		if(is_numeric($line['Tax 2 Percent']) && $line['Tax 2 Name'] != '')
 		{
 			$items_taxes_data[] = array('name' => $line['Tax 2 Name'], 'percent' => $line['Tax 2 Percent'] );
 		}
-
+		
 		if(count($items_taxes_data) > 0)
 		{
 			$this->Item_taxes->save($items_taxes_data, $item_data['item_id']);
 		}
 	}
-
-
+	
+	
 	/**
 	 * Guess whether file extension is not in the table field, if it isn't, then it's an old-format (formerly pic_id) field, so we guess the right filename and update the table
 	 *
@@ -1095,7 +1135,7 @@ class Items extends Secure_Controller
 	private function _update_pic_filename($item)
 	{
 		$filename = pathinfo($item->pic_filename, PATHINFO_FILENAME);
-
+		
 		// if the field is empty there's nothing to check
 		if(!empty($filename))
 		{

--- a/application/controllers/Items.php
+++ b/application/controllers/Items.php
@@ -7,21 +7,21 @@ class Items extends Secure_Controller
 	public function __construct()
 	{
 		parent::__construct('items');
-		
+
 		$this->load->library('item_lib');
 		$this->load->library('events');
 		$this->load->event('integrations');
 	}
-	
+
 	public function index()
 	{
 		$this->session->set_userdata('allow_temp_items', 0);
-		
+
 		$data['table_headers'] = $this->xss_clean(get_items_manage_table_headers());
-		
+
 		$data['stock_location'] = $this->xss_clean($this->item_lib->get_item_location());
 		$data['stock_locations'] = $this->xss_clean($this->Stock_location->get_allowed_locations());
-		
+
 		// filters that will be loaded in the multiselect dropdown
 		$data['filters'] = array('empty_upc' => $this->lang->line('items_empty_upc_items'),
 			'low_inventory' => $this->lang->line('items_low_inventory_items'),
@@ -30,10 +30,10 @@ class Items extends Secure_Controller
 			'search_custom' => $this->lang->line('items_search_attributes'),
 			'is_deleted' => $this->lang->line('items_is_deleted'),
 			'temporary' => $this->lang->line('items_temp'));
-		
+
 		$this->load->view('items/manage', $data);
 	}
-	
+
 	/*
 	 Returns Items table data rows. This will be called with AJAX.
 	 */
@@ -44,11 +44,11 @@ class Items extends Secure_Controller
 		$offset = $this->input->get('offset');
 		$sort = $this->input->get('sort');
 		$order = $this->input->get('order');
-		
+
 		$this->item_lib->set_item_location($this->input->get('stock_location'));
-		
+
 		$definition_names = $this->Attribute->get_definitions_by_flags(Attribute::SHOW_IN_ITEMS);
-		
+
 		$filters = array('start_date' => $this->input->get('start_date'),
 			'end_date' => $this->input->get('end_date'),
 			'stock_location_id' => $this->item_lib->get_item_location(),
@@ -60,15 +60,15 @@ class Items extends Secure_Controller
 			'is_deleted' => FALSE,
 			'temporary' => FALSE,
 			'definition_ids' => array_keys($definition_names));
-		
+
 		// check if any filter is set in the multiselect dropdown
 		$filledup = array_fill_keys($this->input->get('filters'), TRUE);
 		$filters = array_merge($filters, $filledup);
-		
+
 		$items = $this->Item->search($search, $filters, $limit, $offset, $sort, $order);
-		
+
 		$total_rows = $this->Item->get_found_rows($search, $filters);
-		
+
 		$data_rows = array();
 		foreach($items->result() as $item)
 		{
@@ -78,19 +78,19 @@ class Items extends Secure_Controller
 				$this->_update_pic_filename($item);
 			}
 		}
-		
+
 		echo json_encode(array('total' => $total_rows, 'rows' => $data_rows));
 	}
-	
+
 	public function pic_thumb($pic_filename)
 	{
 		$this->load->helper('file');
 		$this->load->library('image_lib');
-		
+
 		// in this context, $pic_filename always has .ext
 		$ext = pathinfo($pic_filename, PATHINFO_EXTENSION);
 		$images = glob('./uploads/item_pics/' . $pic_filename);
-		
+
 		// make sure we pick only the file name, without extension
 		$base_path = './uploads/item_pics/' . pathinfo($pic_filename, PATHINFO_FILENAME);
 		if(sizeof($images) > 0)
@@ -113,7 +113,7 @@ class Items extends Secure_Controller
 			$this->output->set_output(file_get_contents($thumb_path));
 		}
 	}
-	
+
 	/*
 	 Gives search suggestions based on what is being searched for
 	 */
@@ -121,76 +121,74 @@ class Items extends Secure_Controller
 	{
 		$suggestions = $this->xss_clean($this->Item->get_search_suggestions($this->input->post_get('term'),
 			array('search_custom' => $this->input->post('search_custom'), 'is_deleted' => $this->input->post('is_deleted') != NULL), FALSE));
-		
+
 		echo json_encode($suggestions);
 	}
-	
+
 	public function suggest()
 	{
 		$suggestions = $this->xss_clean($this->Item->get_search_suggestions($this->input->post_get('term'),
 			array('search_custom' => FALSE, 'is_deleted' => FALSE), TRUE));
-		
+
 		echo json_encode($suggestions);
 	}
-	
-	
+
 	public function suggest_low_sell()
 	{
 		$suggestions = $this->xss_clean($this->Item->get_low_sell_suggestions($this->input->post_get('name')));
-		
+
 		echo json_encode($suggestions);
 	}
-	
-	
+
 	public function suggest_kits()
 	{
 		$suggestions = $this->xss_clean($this->Item->get_kit_search_suggestions($this->input->post_get('term'),
 			array('search_custom' => FALSE, 'is_deleted' => FALSE), TRUE));
-		
+
 		echo json_encode($suggestions);
 	}
-	
+
 	/*
 	 Gives search suggestions based on what is being searched for
 	 */
 	public function suggest_category()
 	{
 		$suggestions = $this->xss_clean($this->Item->get_category_suggestions($this->input->get('term')));
-		
+
 		echo json_encode($suggestions);
 	}
-	
+
 	/*
 	 Gives search suggestions based on what is being searched for
 	 */
 	public function suggest_location()
 	{
 		$suggestions = $this->xss_clean($this->Item->get_location_suggestions($this->input->get('term')));
-		
+
 		echo json_encode($suggestions);
 	}
-	
+
 	public function get_row($item_ids)
 	{
 		$item_infos = $this->Item->get_multiple_info(explode(":", $item_ids), $this->item_lib->get_item_location());
-		
+
 		$result = array();
 		foreach($item_infos->result() as $item_info)
 		{
 			$result[$item_info->item_id] = $this->xss_clean(get_item_data_row($item_info));
 		}
-		
+
 		echo json_encode($result);
 	}
-	
+
 	public function view($item_id = -1)
 	{
 		if($item_id == -1)
 		{
 			$data = array();
 		}
-		
-		// allow_temp_items is set in the index function of items.php or sales.php
+
+	// allow_temp_items is set in the index function of items.php or sales.php
 		$data['allow_temp_item'] = $this->session->userdata('allow_temp_items');
 		$data['item_tax_info'] = $this->xss_clean($this->Item_taxes->get_info($item_id));
 		$data['default_tax_1_rate'] = '';
@@ -198,19 +196,19 @@ class Items extends Secure_Controller
 		$data['item_kit_disabled'] = !$this->Employee->has_grant('item_kits', $this->Employee->get_logged_in_employee_info()->person_id);
 		$data['definition_values'] = $this->Attribute->get_attributes_by_item($item_id);
 		$data['definition_names'] = $this->Attribute->get_definition_names();
-		
+
 		foreach($data['definition_values'] as $definition_id => $definition)
 		{
 			unset($data['definition_names'][$definition_id]);
 		}
-		
+
 		$item_info = $this->Item->get_info($item_id);
-		
+
 		foreach(get_object_vars($item_info) as $property => $value)
 		{
 			$item_info->$property = $this->xss_clean($value);
 		}
-		
+
 		if($data['allow_temp_item'] == 1)
 		{
 			if($item_id != -1)
@@ -228,15 +226,15 @@ class Items extends Secure_Controller
 				$data['allow_temp_item'] = 1;
 			}
 		}
-		
+
 		$use_destination_based_tax = (boolean)$this->config->item('use_destination_based_tax');
 		$data['include_hsn'] = $this->config->item('include_hsn') == '1';
-		
+
 		if($item_id == -1)
 		{
 			$data['default_tax_1_rate'] = $this->config->item('default_tax_1_rate');
 			$data['default_tax_2_rate'] = $this->config->item('default_tax_2_rate');
-			
+
 			$item_info->receiving_quantity = 1;
 			$item_info->reorder_level = 1;
 			$item_info->item_type = ITEM; // standard
@@ -257,7 +255,7 @@ class Items extends Secure_Controller
 										&& !($this->config->item('derive_sale_quantity') == '1'));
 
 		$data['item_info'] = $item_info;
-		
+
 		$suppliers = array('' => $this->lang->line('items_none'));
 		foreach($this->Supplier->get_all()->result_array() as $row)
 		{
@@ -265,7 +263,7 @@ class Items extends Secure_Controller
 		}
 		$data['suppliers'] = $suppliers;
 		$data['selected_supplier'] = $item_info->supplier_id;
-		
+
 		if($data['include_hsn'])
 		{
 			$data['hsn_code'] = $item_info->hsn_code;
@@ -274,7 +272,7 @@ class Items extends Secure_Controller
 		{
 			$data['hsn_code'] = '';
 		}
-		
+
 		if($use_destination_based_tax)
 		{
 			$data['use_destination_based_tax'] = TRUE;
@@ -299,7 +297,7 @@ class Items extends Secure_Controller
 			$data['tax_categories'] = array();
 			$data['tax_category'] = '';
 		}
-		
+
 		$data['logo_exists'] = $item_info->pic_filename != '';
 		$ext = pathinfo($item_info->pic_filename, PATHINFO_EXTENSION);
 		if($ext == '')
@@ -312,20 +310,21 @@ class Items extends Secure_Controller
 			// else just pick that file
 			$images = glob('./uploads/item_pics/' . $item_info->pic_filename);
 		}
+
 		$data['image_path'] = sizeof($images) > 0 ? base_url($images[0]) : '';
 		$stock_locations = $this->Stock_location->get_undeleted_all()->result_array();
 		foreach($stock_locations as $location)
 		{
 			$location = $this->xss_clean($location);
-			
+
 			$quantity = $this->xss_clean($this->Item_quantity->get_item_quantity($item_id, $location['location_id'])->quantity);
 			$quantity = ($item_id == -1) ? 0 : $quantity;
 			$location_array[$location['location_id']] = array('location_name' => $location['location_name'], 'quantity' => $quantity);
 			$data['stock_locations'] = $location_array;
 		}
-		
+
 		$data['selected_low_sell_item_id'] = $item_info->low_sell_item_id;
-		
+
 		if($item_id != -1 && $item_info->item_id != $item_info->low_sell_item_id)
 		{
 			$low_sell_item_info = $this->Item->get_info($item_info->low_sell_item_id);
@@ -335,10 +334,10 @@ class Items extends Secure_Controller
 		{
 			$data['selected_low_sell_item'] = '';
 		}
-		
+
 		$this->load->view('items/form', $data);
 	}
-	
+
 	public function inventory($item_id = -1)
 	{
 		$item_info = $this->Item->get_info($item_id);
@@ -347,9 +346,10 @@ class Items extends Secure_Controller
 			$item_info->$property = $this->xss_clean($value);
 		}
 		$data['item_info'] = $item_info;
-		
+
 		$data['stock_locations'] = array();
 		$stock_locations = $this->Stock_location->get_undeleted_all()->result_array();
+
 		foreach($stock_locations as $location)
 		{
 			$location = $this->xss_clean($location);
@@ -358,74 +358,76 @@ class Items extends Secure_Controller
 			$data['stock_locations'][$location['location_id']] = $location['location_name'];
 			$data['item_quantities'][$location['location_id']] = $quantity;
 		}
-		
+
 		$this->load->view('items/form_inventory', $data);
 	}
-	
+
 	public function count_details($item_id = -1)
 	{
 		$item_info = $this->Item->get_info($item_id);
+
 		foreach(get_object_vars($item_info) as $property => $value)
 		{
 			$item_info->$property = $this->xss_clean($value);
 		}
 		$data['item_info'] = $item_info;
-		
+
 		$data['stock_locations'] = array();
 		$stock_locations = $this->Stock_location->get_undeleted_all()->result_array();
+
 		foreach($stock_locations as $location)
 		{
 			$location = $this->xss_clean($location);
 			$quantity = $this->xss_clean($this->Item_quantity->get_item_quantity($item_id, $location['location_id'])->quantity);
-			
+
 			$data['stock_locations'][$location['location_id']] = $location['location_name'];
 			$data['item_quantities'][$location['location_id']] = $quantity;
 		}
-		
+
 		$this->load->view('items/form_count_details', $data);
 	}
-	
+
 	public function generate_barcodes($item_ids)
 	{
 		$this->load->library('barcode_lib');
-		
+
 		$item_ids = explode(':', $item_ids);
 		$result = $this->Item->get_multiple_info($item_ids, $this->item_lib->get_item_location())->result_array();
 		$config = $this->barcode_lib->get_barcode_config();
-		
+
 		$data['barcode_config'] = $config;
-		
-		// check the list of items to see if any item_number field is empty
+
+	// check the list of items to see if any item_number field is empty
 		foreach($result as &$item)
 		{
 			$item = $this->xss_clean($item);
-			
-			// update the barcode field if empty / NULL with the newly generated barcode
+
+		// update the barcode field if empty / NULL with the newly generated barcode
 			if(empty($item['item_number']) && $this->config->item('barcode_generate_if_empty'))
 			{
-				// get the newly generated barcode
+			// get the newly generated barcode
 				$barcode_instance = Barcode_lib::barcode_instance($item, $config);
 				$item['item_number'] = $barcode_instance->getData();
-				
+
 				$save_item = array('item_number' => $item['item_number']);
-				
-				// update the item in the database in order to save the barcode field
+
+			// update the item in the database in order to save the barcode field
 				$this->Item->save($save_item, $item['item_id']);
 			}
 		}
 		$data['items'] = $result;
-		
-		// display barcodes
+
+	// display barcodes
 		$this->load->view('barcodes/barcode_sheet', $data);
 	}
-	
+
 	public function attributes($item_id)
 	{
 		$data['item_id'] = $item_id;
 		$definition_ids = json_decode($this->input->post('definition_ids'), TRUE);
 		$data['definition_values'] = $this->Attribute->get_attributes_by_item($item_id) + $this->Attribute->get_values_by_definitions($definition_ids);
 		$data['definition_names'] = $this->Attribute->get_definition_names();
-		
+
 		foreach($data['definition_values'] as $definition_id => $definition_value)
 		{
 			$attribute_value = $this->Attribute->get_attribute_value($item_id, $definition_id);
@@ -434,32 +436,32 @@ class Items extends Secure_Controller
 			$values['attribute_id'] = $attribute_id;
 			$values['attribute_value'] = $attribute_value;
 			$values['selected_value'] = '';
-			
+
 			if ($definition_value['definition_type'] == DROPDOWN)
 			{
 				$values['values'] = $this->Attribute->get_definition_values($definition_id);
 				$link_value = $this->Attribute->get_link_value($item_id, $definition_id);
 				$values['selected_value'] = (empty($link_value)) ? '' : $link_value->attribute_id;
 			}
-			
+
 			if (!empty($definition_ids[$definition_id]))
 			{
 				$values['selected_value'] = $definition_ids[$definition_id];
 			}
-			
+
 			unset($data['definition_names'][$definition_id]);
 		}
-		
+
 		$this->load->view('attributes/item', $data);
 	}
-	
+
 	public function bulk_edit()
 	{
 		$suppliers = array('' => $this->lang->line('items_none'));
 		foreach($this->Supplier->get_all()->result_array() as $row)
 		{
 			$row = $this->xss_clean($row);
-			
+
 			$suppliers[$row['person_id']] = $row['company_name'];
 		}
 		$data['suppliers'] = $suppliers;
@@ -467,30 +469,30 @@ class Items extends Secure_Controller
 			'' => $this->lang->line('items_do_nothing'),
 			1  => $this->lang->line('items_change_all_to_allow_alt_desc'),
 			0  => $this->lang->line('items_change_all_to_not_allow_allow_desc'));
-		
+
 		$data['serialization_choices'] = array(
 			'' => $this->lang->line('items_do_nothing'),
 			1  => $this->lang->line('items_change_all_to_serialized'),
 			0  => $this->lang->line('items_change_all_to_unserialized'));
-		
+
 		$this->load->view('items/form_bulk', $data);
 	}
-	
+
 	public function save($item_id = -1)
 	{
 		$upload_success = $this->_handle_image_upload();
 		$upload_data = $this->upload->data();
-		
+
 		$receiving_quantity = parse_decimals($this->input->post('receiving_quantity'));
 		$item_type = $this->input->post('item_type') == NULL ? ITEM : $this->input->post('item_type');
-		
+
 		if($receiving_quantity == '0' && $item_type!= ITEM_TEMP)
 		{
 			$receiving_quantity = '1';
 		}
 		$default_pack_name = $this->lang->line('items_default_pack_name');
-		
-		//Save item data
+
+	//Save item data
 		$item_data = array(
 			'name' => $this->input->post('name'),
 			'description' => $this->input->post('description'),
@@ -511,15 +513,16 @@ class Items extends Secure_Controller
 			'deleted' => $this->input->post('is_deleted') != NULL,
 			'hsn_code' => $this->input->post('hsn_code') == NULL ? '' : $this->input->post('hsn_code')
 		);
-		
+
 		if($item_data['item_type'] == ITEM_TEMP)
 		{
 			$item_data['stock_type'] = HAS_NO_STOCK;
 			$item_data['receiving_quantity'] = 0;
 			$item_data['reorder_level'] = 0;
 		}
-		
+
 		$x = $this->input->post('tax_category_id');
+
 		if(!isset($x))
 		{
 			$item_data['tax_category_id'] = '';
@@ -528,7 +531,7 @@ class Items extends Secure_Controller
 		{
 			$item_data['tax_category_id'] = $this->input->post('tax_category_id') == '' ? NULL : $this->input->post('tax_category_id');
 		}
-		
+
 		if(!empty($upload_data['orig_name']))
 		{
 			// XSS file image sanity check
@@ -537,9 +540,9 @@ class Items extends Secure_Controller
 				$item_data['pic_filename'] = $upload_data['raw_name'];
 			}
 		}
-		
+
 		$employee_id = $this->Employee->get_logged_in_employee_info()->person_id;
-		
+
 		if($this->Item->save($item_data, $item_id))
 		{
 			$success = TRUE;
@@ -550,9 +553,9 @@ class Items extends Secure_Controller
 				$item_id = $item_data['item_id'];
 				$new_item = TRUE;
 			}
-			
+
 			$use_destination_based_tax = (boolean)$this->config->item('use_destination_based_tax');
-			
+
 			if(!$use_destination_based_tax)
 			{
 				$items_taxes_data = array();
@@ -569,26 +572,28 @@ class Items extends Secure_Controller
 				}
 				$success &= $this->Item_taxes->save($items_taxes_data, $item_id);
 			}
-			
-			//Save item quantity
+
+		//Save item quantity
 			$stock_locations = $this->Stock_location->get_undeleted_all()->result_array();
 			foreach($stock_locations as $location)
 			{
 				$updated_quantity = parse_decimals($this->input->post('quantity_' . $location['location_id']));
+				
 				if($item_data['item_type'] == ITEM_TEMP)
 				{
 					$updated_quantity = 0;
 				}
+				
 				$location_detail = array('item_id' => $item_id,
 					'location_id' => $location['location_id'],
 					'quantity' => $updated_quantity);
-				
-				
+
 				$item_quantity = $this->Item_quantity->get_item_quantity($item_id, $location['location_id']);
+
 				if($item_quantity->quantity != $updated_quantity || $new_item)
 				{
 					$success &= $this->Item_quantity->save($location_detail, $item_id, $location['location_id']);
-					
+
 					$inv_data = array(
 						'trans_date' => date('Y-m-d H:i:s'),
 						'trans_items' => $item_id,
@@ -597,31 +602,33 @@ class Items extends Secure_Controller
 						'trans_comment' => $this->lang->line('items_manually_editing_of_quantity'),
 						'trans_inventory' => $updated_quantity - $item_quantity->quantity
 					);
-					
+
 					$success &= $this->Inventory->insert($inv_data);
 				}
 			}
-			
-			// Save item attributes
+
+		// Save item attributes
 			$attribute_links = $this->input->post('attribute_links') != NULL ? $this->input->post('attribute_links') : array();
 			$attribute_ids = $this->input->post('attribute_ids');
 			$this->Attribute->delete_link($item_id);
 			foreach($attribute_links as $definition_id => $attribute_id)
 			{
 				$definition_type = $this->Attribute->get_info($definition_id)->definition_type;
+
 				if($definition_type != DROPDOWN)
 				{
 					$attribute_id = $this->Attribute->save_value($attribute_id, $definition_id, $item_id, $attribute_ids[$definition_id], $definition_type);
 				}
+				
 				$this->Attribute->save_link($item_id, $definition_id, $attribute_id);
 			}
-			
+
 			if($success && $upload_success)
 			{
 				$message = $this->xss_clean($this->lang->line('items_successful_' . ($new_item ? 'adding' : 'updating')) . ' ' . $item_data['name']);
-				
+
 				echo json_encode(array('success' => TRUE, 'message' => $message, 'id' => $item_id));
-				
+
 			//Event triggers for Third-Party Integrations
 				if($new_item)
 				{
@@ -631,7 +638,7 @@ class Items extends Secure_Controller
 				{
 				    $event_failures = Events::Trigger('event_update', array("type"=> "ITEMS", "data" => $item_data), 'string');
 				}
-				
+
 				if($event_failures)
 				{
 				    log_message("ERROR","Third-Party Integration failed during item save: $event_failures");
@@ -640,24 +647,24 @@ class Items extends Secure_Controller
 			else
 			{
 				$message = $this->xss_clean($upload_success ? $this->lang->line('items_error_adding_updating') . ' ' . $item_data['name'] : strip_tags($this->upload->display_errors()));
-				
+
 				echo json_encode(array('success' => FALSE, 'message' => $message, 'id' => $item_id));
 			}
 		}
 		else // failure
 		{
 			$message = $this->xss_clean($this->lang->line('items_error_adding_updating') . ' ' . $item_data['name']);
-			
+
 			echo json_encode(array('success' => FALSE, 'message' => $message, 'id' => -1));
 		}
 	}
-	
+
 	public function check_item_number()
 	{
 		$exists = $this->Item->item_number_exists($this->input->post('item_number'), $this->input->post('item_id'));
 		echo !$exists ? 'true' : 'false';
 	}
-	
+
 	/*
 	 If adding a new item check to see if an item kit with the same name as the item already exists.
 	 */
@@ -673,12 +680,12 @@ class Items extends Secure_Controller
 		}
 		echo !$exists ? 'true' : 'false';
 	}
-	
+
 	private function _handle_image_upload()
 	{
-		/* Let files be uploaded with their original name */
-		
-		// load upload library
+	/* Let files be uploaded with their original name */
+
+	// load upload library
 		$config = array('upload_path' => './uploads/item_pics/',
 			'allowed_types' => 'gif|jpg|png',
 			'max_size' => '100',
@@ -687,18 +694,18 @@ class Items extends Secure_Controller
 		);
 		$this->load->library('upload', $config);
 		$this->upload->do_upload('item_image');
-		
+
 		return strlen($this->upload->display_errors()) == 0 || !strcmp($this->upload->display_errors(), '<p>'.$this->lang->line('upload_no_file_selected').'</p>');
 	}
-	
+
 	public function remove_logo($item_id)
 	{
 		$item_data = array('pic_filename' => NULL);
 		$result = $this->Item->save($item_data, $item_id);
-		
+
 		echo json_encode(array('success' => $result));
 	}
-	
+
 	public function save_inventory($item_id = -1)
 	{
 		$employee_id = $this->Employee->get_logged_in_employee_info()->person_id;
@@ -712,39 +719,39 @@ class Items extends Secure_Controller
 			'trans_comment' => $this->input->post('trans_comment'),
 			'trans_inventory' => parse_decimals($this->input->post('newquantity'))
 		);
-		
+
 		$this->Inventory->insert($inv_data);
-		
-		//Update stock quantity
+
+	//Update stock quantity
 		$item_quantity = $this->Item_quantity->get_item_quantity($item_id, $location_id);
 		$item_quantity_data = array(
 			'item_id' => $item_id,
 			'location_id' => $location_id,
 			'quantity' => $item_quantity->quantity + parse_decimals($this->input->post('newquantity'))
 		);
-		
+
 		if($this->Item_quantity->save($item_quantity_data, $item_id, $location_id))
 		{
 			$message = $this->xss_clean($this->lang->line('items_successful_updating') . ' ' . $cur_item_info->name);
-			
+
 			echo json_encode(array('success' => TRUE, 'message' => $message, 'id' => $item_id));
 		}
 		else//failure
 		{
 			$message = $this->xss_clean($this->lang->line('items_error_adding_updating') . ' ' . $cur_item_info->name);
-			
+
 			echo json_encode(array('success' => FALSE, 'message' => $message, 'id' => -1));
 		}
 	}
-	
+
 	public function bulk_update()
 	{
 		$items_to_update = $this->input->post('item_ids');
 		$item_data = array();
-		
+
 		foreach($_POST as $key => $value)
 		{
-			//This field is nullable, so treat it differently
+		//This field is nullable, so treat it differently
 			if($key == 'supplier_id' && $value != '')
 			{
 				$item_data["$key"] = $value;
@@ -754,8 +761,8 @@ class Items extends Secure_Controller
 				$item_data["$key"] = $value;
 			}
 		}
-		
-		//Item data could be empty if tax information is being updated
+
+	//Item data could be empty if tax information is being updated
 		if(empty($item_data) || $this->Item->update_multiple($item_data, $items_to_update))
 		{
 			$items_taxes_data = array();
@@ -763,21 +770,22 @@ class Items extends Secure_Controller
 			$tax_percents = $this->input->post('tax_percents');
 			$tax_updated = FALSE;
 			$count = count($tax_percents);
+
 			for($k = 0; $k < $count; ++$k)
 			{
 				if(!empty($tax_names[$k]) && is_numeric($tax_percents[$k]))
 				{
 					$tax_updated = TRUE;
-					
+
 					$items_taxes_data[] = array('name' => $tax_names[$k], 'percent' => $tax_percents[$k]);
 				}
 			}
-			
+
 			if($tax_updated)
 			{
 				$this->Item_taxes->save_multiple($items_taxes_data, $items_to_update);
 			}
-			
+
 			echo json_encode(array('success' => TRUE, 'message' => $this->lang->line('items_successful_bulk_edit'), 'id' => $this->xss_clean($items_to_update)));
 		}
 		else
@@ -785,19 +793,19 @@ class Items extends Secure_Controller
 			echo json_encode(array('success' => FALSE, 'message' => $this->lang->line('items_error_updating_multiple')));
 		}
 	}
-	
+
 	public function delete()
 	{
 		$items_to_delete = $this->input->post('ids');
-		
+
 		if($this->Item->delete_list($items_to_delete))
 		{
 			$message = $this->lang->line('items_successful_deleted') . ' ' . count($items_to_delete) . ' ' . $this->lang->line('items_one_or_multiple');
 			echo json_encode(array('success' => TRUE, 'message' => $message));
-			
-			//Event triggers for Third-Party Integrations
+
+		//Event triggers for Third-Party Integrations
 			$event_failures = Events::Trigger('event_delete', array("type"=> "ITEMS", "data" => $items_to_delete), 'string');
-			
+
 			if($event_failures)
 			{
 				log_message("ERROR","Third-Party Integration failed during item delete: $event_failures");
@@ -808,7 +816,7 @@ class Items extends Secure_Controller
 			echo json_encode(array('success' => FALSE, 'message' => $this->lang->line('items_cannot_be_deleted')));
 		}
 	}
-	
+
 	/*
 	 Items import from csv spreadsheet
 	 */
@@ -825,7 +833,7 @@ class Items extends Secure_Controller
 	{
 		$this->load->view('items/form_csv_import', NULL);
 	}
-	
+
 	/**
 	 * Imports items from CSV formatted file.
 	 */
@@ -842,13 +850,13 @@ class Items extends Secure_Controller
 				$line_array	= get_csv_file($_FILES['file_path']['tmp_name']);
 				$failCodes	= array();
 				$keys		= $line_array[0];
-				
+
 				$this->db->trans_begin();
 				for($i = 1; $i < count($line_array); $i++)
 				{
 					$invalidated	= FALSE;
 					$line 			= array_combine($keys,$this->xss_clean($line_array[$i]));	//Build a XSS-cleaned associative array with the row to use to assign values
-					
+
 					if(!empty($line))
 					{
 						$item_data = array(
@@ -864,15 +872,15 @@ class Items extends Secure_Controller
 							'hsn_code'				=> $line['HSN'],
 							'pic_filename'			=> $line['item_image']
 						);
-						
+
 						$item_number 				= $line['Barcode'];
-						
+
 						if($item_number != '')
 						{
 							$item_data['item_number'] = $item_number;
 							$invalidated = $this->Item->item_number_exists($item_number);
 						}
-						
+
 						//Sanity check of data
 						if(!$invalidated)
 						{
@@ -883,14 +891,14 @@ class Items extends Secure_Controller
 					{
 						$invalidated = TRUE;
 					}
-					
-					//Save to database
+
+				//Save to database
 					if(!$invalidated && $this->Item->save($item_data))
 					{
 						$this->save_tax_data($line, $item_data);
 						$this->save_inventory_quantities($line, $item_data);
 						$this->save_attribute_data($line, $item_data);
-						
+
 					//Event triggers for Third-Party Integrations
 						if($this->Item->item_number_exists($item_number))
 						{
@@ -900,7 +908,7 @@ class Items extends Secure_Controller
 						{
 						    $event_failures = Events::Trigger('event_create', array("type"=> "ITEMS", "data" => $item_data), 'string');
 						}
-						
+
 						if($event_failures)
 						{
 						    log_message("ERROR","Third-Party Integration failed during CSV Import: $event_failures");
@@ -913,7 +921,7 @@ class Items extends Secure_Controller
 						log_message("ERROR","CSV Item import failed on line ". $failed_row .". This item was not imported.");
 					}
 				}
-				
+
 				if(count($failCodes) > 0)
 				{
 					$message = $this->lang->line('items_csv_import_partially_failed', count($failCodes), implode(', ', $failCodes));
@@ -932,7 +940,7 @@ class Items extends Secure_Controller
 			}
 		}
 	}
-	
+
 	/**
 	 * Checks the entire line of data for errors
 	 *
@@ -943,21 +951,21 @@ class Items extends Secure_Controller
 	 */
 	private function data_error_check($line, $item_data)
 	{
-		//Check for empty required fields
+	//Check for empty required fields
 		$check_for_empty = array(
 			$item_data['name'],
 			$item_data['category'],
 			$item_data['cost_price'],
 			$item_data['unit_price']
 		);
-		
+
 		if(in_array('',$check_for_empty,true))
 		{
 			log_message("ERROR","Empty required value");
 			return TRUE;	//Return fail on empty required fields
 		}
-		
-		//Build array of fields to check for numerics
+
+	//Build array of fields to check for numerics
 		$check_for_numeric_values = array(
 			$item_data['cost_price'],
 			$item_data['unit_price'],
@@ -966,16 +974,16 @@ class Items extends Secure_Controller
 			$line['Tax 1 Percent'],
 			$line['Tax 2 Percent']
 		);
-		
-		//Add in Stock Location values to check for numeric
+
+	//Add in Stock Location values to check for numeric
 		$allowed_locations	= $this->Stock_location->get_allowed_locations();
-		
+
 		foreach($allowed_locations as $location_id => $location_name)
 		{
 			$check_for_numeric_values[] = $line['location_'. $location_name];
 		}
-		
-		//Check for non-numeric values which require numeric
+
+	//Check for non-numeric values which require numeric
 		foreach($check_for_numeric_values as $value)
 		{
 			if(!is_numeric($value) && $value != '')
@@ -984,10 +992,10 @@ class Items extends Secure_Controller
 				return TRUE;
 			}
 		}
-		
-		//Check Attribute Data
+
+	//Check Attribute Data
 		$definition_names = $this->Attribute->get_definition_names();
-		
+
 		foreach($definition_names as $definition_name)
 		{
 			if(!empty($line['attribute_' . $definition_name]))
@@ -995,12 +1003,12 @@ class Items extends Secure_Controller
 				$attribute_data 	= $this->Attribute->get_definition_by_name($definition_name)[0];
 				$attribute_type		= $attribute_data['definition_type'];
 				$attribute_value 	= $line['attribute_' . $definition_name];
-				
+
 				if($attribute_type == 'DROPDOWN')
 				{
 					$dropdown_values 	= $this->Attribute->get_definition_values($attribute_data['definition_id']);
 					$dropdown_values[] 	= '';
-					
+
 					if(in_array($attribute_value, $dropdown_values) === FALSE)
 					{
 						log_message("ERROR","Value: '$attribute_value' is not an acceptable DROPDOWN value");
@@ -1025,10 +1033,10 @@ class Items extends Secure_Controller
 				}
 			}
 		}
-		
+
 		return FALSE;
 	}
-	
+
 	/**
 	 * @param line
 	 * @param failCodes
@@ -1037,7 +1045,7 @@ class Items extends Secure_Controller
 	private function save_attribute_data($line, $item_data)
 	{
 		$definition_names = $this->Attribute->get_definition_names();
-		
+
 		foreach($definition_names as $definition_name)
 		{
 			if(!empty($line['attribute_' . $definition_name]))
@@ -1045,7 +1053,7 @@ class Items extends Secure_Controller
 				//Create attribute value
 				$attribute_data = $this->Attribute->get_definition_by_name($definition_name)[0];
 				$status = $this->Attribute->save_value($line['attribute_' . $definition_name], $attribute_data['definition_id'], $item_data['item_id'], FALSE, $attribute_data['definition_type']);
-				
+
 				if($status === FALSE)
 				{
 					return FALSE;
@@ -1053,7 +1061,7 @@ class Items extends Secure_Controller
 			}
 		}
 	}
-	
+
 	/**
 	 * Saves inventory quantities for the row in the appropriate stock locations.
 	 *
@@ -1064,10 +1072,10 @@ class Items extends Secure_Controller
 	{
 		//Quantities & Inventory Section
 		$employee_id		= $this->Employee->get_logged_in_employee_info()->person_id;
-		$emp_info			= $this->Employee->get_info($employee_id);
-		$comment			= $this->lang->line('items_inventory_CSV_import_quantity');
+		$emp_info		= $this->Employee->get_info($employee_id);
+		$comment		= $this->lang->line('items_inventory_CSV_import_quantity');
 		$allowed_locations	= $this->Stock_location->get_allowed_locations();
-		
+
 		foreach($allowed_locations as $location_id => $location_name)
 		{
 			$item_quantity_data = array(
@@ -1081,7 +1089,7 @@ class Items extends Secure_Controller
 				'trans_comment' => $comment,
 				'trans_location' => $location_id,
 			);
-			
+
 			if(!empty($line['location_' . $location_name]))
 			{
 				$item_quantity_data['quantity'] = $line['location_' . $location_name];
@@ -1100,7 +1108,7 @@ class Items extends Secure_Controller
 			}
 		}
 	}
-	
+
 	/**
 	 * Saves the tax data found in the line of the CSV items import file
 	 *
@@ -1109,24 +1117,23 @@ class Items extends Secure_Controller
 	private function save_tax_data($line, $item_data)
 	{
 		$items_taxes_data = array();
-		
+
 		if(is_numeric($line['Tax 1 Percent']) && $line['Tax 1 Name'] != '')
 		{
 			$items_taxes_data[] = array('name' => $line['Tax 1 Name'], 'percent' => $line['Tax 1 Percent'] );
 		}
-		
+
 		if(is_numeric($line['Tax 2 Percent']) && $line['Tax 2 Name'] != '')
 		{
 			$items_taxes_data[] = array('name' => $line['Tax 2 Name'], 'percent' => $line['Tax 2 Percent'] );
 		}
-		
+
 		if(count($items_taxes_data) > 0)
 		{
 			$this->Item_taxes->save($items_taxes_data, $item_data['item_id']);
 		}
 	}
-	
-	
+
 	/**
 	 * Guess whether file extension is not in the table field, if it isn't, then it's an old-format (formerly pic_id) field, so we guess the right filename and update the table
 	 *
@@ -1135,8 +1142,8 @@ class Items extends Secure_Controller
 	private function _update_pic_filename($item)
 	{
 		$filename = pathinfo($item->pic_filename, PATHINFO_FILENAME);
-		
-		// if the field is empty there's nothing to check
+
+	// if the field is empty there's nothing to check
 		if(!empty($filename))
 		{
 			$ext = pathinfo($item->pic_filename, PATHINFO_EXTENSION);

--- a/application/controllers/Items.php
+++ b/application/controllers/Items.php
@@ -625,16 +625,16 @@ class Items extends Secure_Controller
 			//Event triggers for Third-Party Integrations
 				if($new_item)
 				{
-					$event_failures &= Events::Trigger('event_create',$item_data,'string');
+				    $event_failures = Events::Trigger('event_create', array("type"=> "ITEMS", "data" => $item_data), 'string');
 				}
 				else
 				{
-					$event_failures &= Events::Trigger('event_update',$item_data,'string');
+				    $event_failures = Events::Trigger('event_update', array("type"=> "ITEMS", "data" => $item_data), 'string');
 				}
 				
 				if($event_failures)
 				{
-					log_message("ERROR","Third-Party Integration failed during item save: $event_failures");
+				    log_message("ERROR","Third-Party Integration failed during item save: $event_failures");
 				}
 			}
 			else
@@ -796,7 +796,7 @@ class Items extends Secure_Controller
 			echo json_encode(array('success' => TRUE, 'message' => $message));
 			
 			//Event triggers for Third-Party Integrations
-			$event_failures &= Events::Trigger('event_delete',$items_to_delete,'string');
+			$event_failures = Events::Trigger('event_delete', array("type"=> "ITEMS", "data" => $items_to_delete), 'string');
 			
 			if($event_failures)
 			{
@@ -891,19 +891,19 @@ class Items extends Secure_Controller
 						$this->save_inventory_quantities($line, $item_data);
 						$this->save_attribute_data($line, $item_data);
 						
-						//Event triggers for Third-Party Integrations
+					//Event triggers for Third-Party Integrations
 						if($this->Item->item_number_exists($item_number))
 						{
-							$event_failures &= Events::Trigger('event_update',$item_data,'string');
+						    $event_failures = Events::Trigger('event_update', array("type"=> "ITEMS", "data" => $item_data), 'string');
 						}
 						else
 						{
-							$event_failures &= Events::Trigger('event_create',$item_data,'string');
+						    $event_failures = Events::Trigger('event_create', array("type"=> "ITEMS", "data" => $item_data), 'string');
 						}
 						
 						if($event_failures)
 						{
-							log_message("ERROR","Third-Party Integration failed during CSV Import: $event_failures");
+						    log_message("ERROR","Third-Party Integration failed during CSV Import: $event_failures");
 						}
 					}
 					else //insert or update item failure

--- a/application/controllers/Items.php
+++ b/application/controllers/Items.php
@@ -632,16 +632,11 @@ class Items extends Secure_Controller
 			//Event triggers for Third-Party Integrations
 				if($new_item)
 				{
-				    $event_failures = Events::Trigger('event_create', array("type"=> "ITEMS", "data" => $item_data), 'string');
+				    Events::Trigger('event_create', array("type"=> "ITEMS", "data" => $item_data), 'string');
 				}
 				else
 				{
-				    $event_failures = Events::Trigger('event_update', array("type"=> "ITEMS", "data" => $item_data), 'string');
-				}
-
-				if($event_failures)
-				{
-				    log_message("ERROR","Third-Party Integration failed during item save: $event_failures");
+				    Events::Trigger('event_update', array("type"=> "ITEMS", "data" => $item_data), 'string');
 				}
 			}
 			else
@@ -804,12 +799,7 @@ class Items extends Secure_Controller
 			echo json_encode(array('success' => TRUE, 'message' => $message));
 
 		//Event triggers for Third-Party Integrations
-			$event_failures = Events::Trigger('event_delete', array("type"=> "ITEMS", "data" => $items_to_delete), 'string');
-
-			if($event_failures)
-			{
-				log_message("ERROR","Third-Party Integration failed during item delete: $event_failures");
-			}
+			Events::Trigger('event_delete', array("type"=> "ITEMS", "data" => $items_to_delete), 'string');
 		}
 		else
 		{
@@ -902,16 +892,11 @@ class Items extends Secure_Controller
 					//Event triggers for Third-Party Integrations
 						if($this->Item->item_number_exists($item_number))
 						{
-						    $event_failures = Events::Trigger('event_update', array("type"=> "ITEMS", "data" => $item_data), 'string');
+						    Events::Trigger('event_update', array("type"=> "ITEMS", "data" => $item_data), 'string');
 						}
 						else
 						{
-						    $event_failures = Events::Trigger('event_create', array("type"=> "ITEMS", "data" => $item_data), 'string');
-						}
-
-						if($event_failures)
-						{
-						    log_message("ERROR","Third-Party Integration failed during CSV Import: $event_failures");
+						    Events::Trigger('event_create', array("type"=> "ITEMS", "data" => $item_data), 'string');
 						}
 					}
 					else //insert or update item failure

--- a/application/controllers/Receivings.php
+++ b/application/controllers/Receivings.php
@@ -10,6 +10,8 @@ class Receivings extends Secure_Controller
 
 		$this->load->library('receiving_lib');
 		$this->load->library('barcode_lib');
+		$this->load->library('events');
+		$this->load->event('integrations');
 	}
 
 	public function index()
@@ -251,6 +253,13 @@ class Receivings extends Secure_Controller
 		else
 		{
 			$data['barcode'] = $this->barcode_lib->generate_receipt_barcode($data['receiving_id']);				
+			
+			$event_failures = Events::Trigger('event_update', array("type"=> "RECEIVINGS", "data" => $data), 'string');
+			
+			if($event_failures)
+			{
+			    log_message("ERROR","Third-Party Integration failed during Receiving: $event_failures");
+			}
 		}
 
 		$data['print_after_sale'] = $this->receiving_lib->is_print_after_sale();

--- a/application/controllers/Receivings.php
+++ b/application/controllers/Receivings.php
@@ -233,7 +233,7 @@ class Receivings extends Secure_Controller
 			$data['supplier_address'] = $supplier_info->address_1;
 			if(!empty($supplier_info->zip) or !empty($supplier_info->city))
 			{
-				$data['supplier_location'] = $supplier_info->zip . ' ' . $supplier_info->city;				
+				$data['supplier_location'] = $supplier_info->zip . ' ' . $supplier_info->city;
 			}
 			else
 			{
@@ -252,14 +252,9 @@ class Receivings extends Secure_Controller
 		}
 		else
 		{
-			$data['barcode'] = $this->barcode_lib->generate_receipt_barcode($data['receiving_id']);				
+			$data['barcode'] = $this->barcode_lib->generate_receipt_barcode($data['receiving_id']);
 			
-			$event_failures = Events::Trigger('event_update', array("type"=> "RECEIVINGS", "data" => $data), 'string');
-			
-			if($event_failures)
-			{
-			    log_message("ERROR","Third-Party Integration failed during Receiving: $event_failures");
-			}
+			Events::Trigger('event_update', array("type"=> "RECEIVINGS", "data" => $data), 'string');
 		}
 
 		$data['print_after_sale'] = $this->receiving_lib->is_print_after_sale();

--- a/application/controllers/Sales.php
+++ b/application/controllers/Sales.php
@@ -16,6 +16,8 @@ class Sales extends Secure_Controller
 		$this->load->library('barcode_lib');
 		$this->load->library('email_lib');
 		$this->load->library('token_lib');
+		$this->load->library('events');
+		$this->load->event('integrations');
 	}
 
 	public function index()
@@ -804,6 +806,13 @@ class Sales extends Secure_Controller
 				$data['barcode'] = $this->barcode_lib->generate_receipt_barcode($data['sale_id']);
 				$this->load->view('sales/receipt', $data);
 				$this->sale_lib->clear_all();
+
+				$event_failures &= Events::Trigger('event_update',$data,'string');
+				
+				if($event_failures)
+				{
+					log_message("ERROR","Third-Party Integration failed during item sale: $event_failures");
+				}
 			}
 		}
 	}

--- a/application/controllers/Sales.php
+++ b/application/controllers/Sales.php
@@ -807,7 +807,7 @@ class Sales extends Secure_Controller
 				$this->load->view('sales/receipt', $data);
 				$this->sale_lib->clear_all();
 
-				$event_failures &= Events::Trigger('event_update',$data,'string');
+				$event_failures = Events::Trigger('event_update', array("type"=> "SALES", "data" => $data), 'string');
 				
 				if($event_failures)
 				{

--- a/application/controllers/Sales.php
+++ b/application/controllers/Sales.php
@@ -807,12 +807,7 @@ class Sales extends Secure_Controller
 				$this->load->view('sales/receipt', $data);
 				$this->sale_lib->clear_all();
 
-				$event_failures = Events::Trigger('event_update', array("type"=> "SALES", "data" => $data), 'string');
-				
-				if($event_failures)
-				{
-					log_message("ERROR","Third-Party Integration failed during item sale: $event_failures");
-				}
+				Events::Trigger('event_update', array("type"=> "SALES", "data" => $data), 'string');
 			}
 		}
 	}

--- a/application/controllers/Suppliers.php
+++ b/application/controllers/Suppliers.php
@@ -133,7 +133,7 @@ class Suppliers extends Persons
 			    echo json_encode(array('success' => TRUE,
 			        'message' => $this->lang->line('suppliers_successful_adding') . ' ' . $supplier_data['company_name'],
 			        'id' => $supplier_data['person_id']));
-			    $event_failures = Events::Trigger('event_create', array("type"=> "SUPPLIERS", "data" => $supplier_data), 'string');
+			    Events::Trigger('event_create', array("type"=> "SUPPLIERS", "data" => $supplier_data), 'string');
 			}
 		//Existing supplier
 			else
@@ -141,12 +141,7 @@ class Suppliers extends Persons
 			    echo json_encode(array('success' => TRUE,
 			        'message' => $this->lang->line('suppliers_successful_updating') . ' ' . $supplier_data['company_name'],
 			        'id' => $supplier_id));
-			    $event_failures = Events::Trigger('event_update', array("type"=> "SUPPLIERS", "data" => $supplier_data), 'string');
-			}
-			
-			if($event_failures)
-			{
-			    log_message("ERROR","Third-Party Integration failed during Supplier create or update: $event_failures");
+			    Events::Trigger('event_update', array("type"=> "SUPPLIERS", "data" => $supplier_data), 'string');
 			}
 		}
 	//Failure
@@ -173,12 +168,7 @@ class Suppliers extends Persons
 							count($suppliers_to_delete).' '.$this->lang->line('suppliers_one_or_multiple')));
 
 		//Event triggers for Third-Party Integrations
-			$event_failures = Events::Trigger('event_delete', array("type"=> "SUPPLIERS", "data" => $suppliers_to_delete), 'string');
-			
-			if($event_failures)
-			{
-			    log_message("ERROR","Third-Party Integration failed during Customer delete: $event_failures");
-			}
+			Events::Trigger('event_delete', array("type"=> "SUPPLIERS", "data" => $suppliers_to_delete), 'string');
 		}
 		else
 		{

--- a/application/core/MY_Loader.php
+++ b/application/core/MY_Loader.php
@@ -1,0 +1,165 @@
+<?php
+
+(defined('BASEPATH')) OR exit('No direct script access allowed');
+
+class MY_Loader extends CI_Loader {
+
+    protected $_ci_events_paths = array();
+
+    public function __construct() {
+        parent::__construct();
+
+        $this->_ci_events_paths = array(APPPATH);
+        log_message('debug', "MY_Loader Class Initialized");
+    }
+
+    /** Load a events module * */
+    public function event($event = '', $params = NULL, $object_name = NULL)
+    {
+        if (is_array($event))
+        {
+            foreach ($event as $class)
+            {
+                $this->library($class, $params);
+            }
+
+            return;
+        }
+
+        if ($event == '' OR isset($this->_base_classes[$event]))
+        {
+            return FALSE;
+        }
+
+        if ( ! is_null($params) && ! is_array($params))
+        {
+            $params = NULL;
+        }
+
+        $this->_ci_events_class($event, $params, $object_name);
+    }
+
+    /** Load an array of events * */
+    public function events($event = '', $params = NULL, $object_name = NULL)
+    {
+        if (is_array($event))
+        {
+            foreach ($event as $class)
+            {
+                $this->library($class, $params);
+            }
+        }
+        return;
+    }
+
+    /**
+     * Load Events
+     *
+     * This function loads the requested class.
+     *
+     * @param	string	the item that is being loaded
+     * @param	mixed	any additional parameters
+     * @param	string	an optional object name
+     * @return	void
+     */
+    protected function _ci_events_class($class, $params = NULL, $object_name = NULL) {
+        // Get the class name, and while we're at it trim any slashes.
+        // The directory path can be included as part of the class name,
+        // but we don't want a leading slash
+        $class = str_replace('.php', '', trim($class, '/'));
+
+        // Was the path included with the class name?
+        // We look for a slash to determine this
+        $subdir = '';
+        if (($last_slash = strrpos($class, '/')) !== FALSE) {
+            // Extract the path
+            $subdir = substr($class, 0, $last_slash + 1);
+
+            // Get the filename from the path
+            $class = substr($class, $last_slash + 1);
+        }
+
+        // We'll test for both lowercase and capitalized versions of the file name
+        foreach (array(ucfirst($class), strtolower($class)) as $class) {
+            $subclass = APPPATH . 'events/' . $subdir . config_item('subclass_prefix') . $class . '.php';
+
+            // Is this a class extension request?
+            if (file_exists($subclass)) {
+                $baseclass = BASEPATH . 'events/' . ucfirst($class) . '.php';
+
+                if (!file_exists($baseclass)) {
+                    log_message('error', "Unable to load the requested class: " . $class);
+                    show_error("Unable to load the requested class: " . $class);
+                }
+
+                // Safety:  Was the class already loaded by a previous call?
+                if (in_array($subclass, $this->_ci_library_paths)) {
+                    // Before we deem this to be a duplicate request, let's see
+                    // if a custom object name is being supplied.  If so, we'll
+                    // return a new instance of the object
+                    if (!is_null($object_name)) {
+                        $CI = & get_instance();
+                        if (!isset($CI->$object_name)) {
+                            return $this->_ci_init_library($class, config_item('subclass_prefix'), $params, $object_name);
+                        }
+                    }
+
+                    $is_duplicate = TRUE;
+                    log_message('debug', $class . " class already loaded. Second attempt ignored.");
+                    return;
+                }
+
+                include_once($baseclass);
+                include_once($subclass);
+                $this->_ci_library_paths[] = $subclass;
+
+                return $this->_ci_init_library($class, config_item('subclass_prefix'), $params, $object_name);
+            }
+
+            // Lets search for the requested library file and load it.
+            $is_duplicate = FALSE;
+            foreach ($this->_ci_events_paths as $path) {
+                $filepath = $path . 'events/' . $subdir . $class . '.php';
+
+                // Does the file exist?  No?  Bummer...
+                if (!file_exists($filepath)) {
+                    continue;
+                }
+
+                // Safety:  Was the class already loaded by a previous call?
+                if (in_array($filepath, $this->_ci_library_paths)) {
+                    // Before we deem this to be a duplicate request, let's see
+                    // if a custom object name is being supplied.  If so, we'll
+                    // return a new instance of the object
+                    if (!is_null($object_name)) {
+                        $CI = & get_instance();
+                        if (!isset($CI->$object_name)) {
+                            return $this->_ci_init_library($class, '', $params, $object_name);
+                        }
+                    }
+
+                    $is_duplicate = TRUE;
+                    log_message('debug', $class . " class already loaded. Second attempt ignored.");
+                    return;
+                }
+
+                include_once($filepath);
+                $this->_ci_library_paths[] = $filepath;
+                return $this->_ci_init_library($class, '', $params, $object_name);
+            }
+        } // END FOREACH
+        // One last attempt.  Maybe the library is in a subdirectory, but it wasn't specified?
+        if ($subdir == '') {
+            $path = strtolower($class) . '/' . $class;
+            return $this->_ci_load_class($path, $params);
+        }
+
+        // If we got this far we were unable to find the requested class.
+        // We do not issue errors if the load call failed due to a duplicate request
+        if ($is_duplicate == FALSE) {
+            log_message('error', "Unable to load the requested class: " . $class);
+            show_error("Unable to load the requested class: " . $class);
+        }
+    }
+
+}

--- a/application/core/MY_Loader.php
+++ b/application/core/MY_Loader.php
@@ -10,7 +10,6 @@ class MY_Loader extends CI_Loader {
         parent::__construct();
 
         $this->_ci_events_paths = array(APPPATH);
-        log_message('debug', "MY_Loader Class Initialized");
     }
 
     /** Load a events module * */

--- a/application/core/MY_Loader.php
+++ b/application/core/MY_Loader.php
@@ -1,164 +1,179 @@
 <?php
-
 (defined('BASEPATH')) OR exit('No direct script access allowed');
 
-class MY_Loader extends CI_Loader {
+class MY_Loader extends CI_Loader 
+{
+	protected $_ci_events_paths = array();
 
-    protected $_ci_events_paths = array();
+	public function __construct() 
+	{
+		parent::__construct();
 
-    public function __construct() {
-        parent::__construct();
+		$this->_ci_events_paths = array(APPPATH);
+	}
 
-        $this->_ci_events_paths = array(APPPATH);
-    }
+	/** Load a events module * */
+	public function event($event = '', $params = NULL, $object_name = NULL)
+	{
+		if (is_array($event))
+		{
+			foreach ($event as $class)
+			{
+				$this->library($class, $params);
+			}
 
-    /** Load a events module * */
-    public function event($event = '', $params = NULL, $object_name = NULL)
-    {
-        if (is_array($event))
-        {
-            foreach ($event as $class)
-            {
-                $this->library($class, $params);
-            }
+			return;
+		}
 
-            return;
-        }
+		if ($event == '' OR isset($this->_base_classes[$event]))
+		{
+			return FALSE;
+		}
 
-        if ($event == '' OR isset($this->_base_classes[$event]))
-        {
-            return FALSE;
-        }
+		if ( ! is_null($params) && ! is_array($params))
+		{
+			$params = NULL;
+		}
 
-        if ( ! is_null($params) && ! is_array($params))
-        {
-            $params = NULL;
-        }
+		$this->_ci_events_class($event, $params, $object_name);
+	}
 
-        $this->_ci_events_class($event, $params, $object_name);
-    }
+	/** Load an array of events * */
+	public function events($event = '', $params = NULL, $object_name = NULL)
+	{
+		if (is_array($event))
+		{
+			foreach ($event as $class)
+			{
+				$this->library($class, $params);
+			}
+		}
+		return;
+	}
 
-    /** Load an array of events * */
-    public function events($event = '', $params = NULL, $object_name = NULL)
-    {
-        if (is_array($event))
-        {
-            foreach ($event as $class)
-            {
-                $this->library($class, $params);
-            }
-        }
-        return;
-    }
+	/**
+	 * Load Events
+	 *
+	 * This function loads the requested class.
+	 *
+	 * @param	string	the item that is being loaded
+	 * @param	mixed	any additional parameters
+	 * @param	string	an optional object name
+	 * @return	void
+	 */
+	protected function _ci_events_class($class, $params = NULL, $object_name = NULL) 
+	{
+		// Get the class name, and while we're at it trim any slashes.
+		// The directory path can be included as part of the class name,
+		// but we don't want a leading slash
+		$class = str_replace('.php', '', trim($class, '/'));
 
-    /**
-     * Load Events
-     *
-     * This function loads the requested class.
-     *
-     * @param	string	the item that is being loaded
-     * @param	mixed	any additional parameters
-     * @param	string	an optional object name
-     * @return	void
-     */
-    protected function _ci_events_class($class, $params = NULL, $object_name = NULL) {
-        // Get the class name, and while we're at it trim any slashes.
-        // The directory path can be included as part of the class name,
-        // but we don't want a leading slash
-        $class = str_replace('.php', '', trim($class, '/'));
+		// Was the path included with the class name?
+		// We look for a slash to determine this
+		$subdir = '';
+		if (($last_slash = strrpos($class, '/')) !== FALSE) 
+		{
+			// Extract the path
+			$subdir = substr($class, 0, $last_slash + 1);
 
-        // Was the path included with the class name?
-        // We look for a slash to determine this
-        $subdir = '';
-        if (($last_slash = strrpos($class, '/')) !== FALSE) {
-            // Extract the path
-            $subdir = substr($class, 0, $last_slash + 1);
+			// Get the filename from the path
+			$class = substr($class, $last_slash + 1);
+		}
 
-            // Get the filename from the path
-            $class = substr($class, $last_slash + 1);
-        }
+		// We'll test for both lowercase and capitalized versions of the file name
+		foreach (array(ucfirst($class), strtolower($class)) as $class) 
+		{
+			$subclass = APPPATH . 'events/' . $subdir . config_item('subclass_prefix') . $class . '.php';
 
-        // We'll test for both lowercase and capitalized versions of the file name
-        foreach (array(ucfirst($class), strtolower($class)) as $class) {
-            $subclass = APPPATH . 'events/' . $subdir . config_item('subclass_prefix') . $class . '.php';
+			// Is this a class extension request?
+			if (file_exists($subclass)) 
+			{
+				$baseclass = BASEPATH . 'events/' . ucfirst($class) . '.php';
 
-            // Is this a class extension request?
-            if (file_exists($subclass)) {
-                $baseclass = BASEPATH . 'events/' . ucfirst($class) . '.php';
+				if (!file_exists($baseclass)) 
+				{
+					log_message('error', "Unable to load the requested class: " . $class);
+					show_error("Unable to load the requested class: " . $class);
+				}
 
-                if (!file_exists($baseclass)) {
-                    log_message('error', "Unable to load the requested class: " . $class);
-                    show_error("Unable to load the requested class: " . $class);
-                }
+				// Safety:  Was the class already loaded by a previous call?
+				if (in_array($subclass, $this->_ci_library_paths)) 
+				{
+					// Before we deem this to be a duplicate request, let's see
+					// if a custom object name is being supplied.  If so, we'll
+					// return a new instance of the object
+					if (!is_null($object_name)) 
+					{
+						$CI = & get_instance();
+						if (!isset($CI->$object_name)) 
+						{
+							return $this->_ci_init_library($class, config_item('subclass_prefix'), $params, $object_name);
+						}
+					}
 
-                // Safety:  Was the class already loaded by a previous call?
-                if (in_array($subclass, $this->_ci_library_paths)) {
-                    // Before we deem this to be a duplicate request, let's see
-                    // if a custom object name is being supplied.  If so, we'll
-                    // return a new instance of the object
-                    if (!is_null($object_name)) {
-                        $CI = & get_instance();
-                        if (!isset($CI->$object_name)) {
-                            return $this->_ci_init_library($class, config_item('subclass_prefix'), $params, $object_name);
-                        }
-                    }
+					$is_duplicate = TRUE;
+					log_message('debug', $class . " class already loaded. Second attempt ignored.");
+					return;
+				}
 
-                    $is_duplicate = TRUE;
-                    log_message('debug', $class . " class already loaded. Second attempt ignored.");
-                    return;
-                }
+				include_once($baseclass);
+				include_once($subclass);
+				$this->_ci_library_paths[] = $subclass;
 
-                include_once($baseclass);
-                include_once($subclass);
-                $this->_ci_library_paths[] = $subclass;
+				return $this->_ci_init_library($class, config_item('subclass_prefix'), $params, $object_name);
+			}
 
-                return $this->_ci_init_library($class, config_item('subclass_prefix'), $params, $object_name);
-            }
+		// Lets search for the requested library file and load it.
+			$is_duplicate = FALSE;
+			foreach ($this->_ci_events_paths as $path) 
+			{
+				$filepath = $path . 'events/' . $subdir . $class . '.php';
 
-            // Lets search for the requested library file and load it.
-            $is_duplicate = FALSE;
-            foreach ($this->_ci_events_paths as $path) {
-                $filepath = $path . 'events/' . $subdir . $class . '.php';
+				// Does the file exist?  No?  Bummer...
+				if (!file_exists($filepath)) 
+				{
+					continue;
+				}
 
-                // Does the file exist?  No?  Bummer...
-                if (!file_exists($filepath)) {
-                    continue;
-                }
+				// Safety:  Was the class already loaded by a previous call?
+				if (in_array($filepath, $this->_ci_library_paths)) 
+				{
+					// Before we deem this to be a duplicate request, let's see
+					// if a custom object name is being supplied.  If so, we'll
+					// return a new instance of the object
+					if (!is_null($object_name)) 
+					{
+						$CI = & get_instance();
+						if (!isset($CI->$object_name)) 
+						{
+							return $this->_ci_init_library($class, '', $params, $object_name);
+						}
+					}
 
-                // Safety:  Was the class already loaded by a previous call?
-                if (in_array($filepath, $this->_ci_library_paths)) {
-                    // Before we deem this to be a duplicate request, let's see
-                    // if a custom object name is being supplied.  If so, we'll
-                    // return a new instance of the object
-                    if (!is_null($object_name)) {
-                        $CI = & get_instance();
-                        if (!isset($CI->$object_name)) {
-                            return $this->_ci_init_library($class, '', $params, $object_name);
-                        }
-                    }
+					$is_duplicate = TRUE;
+					log_message('debug', $class . " class already loaded. Second attempt ignored.");
+					return;
+				}
 
-                    $is_duplicate = TRUE;
-                    log_message('debug', $class . " class already loaded. Second attempt ignored.");
-                    return;
-                }
+				include_once($filepath);
+				$this->_ci_library_paths[] = $filepath;
+				return $this->_ci_init_library($class, '', $params, $object_name);
+			}
+		} // END FOREACH
+	
+	// One last attempt.  Maybe the library is in a subdirectory, but it wasn't specified?
+		if ($subdir == '') 
+		{
+			$path = strtolower($class) . '/' . $class;
+			return $this->_ci_load_class($path, $params);
+		}
 
-                include_once($filepath);
-                $this->_ci_library_paths[] = $filepath;
-                return $this->_ci_init_library($class, '', $params, $object_name);
-            }
-        } // END FOREACH
-        // One last attempt.  Maybe the library is in a subdirectory, but it wasn't specified?
-        if ($subdir == '') {
-            $path = strtolower($class) . '/' . $class;
-            return $this->_ci_load_class($path, $params);
-        }
-
-        // If we got this far we were unable to find the requested class.
-        // We do not issue errors if the load call failed due to a duplicate request
-        if ($is_duplicate == FALSE) {
-            log_message('error', "Unable to load the requested class: " . $class);
-            show_error("Unable to load the requested class: " . $class);
-        }
-    }
-
+		// If we got this far we were unable to find the requested class.
+		// We do not issue errors if the load call failed due to a duplicate request
+		if ($is_duplicate == FALSE) 
+		{
+			log_message('error', "Unable to load the requested class: " . $class);
+			show_error("Unable to load the requested class: " . $class);
+		}
+	}
 }

--- a/application/events/Integrations.php
+++ b/application/events/Integrations.php
@@ -12,96 +12,75 @@
  */
 class Integrations
 {
-	/**
-	 *	Registers listeners to be kicked off on trigger
-	 */
-	public function __construct()
-	{
-		Events::register('event_create', array($this,'integrations_create'));
-		Events::register('event_read', array($this,'integrations_read'));
-		Events::register('event_update', array($this,'integrations_update'));
-		Events::register('event_delete', array($this,'integrations_delete'));
-	}
-	
-	/**
-	 * Event trigger for integrations on Create CRUD operation
-	 *
-	 * @param	array		$data	Data to be made available to Third Party Integrations
-	 * @return	string|NULL			NULL is returned on a successful completion of integration tasks or the integration and failure message
-	 */
-	public function integrations_create($data)
-	{
-		$negative_results = NULL;
-		ob_start();
-		var_dump($data);
-		$dump = ob_get_contents();
-		ob_end_clean();
-		log_message("ERROR","event created for integrations create: ". $dump);
-		//calls to create functions for the different Integrations
-		
-		return $negative_results;
-	}
-	
-	/**
-	 * Event trigger for integrations on Read CRUD operation
-	 *
-	 * @param 	array		$data	Data to be made available to Third Party Integrations
-	 * @return	string|NULL			NULL is returned on a successful completion of integration tasks or the integration and failure message
-	 */
-	public function integrations_read($data)
-	{
-		$negative_results = NULL;
-		ob_start();
-		var_dump($data);
-		$dump = ob_get_contents();
-		ob_end_clean();
-		log_message("ERROR","event created for integrations read: ". $dump);
-		//calls to read functions for the different Integrations
-		
-		return $negative_results;
-	}
-	
-	/**
-	 * Event trigger for integrations on Create CRUD operation
-	 *
-	 * @param 	array		$data	Data to be made available to Third Party Integrations
-	 * @return	string|NULL			NULL is returned on a successful completion of integration tasks or the integration and failure message
-	 */
-	public function integrations_update($data)
-	{
-		$negative_results = NULL;
-		ob_start();
-		var_dump($data);
-		$dump = ob_get_contents();
-		ob_end_clean();
-		
-		log_message("ERROR","event created for integrations update: ". $dump);
-		//calls to update functions for the different Integrations
-		
-		return $negative_results;
-	}
-	
-	/**
-	 * Event trigger for integrations on Create CRUD operation
-	 *
-	 * @param 	array		$data	Data to be made available to Third Party Integrations
-	 * @return	string|NULL			NULL is returned on a successful completion of integration tasks or the integration and failure message
-	 */
-	public function integrations_delete($data)
-	{
-		$negative_results = NULL;
-		ob_start();
-		var_dump($data);
-		$dump = ob_get_contents();
-		ob_end_clean();
-		
-		log_message("ERROR","event created for integrations delete: ". $dump);
-		//calls to delete functions for the different Integrations
-		
-		return $negative_results;
-	}
-	
-/**
- * ALL THIRD-PARTY INTEGRATION-SPECIFIC FUNCTIONS SHOULD BE GROUPED BELOW THIS LINE AND CALLED IN THE FUNCTIONS ABOVE
- */	
+    /**
+     *	Registers listeners to be kicked off on trigger
+     */
+    public function __construct()
+    {
+        Events::register('event_create', array($this,'integrations_create'));
+        Events::register('event_read', array($this,'integrations_read'));
+        Events::register('event_update', array($this,'integrations_update'));
+        Events::register('event_delete', array($this,'integrations_delete'));
+    }
+    
+    /**
+     * Event trigger for integrations on Create CRUD operation
+     *
+     * @param	array		$data	Data to be made available to Third Party Integrations separated into "type" which is the type of data being sent (ITEMS, ITEM_KITS, CUSTOMERS, SUPPLIERS and GIFTCARDS) and "data"
+     * @return	string|NULL			NULL is returned on a successful completion of integration tasks or the integration and failure message
+     */
+    public function integrations_create($data)
+    {
+        $negative_results = NULL;
+        //calls to create functions for the different Integrations
+        
+        return $negative_results;
+    }
+    
+    /**
+     * Event trigger for integrations on Read CRUD operation
+     *
+     * @param	array		$data	Data to be made available to Third Party Integrations separated into "type" which is the type of data being sent (ITEMS, ITEM_KITS, CUSTOMERS, SUPPLIERS, GIFTCARDS, RECEIVINGS, and SALES) and "data"
+     * @return	string|NULL			NULL is returned on a successful completion of integration tasks or the integration and failure message
+     */
+    public function integrations_read($data)
+    {
+        //Currently no triggers are established for Read operations.  It's unclear whether we will use these in integrations
+        $negative_results = NULL;
+        //calls to read functions for the different Integrations
+        
+        return $negative_results;
+    }
+    
+    /**
+     * Event trigger for integrations on Update CRUD operation
+     *
+     * @param	array		$data	Data to be made available to Third Party Integrations separated into "type" which is the type of data being sent (ITEMS, ITEM_KITS, CUSTOMERS, SUPPLIERS, GIFTCARDS, RECEIVINGS, and SALES) and "data"
+     * @return	string|NULL			NULL is returned on a successful completion of integration tasks or the integration and failure message
+     */
+    public function integrations_update($data)
+    {
+        $negative_results = NULL;
+        //calls to update functions for the different Integrations
+        
+        return $negative_results;
+    }
+    
+    /**
+     * Event trigger for integrations on Delete CRUD operation
+     *
+     * @param	array		$data	Data to be made available to Third Party Integrations separated into "type" which is the type of data being sent (ITEMS, ITEM_KITS, CUSTOMERS, SUPPLIERS and GIFTCARDS) and "data"
+     * @return	string|NULL			NULL is returned on a successful completion of integration tasks or the integration and failure message
+     */
+    public function integrations_delete($data)
+    {
+        $negative_results = NULL;
+        //calls to delete functions for the different Integrations
+        
+        return $negative_results;
+    }
+    
+    /**
+     * ALL THIRD-PARTY INTEGRATION-SPECIFIC FUNCTIONS SHOULD BE GROUPED BELOW THIS LINE AND CALLED IN THE FUNCTIONS ABOVE
+     */
 }

--- a/application/events/Integrations.php
+++ b/application/events/Integrations.php
@@ -1,0 +1,107 @@
+<?php defined('BASEPATH') or exit('No direct script access allowed');
+/**
+ * Integrations
+ *
+ * This Class contains all functions pertaining to Third-Party Integrations
+ *
+ * @package		CodeIgniter
+ */
+
+/**
+ * Integrations Library
+ */
+class Integrations
+{
+	/**
+	 *	Registers listeners to be kicked off on trigger
+	 */
+	public function __construct()
+	{
+		Events::register('event_create', array($this,'integrations_create'));
+		Events::register('event_read', array($this,'integrations_read'));
+		Events::register('event_update', array($this,'integrations_update'));
+		Events::register('event_delete', array($this,'integrations_delete'));
+	}
+	
+	/**
+	 * Event trigger for integrations on Create CRUD operation
+	 *
+	 * @param	array		$data	Data to be made available to Third Party Integrations
+	 * @return	string|NULL			NULL is returned on a successful completion of integration tasks or the integration and failure message
+	 */
+	public function integrations_create($data)
+	{
+		$negative_results = NULL;
+		ob_start();
+		var_dump($data);
+		$dump = ob_get_contents();
+		ob_end_clean();
+		log_message("ERROR","event created for integrations create: ". $dump);
+		//calls to create functions for the different Integrations
+		
+		return $negative_results;
+	}
+	
+	/**
+	 * Event trigger for integrations on Read CRUD operation
+	 *
+	 * @param 	array		$data	Data to be made available to Third Party Integrations
+	 * @return	string|NULL			NULL is returned on a successful completion of integration tasks or the integration and failure message
+	 */
+	public function integrations_read($data)
+	{
+		$negative_results = NULL;
+		ob_start();
+		var_dump($data);
+		$dump = ob_get_contents();
+		ob_end_clean();
+		log_message("ERROR","event created for integrations read: ". $dump);
+		//calls to read functions for the different Integrations
+		
+		return $negative_results;
+	}
+	
+	/**
+	 * Event trigger for integrations on Create CRUD operation
+	 *
+	 * @param 	array		$data	Data to be made available to Third Party Integrations
+	 * @return	string|NULL			NULL is returned on a successful completion of integration tasks or the integration and failure message
+	 */
+	public function integrations_update($data)
+	{
+		$negative_results = NULL;
+		ob_start();
+		var_dump($data);
+		$dump = ob_get_contents();
+		ob_end_clean();
+		
+		log_message("ERROR","event created for integrations update: ". $dump);
+		//calls to update functions for the different Integrations
+		
+		return $negative_results;
+	}
+	
+	/**
+	 * Event trigger for integrations on Create CRUD operation
+	 *
+	 * @param 	array		$data	Data to be made available to Third Party Integrations
+	 * @return	string|NULL			NULL is returned on a successful completion of integration tasks or the integration and failure message
+	 */
+	public function integrations_delete($data)
+	{
+		$negative_results = NULL;
+		ob_start();
+		var_dump($data);
+		$dump = ob_get_contents();
+		ob_end_clean();
+		
+		log_message("ERROR","event created for integrations delete: ". $dump);
+		//calls to delete functions for the different Integrations
+		
+		return $negative_results;
+	}
+	
+/**
+ * ALL THIRD-PARTY INTEGRATION-SPECIFIC FUNCTIONS SHOULD BE GROUPED BELOW THIS LINE AND CALLED IN THE FUNCTIONS ABOVE
+ */	
+}

--- a/application/events/Integrations.php
+++ b/application/events/Integrations.php
@@ -12,75 +12,157 @@
  */
 class Integrations
 {
-    /**
-     *	Registers listeners to be kicked off on trigger
-     */
-    public function __construct()
-    {
-        Events::register('event_create', array($this,'integrations_create'));
-        Events::register('event_read', array($this,'integrations_read'));
-        Events::register('event_update', array($this,'integrations_update'));
-        Events::register('event_delete', array($this,'integrations_delete'));
-    }
-    
-    /**
-     * Event trigger for integrations on Create CRUD operation
-     *
-     * @param	array		$data	Data to be made available to Third Party Integrations separated into "type" which is the type of data being sent (ITEMS, ITEM_KITS, CUSTOMERS, SUPPLIERS and GIFTCARDS) and "data"
-     * @return	string|NULL			NULL is returned on a successful completion of integration tasks or the integration and failure message
-     */
-    public function integrations_create($data)
-    {
-        $negative_results = NULL;
-        //calls to create functions for the different Integrations
-        
-        return $negative_results;
-    }
-    
-    /**
-     * Event trigger for integrations on Read CRUD operation
-     *
-     * @param	array		$data	Data to be made available to Third Party Integrations separated into "type" which is the type of data being sent (ITEMS, ITEM_KITS, CUSTOMERS, SUPPLIERS, GIFTCARDS, RECEIVINGS, and SALES) and "data"
-     * @return	string|NULL			NULL is returned on a successful completion of integration tasks or the integration and failure message
-     */
-    public function integrations_read($data)
-    {
-        //Currently no triggers are established for Read operations.  It's unclear whether we will use these in integrations
-        $negative_results = NULL;
-        //calls to read functions for the different Integrations
-        
-        return $negative_results;
-    }
-    
-    /**
-     * Event trigger for integrations on Update CRUD operation
-     *
-     * @param	array		$data	Data to be made available to Third Party Integrations separated into "type" which is the type of data being sent (ITEMS, ITEM_KITS, CUSTOMERS, SUPPLIERS, GIFTCARDS, RECEIVINGS, and SALES) and "data"
-     * @return	string|NULL			NULL is returned on a successful completion of integration tasks or the integration and failure message
-     */
-    public function integrations_update($data)
-    {
-        $negative_results = NULL;
-        //calls to update functions for the different Integrations
-        
-        return $negative_results;
-    }
-    
-    /**
-     * Event trigger for integrations on Delete CRUD operation
-     *
-     * @param	array		$data	Data to be made available to Third Party Integrations separated into "type" which is the type of data being sent (ITEMS, ITEM_KITS, CUSTOMERS, SUPPLIERS and GIFTCARDS) and "data"
-     * @return	string|NULL			NULL is returned on a successful completion of integration tasks or the integration and failure message
-     */
-    public function integrations_delete($data)
-    {
-        $negative_results = NULL;
-        //calls to delete functions for the different Integrations
-        
-        return $negative_results;
-    }
-    
-    /**
-     * ALL THIRD-PARTY INTEGRATION-SPECIFIC FUNCTIONS SHOULD BE GROUPED BELOW THIS LINE AND CALLED IN THE FUNCTIONS ABOVE
-     */
+	private $CI;
+	
+	/**
+	 *	Registers listeners to be kicked off on trigger
+	 */
+	public function __construct()
+	{
+		//Third-Party Integrations by adding all code related to the integration into a library and referencing the library here with $this->ci->load->library();
+		$this->CI =& get_instance();
+		//$this->CI->load->library('LIB_NAME_HERE');
+		
+		Events::register('event_create', array($this,'integrations_create'));
+		Events::register('event_read', array($this,'integrations_read'));
+		Events::register('event_update', array($this,'integrations_update'));
+		Events::register('event_delete', array($this,'integrations_delete'));
+	}
+	
+	/**
+	 * Event trigger for integrations on Create CRUD operation
+	 *
+	 * @param	array		$data	Data to be made available to Third Party Integrations separated into "type" which is the type of data being sent (ITEMS, ITEM_KITS, CUSTOMERS, SUPPLIERS and GIFTCARDS) and "data"
+	 * @return	string|NULL			NULL is returned on a successful completion of integration tasks or the integration and failure message
+	 */
+	public function integrations_create(array $data)
+	{
+		$results = NULL;
+		
+		//calls to create functions for the different Integrations
+		switch($data['type'])
+		{
+			case 'ITEMS':
+				//$results = $this->CI->LIB_NAME->METHOD_NAME();
+				break;
+				
+			case 'ITEM_KITS':
+				break;
+				
+			case 'CUSTOMERS':
+				break;
+				
+			case 'SUPPLIERS':
+				break;
+				
+			case 'GIFTCARDS':
+				break;
+				
+			default:
+				$results = 'Improper integrations create type';
+				break;
+		}
+		
+		return $results;
+	}
+	
+	/**
+	 * Event trigger for integrations on Read CRUD operation
+	 *
+	 * @param	array		$data	Data to be made available to Third Party Integrations separated into "type" which is the type of data being sent (ITEMS, ITEM_KITS, CUSTOMERS, SUPPLIERS, GIFTCARDS, RECEIVINGS, and SALES) and "data"
+	 * @return	string|NULL			NULL is returned on a successful completion of integration tasks or the integration and failure message
+	 */
+	public function integrations_read(array $data)
+	{
+		//Currently no triggers are established for Read operations.  It's unclear whether we will use these in integrations
+		$results = NULL;
+		
+		//calls to read functions for the different Integrations
+		switch($data['type'])
+		{
+			default:
+				$results = 'Improper integrations read type';
+				break;
+		}
+		
+		return $results;
+	}
+	
+	/**
+	 * Event trigger for integrations on Update CRUD operation
+	 *
+	 * @param	array		$data	Data to be made available to Third Party Integrations separated into "type" which is the type of data being sent (ITEMS, ITEM_KITS, CUSTOMERS, SUPPLIERS, GIFTCARDS, RECEIVINGS, and SALES) and "data"
+	 * @return	string|NULL			NULL is returned on a successful completion of integration tasks or the integration and failure message
+	 */
+	public function integrations_update(array $data)
+	{
+		$results = NULL;
+		
+		//calls to update functions for the different Integrations
+		switch($data['type'])
+		{
+			case 'ITEMS':
+				break;
+				
+			case 'ITEM_KITS':
+				break;
+				
+			case 'CUSTOMERS':
+				break;
+				
+			case 'SUPPLIERS':
+				break;
+				
+			case 'RECEIVINGS':
+				break;
+				
+			case 'SALES':
+				break;
+				
+			case 'GIFTCARDS':
+				break;
+				
+			default:
+				$results = 'Improper integrations update type.';
+				break;
+		}
+		
+		return $results;
+	}
+	
+	/**
+	 * Event trigger for integrations on Delete CRUD operation
+	 *
+	 * @param	array		$data	Data to be made available to Third Party Integrations separated into "type" which is the type of data being sent (ITEMS, ITEM_KITS, CUSTOMERS, SUPPLIERS and GIFTCARDS) and "data"
+	 * @return	string|NULL			NULL is returned on a successful completion of integration tasks or the integration and failure message
+	 */
+	public function integrations_delete(array $data)
+	{
+		$results = NULL;
+		
+		//calls to delete functions for the different Integrations
+		switch($data['type'])
+		{
+			case 'ITEMS':
+				break;
+				
+			case 'ITEM_KITS':
+				break;
+				
+			case 'CUSTOMERS':
+				break;
+				
+			case 'SUPPLIERS':
+				break;
+				
+			case 'GIFTCARDS':
+				break;
+				
+			default:
+				$results = 'Improper integrations delete type.';
+				break;
+		}
+		
+		return $results;
+	}
 }

--- a/application/events/Integrations.php
+++ b/application/events/Integrations.php
@@ -13,7 +13,7 @@
 class Integrations
 {
 	private $CI;
-	
+
 	/**
 	 *	Registers listeners to be kicked off on trigger
 	 */
@@ -21,14 +21,14 @@ class Integrations
 	{
 		//Third-Party Integrations by adding all code related to the integration into a library and referencing the library here with $this->ci->load->library();
 		$this->CI =& get_instance();
-		//$this->CI->load->library('LIB_NAME_HERE');
-		
+		$this->CI->load->library('clcdesq_integration_lib');
+
 		Events::register('event_create', array($this,'integrations_create'));
 		Events::register('event_read', array($this,'integrations_read'));
 		Events::register('event_update', array($this,'integrations_update'));
 		Events::register('event_delete', array($this,'integrations_delete'));
 	}
-	
+
 	/**
 	 * Event trigger for integrations on Create CRUD operation
 	 *
@@ -38,34 +38,37 @@ class Integrations
 	public function integrations_create(array $data)
 	{
 		$results = NULL;
-		
+
 		//calls to create functions for the different Integrations
 		switch($data['type'])
 		{
 			case 'ITEMS':
-				//$results = $this->CI->LIB_NAME->METHOD_NAME();
+				$failure = $this->CI->clcdesq_integration_lib->new_product_push($data['data']);
 				break;
-				
+
 			case 'ITEM_KITS':
 				break;
-				
+
 			case 'CUSTOMERS':
 				break;
-				
+
 			case 'SUPPLIERS':
 				break;
-				
+
 			case 'GIFTCARDS':
 				break;
-				
+
 			default:
-				$results = 'Improper integrations create type';
+				$failure = 'Improper integrations create type';
 				break;
 		}
-		
-		return $results;
+
+		if($failure)
+		{
+		    log_message("ERROR",'Third-Party Integration failed during '. $data['type'] ."create: $event_failures");
+		}
 	}
-	
+
 	/**
 	 * Event trigger for integrations on Read CRUD operation
 	 *
@@ -76,7 +79,7 @@ class Integrations
 	{
 		//Currently no triggers are established for Read operations.  It's unclear whether we will use these in integrations
 		$results = NULL;
-		
+
 		//calls to read functions for the different Integrations
 		switch($data['type'])
 		{
@@ -84,10 +87,13 @@ class Integrations
 				$results = 'Improper integrations read type';
 				break;
 		}
-		
-		return $results;
+
+		if($failure)
+		{
+		    log_message("ERROR",'Third-Party Integration failed during '. $data['type'] ."read: $event_failures");
+		}
 	}
-	
+
 	/**
 	 * Event trigger for integrations on Update CRUD operation
 	 *
@@ -97,39 +103,43 @@ class Integrations
 	public function integrations_update(array $data)
 	{
 		$results = NULL;
-		
+
 		//calls to update functions for the different Integrations
 		switch($data['type'])
 		{
 			case 'ITEMS':
+				$results = $this->CI->clcdesq_integration_lib->update_product_push($data['data']);
 				break;
-				
+
 			case 'ITEM_KITS':
 				break;
-				
+
 			case 'CUSTOMERS':
 				break;
-				
+
 			case 'SUPPLIERS':
 				break;
-				
+
 			case 'RECEIVINGS':
 				break;
-				
+
 			case 'SALES':
 				break;
-				
+
 			case 'GIFTCARDS':
 				break;
-				
+
 			default:
 				$results = 'Improper integrations update type.';
 				break;
 		}
-		
-		return $results;
+
+		if($failure)
+		{
+		    log_message("ERROR",'Third-Party Integration failed during '. $data['type'] ."update: $event_failures");
+		}
 	}
-	
+
 	/**
 	 * Event trigger for integrations on Delete CRUD operation
 	 *
@@ -139,30 +149,34 @@ class Integrations
 	public function integrations_delete(array $data)
 	{
 		$results = NULL;
-		
+
 		//calls to delete functions for the different Integrations
 		switch($data['type'])
 		{
 			case 'ITEMS':
+				$results = $this->CI->clcdesq_integration_lib->delete_product_push($data['data']);
 				break;
-				
+
 			case 'ITEM_KITS':
 				break;
-				
+
 			case 'CUSTOMERS':
 				break;
-				
+
 			case 'SUPPLIERS':
 				break;
-				
+
 			case 'GIFTCARDS':
 				break;
-				
+
 			default:
 				$results = 'Improper integrations delete type.';
 				break;
 		}
-		
-		return $results;
+
+		if($failure)
+		{
+		    log_message("ERROR",'Third-Party Integration failed during '. $data['type'] ."delete: $event_failures");
+		}
 	}
 }

--- a/application/libraries/Events.php
+++ b/application/libraries/Events.php
@@ -49,7 +49,6 @@ class Events
 	{
 		$key = get_class($callback[0]).'::'.$callback[1];
 		self::$_listeners[$event][$key] = $callback;
-		log_message('debug', 'Events::register() - Registered "'.$key.' with event "'.$event.'"');
 	}
 	
 	/**
@@ -71,8 +70,6 @@ class Events
 	 */
 	public static function trigger($event, $data = '', $return_type = 'string')
 	{
-		log_message('debug', 'Events::trigger() - Triggering event "'.$event.'"');
-		
 		$calls = array();
 		
 		if (self::has_listeners($event))
@@ -101,8 +98,6 @@ class Events
 	 */
 	protected static function _format_return(array $calls, $return_type)
 	{
-		log_message('debug', 'Events::_format_return() - Formating calls in type "'.$return_type.'"');
-		
 		switch ($return_type)
 		{
 			case 'json':
@@ -138,72 +133,10 @@ class Events
 	 */
 	public static function has_listeners($event)
 	{
-		log_message('debug', 'Events::has_listeners() - Checking if event "'.$event.'" has listeners.');
-		
 		if (isset(self::$_listeners[$event]) AND count(self::$_listeners[$event]) > 0)
 		{
 			return TRUE;
 		}
 		return FALSE;
-	}
-	
-	/**
-	 * Event trigger for integrations on Create CRUD operation
-	 *
-	 * @param	array		$data	Data to be made available to Third Party Integrations
-	 * @return	string|NULL			NULL is returned on a successful completion of integration tasks or the integration and failure message
-	 */
-	public function integrations_create($data)
-	{
-		$negative_results = NULL;
-		log_message("ERROR","event created for integrations create: ". var_dump($data));
-		//calls to create functions for the different Integrations
-		
-		return $negative_results;
-	}
-	
-	/**
-	 * Event trigger for integrations on Read CRUD operation
-	 *
-	 * @param 	array		$data	Data to be made available to Third Party Integrations
-	 * @return	string|NULL			NULL is returned on a successful completion of integration tasks or the integration and failure message
-	 */
-	public function integrations_read($data)
-	{
-		$negative_results = NULL;
-		log_message("ERROR","event created for integrations read: ". var_dump($data));
-		//calls to read functions for the different Integrations
-		
-		return $negative_results;
-	}
-	
-	/**
-	 * Event trigger for integrations on Create CRUD operation
-	 *
-	 * @param 	array		$data	Data to be made available to Third Party Integrations
-	 * @return	string|NULL			NULL is returned on a successful completion of integration tasks or the integration and failure message
-	 */
-	public function integrations_update($data)
-	{
-		$negative_results = NULL;
-		log_message("ERROR","event created for integrations update: ". var_dump($data));
-		//calls to update functions for the different Integrations
-		$negative_results = "CLCdesq API failed to update item.  Error Code 1232";
-		return $negative_results;
-	}
-	
-	/**
-	 * Event trigger for integrations on Create CRUD operation
-	 *
-	 * @param 	array		$data	Data to be made available to Third Party Integrations
-	 * @return	string|NULL			NULL is returned on a successful completion of integration tasks or the integration and failure message
-	 */
-	public function integrations_delete($data)
-	{
-		$negative_results = NULL;
-		log_message("ERROR","event created for integrations delete: ". var_dump($data));
-		//calls to delete functions for the different Integrations
-		
-		return $negative_results;
 	}
 }

--- a/application/libraries/Events.php
+++ b/application/libraries/Events.php
@@ -133,10 +133,6 @@ class Events
 	 */
 	public static function has_listeners($event)
 	{
-		if (isset(self::$_listeners[$event]) AND count(self::$_listeners[$event]) > 0)
-		{
-			return TRUE;
-		}
-		return FALSE;
+		return isset(self::$_listeners[$event]) AND count(self::$_listeners[$event]) > 0;
 	}
 }

--- a/application/libraries/Events.php
+++ b/application/libraries/Events.php
@@ -28,7 +28,7 @@
 /**
  * Events Library
  */
-class Events 
+class Events
 {
 	/**
 	 * @var	array	An array of listeners

--- a/application/libraries/Events.php
+++ b/application/libraries/Events.php
@@ -1,0 +1,209 @@
+<?php defined('BASEPATH') or exit('No direct script access allowed');
+/**
+ * Events
+ *
+ * A simple events system for CodeIgniter.
+ *
+ * @package		CodeIgniter
+ * @subpackage	Events
+ * @version		1.0
+ * @author		Eric Barnes <http://ericlbarnes.com>
+ * @author		Dan Horrigan <http://dhorrigan.com>
+ * @license		Apache License v2.0
+ * @copyright	2010 Dan Horrigan
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * Events Library
+ */
+class Events 
+{
+	/**
+	 * @var	array	An array of listeners
+	 */
+	protected static $_listeners = array();
+	
+	/**
+	 * Register
+	 *
+	 * Registers a Callback for a given event
+	 *
+	 * @access	public
+	 * @param	string	The name of the event
+	 * @param	array	The callback for the Event
+	 * @return	void
+	 */
+	public static function register($event, array $callback)
+	{
+		$key = get_class($callback[0]).'::'.$callback[1];
+		self::$_listeners[$event][$key] = $callback;
+		log_message('debug', 'Events::register() - Registered "'.$key.' with event "'.$event.'"');
+	}
+	
+	/**
+	 * Trigger
+	 *
+	 * Triggers an event and returns the results.  The results can be returned
+	 * in the following formats:
+	 *
+	 * 'array'
+	 * 'json'
+	 * 'serialized'
+	 * 'string'
+	 *
+	 * @access	public
+	 * @param	string	The name of the event
+	 * @param	mixed	Any data that is to be passed to the listener
+	 * @param	string	The return type
+	 * @return	mixed	The return of the listeners, in the return type
+	 */
+	public static function trigger($event, $data = '', $return_type = 'string')
+	{
+		log_message('debug', 'Events::trigger() - Triggering event "'.$event.'"');
+		
+		$calls = array();
+		
+		if (self::has_listeners($event))
+		{
+			foreach (self::$_listeners[$event] as $listener)
+			{
+				if (is_callable($listener))
+				{
+					$calls[] = call_user_func($listener, $data);
+				}
+			}
+		}
+		
+		return self::_format_return($calls, $return_type);
+	}
+	
+	/**
+	 * Format Return
+	 *
+	 * Formats the return in the given type
+	 *
+	 * @access	protected
+	 * @param	array	The array of returns
+	 * @param	string	The return type
+	 * @return	mixed	The formatted return
+	 */
+	protected static function _format_return(array $calls, $return_type)
+	{
+		log_message('debug', 'Events::_format_return() - Formating calls in type "'.$return_type.'"');
+		
+		switch ($return_type)
+		{
+			case 'json':
+				return json_encode($calls);
+				break;
+			case 'serialized':
+				return serialize($calls);
+				break;
+			case 'string':
+				$str = '';
+				foreach ($calls as $call)
+				{
+					$str .= $call;
+				}
+				return $str;
+				break;
+			default:
+				return $calls;
+				break;
+		}
+		
+		return FALSE;
+	}
+	
+	/**
+	 * Has Listeners
+	 *
+	 * Checks if the event has listeners
+	 *
+	 * @access	public
+	 * @param	string	The name of the event
+	 * @return	bool	Whether the event has listeners
+	 */
+	public static function has_listeners($event)
+	{
+		log_message('debug', 'Events::has_listeners() - Checking if event "'.$event.'" has listeners.');
+		
+		if (isset(self::$_listeners[$event]) AND count(self::$_listeners[$event]) > 0)
+		{
+			return TRUE;
+		}
+		return FALSE;
+	}
+	
+	/**
+	 * Event trigger for integrations on Create CRUD operation
+	 *
+	 * @param	array		$data	Data to be made available to Third Party Integrations
+	 * @return	string|NULL			NULL is returned on a successful completion of integration tasks or the integration and failure message
+	 */
+	public function integrations_create($data)
+	{
+		$negative_results = NULL;
+		log_message("ERROR","event created for integrations create: ". var_dump($data));
+		//calls to create functions for the different Integrations
+		
+		return $negative_results;
+	}
+	
+	/**
+	 * Event trigger for integrations on Read CRUD operation
+	 *
+	 * @param 	array		$data	Data to be made available to Third Party Integrations
+	 * @return	string|NULL			NULL is returned on a successful completion of integration tasks or the integration and failure message
+	 */
+	public function integrations_read($data)
+	{
+		$negative_results = NULL;
+		log_message("ERROR","event created for integrations read: ". var_dump($data));
+		//calls to read functions for the different Integrations
+		
+		return $negative_results;
+	}
+	
+	/**
+	 * Event trigger for integrations on Create CRUD operation
+	 *
+	 * @param 	array		$data	Data to be made available to Third Party Integrations
+	 * @return	string|NULL			NULL is returned on a successful completion of integration tasks or the integration and failure message
+	 */
+	public function integrations_update($data)
+	{
+		$negative_results = NULL;
+		log_message("ERROR","event created for integrations update: ". var_dump($data));
+		//calls to update functions for the different Integrations
+		$negative_results = "CLCdesq API failed to update item.  Error Code 1232";
+		return $negative_results;
+	}
+	
+	/**
+	 * Event trigger for integrations on Create CRUD operation
+	 *
+	 * @param 	array		$data	Data to be made available to Third Party Integrations
+	 * @return	string|NULL			NULL is returned on a successful completion of integration tasks or the integration and failure message
+	 */
+	public function integrations_delete($data)
+	{
+		$negative_results = NULL;
+		log_message("ERROR","event created for integrations delete: ". var_dump($data));
+		//calls to delete functions for the different Integrations
+		
+		return $negative_results;
+	}
+}


### PR DESCRIPTION
This is the CRUD event generator that @jekkos suggested be the driver for third-party integrations.  Per #2608 this has been implemented using the CI Events library and is pretty lean in its functionality so as not to bog the code down. The goal is to provide a layer of separation between the base code and third party integrations.

The concept is that "Triggers" are placed throughout the code (in the controllers) which trigger Create, Read, Update and Delete Methods.  Simultaneously "Listeners" receive the appropriate data and pass it off to the third-party integrations.

An example of this is that there is a trigger in the Items controller so that when a user successfully creates an item, the trigger puts the event out there with the item_data.  The event_create listener defined in the events/Integrations library then picks up the event and sends it to integrations_create defined in the same library which in turn will call any third party functions needing to use the data.  The idea is that that integrations_create function would do no heavy lifting but serve to call the third-party integrations functions only.  So, for example integrations_create($data) will look at $data[type] and when it's of type CUSTOMERS it might call, say mailchimp_add_email($data[data]) which would be defined separately.

There are a couple of question marks:
- Currently I have not added any "Read" triggers, because it was unclear to me how or if third-party integrations would use a read operation.  We can either remove the code or keep it as a place-holder for future use.  Alternately if someone can think of a good use case, I'll be glad to insert the triggers in the appropriate controllers.
- ~~Currently I have third-party integrations specific functions being created in the events/Integrations at the bottom of the class, but I'm thinking that will quickly get messy.  I'm thinking that we should extrapolate each integration into it's own file.  I was thinking that this could be done with a helper or library for each integration.  What is the best way to do this?  A helper would make the scope of each function global to the whole code, and I don't think we want that.  A library would require it be nested into its own class.  I'm not sure if that creates it's own scope problems.  Thoughts?~~ I went ahead and made changes so that each third party integration needs to be defined in its own library to create better code separation.
- This seems to be consistent with the rest of the code, but the errors on third-party integration fails are written to the log with a hard-coded English error message.  Should these be switched to toast notifications and not written in the log?  Another question is whether the error messages should be translatable regardless of whether they are toast notifications or written to the error log.  It seems that error log notifications are always in English and toast notifications are always translatable.