### PR TITLE
Expand flexibility of parse_decimal function

### DIFF
--- a/application/controllers/Config.php
+++ b/application/controllers/Config.php
@@ -635,11 +635,13 @@ class Config extends Secure_Controller
 	public function save_tax()
 	{
 		$this->db->trans_start();
-		
+
+		$decimals = $this->config->item('tax_decimals');
+
 		$batch_save_data = array(
-			'default_tax_1_rate' => parse_decimals($this->input->post('default_tax_1_rate')),
+			'default_tax_1_rate' => parse_decimals($this->input->post('default_tax_1_rate'), $decimals),
 			'default_tax_1_name' => $this->input->post('default_tax_1_name'),
-			'default_tax_2_rate' => parse_decimals($this->input->post('default_tax_2_rate')),
+			'default_tax_2_rate' => parse_decimals($this->input->post('default_tax_2_rate'), $decimals),
 			'default_tax_2_name' => $this->input->post('default_tax_2_name'),
 			'tax_included' => $this->input->post('tax_included') != NULL,
 			'use_destination_based_tax' => $this->input->post('use_destination_based_tax') != NULL,
@@ -648,9 +650,9 @@ class Config extends Secure_Controller
 			'default_tax_jurisdiction' => $this->input->post('default_tax_jurisdiction'),
 			'tax_id' => $this->input->post('tax_id')
 		);
-		
+
 		$success = $this->Appconfig->batch_save($batch_save_data) ? TRUE : FALSE;
-		
+
 		$this->db->trans_complete();
 		
 		$success &= $this->db->trans_status();

--- a/application/controllers/Config.php
+++ b/application/controllers/Config.php
@@ -636,12 +636,10 @@ class Config extends Secure_Controller
 	{
 		$this->db->trans_start();
 
-		$decimals = $this->config->item('tax_decimals');
-
 		$batch_save_data = array(
-			'default_tax_1_rate' => parse_decimals($this->input->post('default_tax_1_rate'), $decimals),
+			'default_tax_1_rate' => parse_tax($this->input->post('default_tax_1_rate')),
 			'default_tax_1_name' => $this->input->post('default_tax_1_name'),
-			'default_tax_2_rate' => parse_decimals($this->input->post('default_tax_2_rate'), $decimals),
+			'default_tax_2_rate' => parse_tax($this->input->post('default_tax_2_rate')),
 			'default_tax_2_name' => $this->input->post('default_tax_2_name'),
 			'tax_included' => $this->input->post('tax_included') != NULL,
 			'use_destination_based_tax' => $this->input->post('use_destination_based_tax') != NULL,

--- a/application/controllers/Items.php
+++ b/application/controllers/Items.php
@@ -479,7 +479,7 @@ class Items extends Secure_Controller
 		$upload_success = $this->_handle_image_upload();
 		$upload_data = $this->upload->data();
 
-		$receiving_quantity = parse_decimals($this->input->post('receiving_quantity'));
+		$receiving_quantity = parse_decimals($this->input->post('receiving_quantity'), $this->config->item('quantity_decimals'));
 		$item_type = $this->input->post('item_type') == NULL ? ITEM : $this->input->post('item_type');
 
 		if($receiving_quantity == '0' && $item_type!= ITEM_TEMP)
@@ -499,7 +499,7 @@ class Items extends Secure_Controller
 			'item_number' => $this->input->post('item_number') == '' ? NULL : $this->input->post('item_number'),
 			'cost_price' => parse_decimals($this->input->post('cost_price')),
 			'unit_price' => parse_decimals($this->input->post('unit_price')),
-			'reorder_level' => parse_decimals($this->input->post('reorder_level')),
+			'reorder_level' => parse_decimals($this->input->post('reorder_level'), $this->config->item('quantity_decimals')),
 			'receiving_quantity' => $receiving_quantity,
 			'allow_alt_description' => $this->input->post('allow_alt_description') != NULL,
 			'is_serialized' => $this->input->post('is_serialized') != NULL,
@@ -559,7 +559,7 @@ class Items extends Secure_Controller
 				$count = count($tax_percents);
 				for ($k = 0; $k < $count; ++$k)
 				{
-					$tax_percentage = parse_decimals($tax_percents[$k]);
+					$tax_percentage = parse_decimals($tax_percents[$k], $this->config->item('tax_decimals'));
 					if(is_numeric($tax_percentage))
 					{
 						$items_taxes_data[] = array('name' => $tax_names[$k], 'percent' => $tax_percentage);
@@ -572,7 +572,7 @@ class Items extends Secure_Controller
 			$stock_locations = $this->Stock_location->get_undeleted_all()->result_array();
 			foreach($stock_locations as $location)
 			{
-				$updated_quantity = parse_decimals($this->input->post('quantity_' . $location['location_id']));
+				$updated_quantity = parse_decimals($this->input->post('quantity_' . $location['location_id']), $this->config->item('quantity_decimals'));
 				if($item_data['item_type'] == ITEM_TEMP)
 				{
 					$updated_quantity = 0;
@@ -693,7 +693,7 @@ class Items extends Secure_Controller
 			'trans_user' => $employee_id,
 			'trans_location' => $location_id,
 			'trans_comment' => $this->input->post('trans_comment'),
-			'trans_inventory' => parse_decimals($this->input->post('newquantity'))
+			'trans_inventory' => parse_decimals($this->input->post('newquantity'), $this->config->item('quantity_decimals'))
 		);
 
 		$this->Inventory->insert($inv_data);
@@ -703,7 +703,7 @@ class Items extends Secure_Controller
 		$item_quantity_data = array(
 			'item_id' => $item_id,
 			'location_id' => $location_id,
-			'quantity' => $item_quantity->quantity + parse_decimals($this->input->post('newquantity'))
+			'quantity' => $item_quantity->quantity + parse_decimals($this->input->post('newquantity'), $this->config->item('quantity_decimals'))
 		);
 
 		if($this->Item_quantity->save($item_quantity_data, $item_id, $location_id))

--- a/application/controllers/Items.php
+++ b/application/controllers/Items.php
@@ -479,7 +479,7 @@ class Items extends Secure_Controller
 		$upload_success = $this->_handle_image_upload();
 		$upload_data = $this->upload->data();
 
-		$receiving_quantity = parse_decimals($this->input->post('receiving_quantity'), $this->config->item('quantity_decimals'));
+		$receiving_quantity = parse_quantity($this->input->post('receiving_quantity'));
 		$item_type = $this->input->post('item_type') == NULL ? ITEM : $this->input->post('item_type');
 
 		if($receiving_quantity == '0' && $item_type!= ITEM_TEMP)
@@ -499,7 +499,7 @@ class Items extends Secure_Controller
 			'item_number' => $this->input->post('item_number') == '' ? NULL : $this->input->post('item_number'),
 			'cost_price' => parse_decimals($this->input->post('cost_price')),
 			'unit_price' => parse_decimals($this->input->post('unit_price')),
-			'reorder_level' => parse_decimals($this->input->post('reorder_level'), $this->config->item('quantity_decimals')),
+			'reorder_level' => parse_quantity($this->input->post('reorder_level')),
 			'receiving_quantity' => $receiving_quantity,
 			'allow_alt_description' => $this->input->post('allow_alt_description') != NULL,
 			'is_serialized' => $this->input->post('is_serialized') != NULL,
@@ -559,7 +559,7 @@ class Items extends Secure_Controller
 				$count = count($tax_percents);
 				for ($k = 0; $k < $count; ++$k)
 				{
-					$tax_percentage = parse_decimals($tax_percents[$k], $this->config->item('tax_decimals'));
+					$tax_percentage = parse_tax($tax_percents[$k]);
 					if(is_numeric($tax_percentage))
 					{
 						$items_taxes_data[] = array('name' => $tax_names[$k], 'percent' => $tax_percentage);
@@ -572,7 +572,7 @@ class Items extends Secure_Controller
 			$stock_locations = $this->Stock_location->get_undeleted_all()->result_array();
 			foreach($stock_locations as $location)
 			{
-				$updated_quantity = parse_decimals($this->input->post('quantity_' . $location['location_id']), $this->config->item('quantity_decimals'));
+				$updated_quantity = parse_quantity($this->input->post('quantity_' . $location['location_id']));
 				if($item_data['item_type'] == ITEM_TEMP)
 				{
 					$updated_quantity = 0;
@@ -693,7 +693,7 @@ class Items extends Secure_Controller
 			'trans_user' => $employee_id,
 			'trans_location' => $location_id,
 			'trans_comment' => $this->input->post('trans_comment'),
-			'trans_inventory' => parse_decimals($this->input->post('newquantity'), $this->config->item('quantity_decimals'))
+			'trans_inventory' => parse_quantity($this->input->post('newquantity'))
 		);
 
 		$this->Inventory->insert($inv_data);
@@ -703,7 +703,7 @@ class Items extends Secure_Controller
 		$item_quantity_data = array(
 			'item_id' => $item_id,
 			'location_id' => $location_id,
-			'quantity' => $item_quantity->quantity + parse_decimals($this->input->post('newquantity'), $this->config->item('quantity_decimals'))
+			'quantity' => $item_quantity->quantity + parse_quantity($this->input->post('newquantity'))
 		);
 
 		if($this->Item_quantity->save($item_quantity_data, $item_id, $location_id))

--- a/application/controllers/Receivings.php
+++ b/application/controllers/Receivings.php
@@ -123,7 +123,7 @@ class Receivings extends Secure_Controller
 		$description = $this->input->post('description');
 		$serialnumber = $this->input->post('serialnumber');
 		$price = parse_decimals($this->input->post('price'));
-		$quantity = parse_decimals($this->input->post('quantity'), $this->config->item('quantity_decimals'));
+		$quantity = parse_quantity($this->input->post('quantity'));
 		$discount = parse_decimals($this->input->post('discount'));
 		$discount_type = $this->input->post('discount_type');
 		$item_location = $this->input->post('location');

--- a/application/controllers/Receivings.php
+++ b/application/controllers/Receivings.php
@@ -123,9 +123,9 @@ class Receivings extends Secure_Controller
 		$description = $this->input->post('description');
 		$serialnumber = $this->input->post('serialnumber');
 		$price = parse_decimals($this->input->post('price'));
-		$quantity = parse_decimals($this->input->post('quantity'));
+		$quantity = parse_decimals($this->input->post('quantity'), $this->config->item('quantity_decimals'));
 		$discount = parse_decimals($this->input->post('discount'));
-		$discount_type = parse_decimals($this->input->post('discount_type'));
+		$discount_type = $this->input->post('discount_type');
 		$item_location = $this->input->post('location');
 		$receiving_quantity = $this->input->post('receiving_quantity');
 

--- a/application/controllers/Sales.php
+++ b/application/controllers/Sales.php
@@ -474,7 +474,7 @@ class Sales extends Secure_Controller
 		$description = $this->input->post('description');
 		$serialnumber = $this->input->post('serialnumber');
 		$price = parse_decimals($this->input->post('price'));
-		$quantity = parse_decimals($this->input->post('quantity'), $this->config->item('quantity_decimals'));
+		$quantity = parse_quantity($this->input->post('quantity'));
 		$discount = parse_decimals($this->input->post('discount'));
 		$discount_type = $this->input->post('discount_type');
 

--- a/application/controllers/Sales.php
+++ b/application/controllers/Sales.php
@@ -474,7 +474,7 @@ class Sales extends Secure_Controller
 		$description = $this->input->post('description');
 		$serialnumber = $this->input->post('serialnumber');
 		$price = parse_decimals($this->input->post('price'));
-		$quantity = parse_decimals($this->input->post('quantity'));
+		$quantity = parse_decimals($this->input->post('quantity'), $this->config->item('quantity_decimals'));
 		$discount = parse_decimals($this->input->post('discount'));
 		$discount_type = $this->input->post('discount_type');
 

--- a/application/controllers/Taxes.php
+++ b/application/controllers/Taxes.php
@@ -354,7 +354,7 @@ class Taxes extends Secure_Controller
 	public function save($tax_rate_id = -1)
 	{
 		$tax_category_id = $this->input->post('rate_tax_category_id');
-		$tax_rate = parse_decimals($this->input->post('tax_rate'), $this->config->item('tax_decimals'));
+		$tax_rate = parse_tax($this->input->post('tax_rate'));
 
 		if ($tax_rate == 0) {
 			$tax_category_info = $this->Tax_category->get_info($tax_category_id);

--- a/application/controllers/Taxes.php
+++ b/application/controllers/Taxes.php
@@ -354,7 +354,7 @@ class Taxes extends Secure_Controller
 	public function save($tax_rate_id = -1)
 	{
 		$tax_category_id = $this->input->post('rate_tax_category_id');
-		$tax_rate = parse_decimals($this->input->post('tax_rate'));
+		$tax_rate = parse_decimals($this->input->post('tax_rate'), $this->config->item('tax_decimals'));
 
 		if ($tax_rate == 0) {
 			$tax_category_info = $this->Tax_category->get_info($tax_category_id);

--- a/application/helpers/locale_helper.php
+++ b/application/helpers/locale_helper.php
@@ -400,18 +400,25 @@ function to_decimals($number, $decimals, $type=\NumberFormatter::DECIMAL)
 	return $fmt->format($number);
 }
 
-function parse_decimals($number)
+function parse_decimals($number, $decimals = NULL)
 {
 	// ignore empty strings and return
+
 	if(empty($number))
 	{
 		return $number;
 	}
 
 	$config = get_instance()->config;
+
+	if($decimals == NULL)
+	{
+		$decimals = $config->item('currency_decimals');
+	}
+
 	$fmt = new \NumberFormatter($config->item('number_locale'), \NumberFormatter::DECIMAL);
 
-	$fmt->setAttribute(\NumberFormatter::FRACTION_DIGITS, $config->item('currency_decimals'));
+	$fmt->setAttribute(\NumberFormatter::FRACTION_DIGITS, $decimals);
 
 	if(empty($config->item('thousands_separator')))
 	{

--- a/application/helpers/locale_helper.php
+++ b/application/helpers/locale_helper.php
@@ -400,6 +400,16 @@ function to_decimals($number, $decimals, $type=\NumberFormatter::DECIMAL)
 	return $fmt->format($number);
 }
 
+function parse_quantity($number)
+{
+	return parse_decimals($number, quantity_decimals());
+}
+
+function parse_tax($number)
+{
+	return parse_decimals($number, tax_decimals());
+}
+
 function parse_decimals($number, $decimals = NULL)
 {
 	// ignore empty strings and return


### PR DESCRIPTION
Add support to parse_decimal function for tax_decimals and quantity_decimals parsing.

This addresses the problem reported in issue #2626 