### PR TITLE
Refresh tables after import + close after invoice email (#478)

### DIFF
--- a/application/views/customers/form_csv_import.php
+++ b/application/views/customers/form_csv_import.php
@@ -30,7 +30,7 @@ $(document).ready(function()
 				success: function(response)
 				{
 					dialog_support.hide();
-					$.notify(response.message, { type: response.success ? 'success' : 'danger'} );
+					table_support.handle_submit('<?php echo site_url('customers'); ?>', response);
 				},
 				dataType: 'json'
 			});

--- a/application/views/items/form_csv_import.php
+++ b/application/views/items/form_csv_import.php
@@ -30,7 +30,7 @@ $(document).ready(function()
 				success:function(response)
 				{
 					dialog_support.hide();
-					$.notify(response.message, { type: response.success ? 'success' : 'danger'} );
+					table_support.handle_submit('<?php echo site_url('items'); ?>', response);
 				},
 				dataType: 'json'
 			});

--- a/application/views/sales/form.php
+++ b/application/views/sales/form.php
@@ -126,8 +126,7 @@ $(document).ready(function()
 			if (confirm("<?php echo $this->lang->line('sales_invoice_confirm') . ' ' . $sale_info['email'] ?>")) {
 				$.get("<?php echo site_url($controller_name . '/send_pdf/' . $sale_info['sale_id']); ?>",
 					function(response) {
-						dialog_support.hide();
-						table_support.handle_submit("<?php echo site_url('sales'); ?>", response);
+						BootstrapDialog.closeAll();
 						$.notify(response.message, { type: response.success ? 'success' : 'danger'} );
 					}, 'json'
 				);	

--- a/public/js/manage_tables.js
+++ b/public/js/manage_tables.js
@@ -3,7 +3,7 @@
 	var btn_id, dialog_ref;
 
 	var hide = function() {
-		dialog_ref.close();
+		dialog_ref && dialog_ref.close();
 	};
 
 	var clicked_id = function() {


### PR DESCRIPTION
Fixes two minor glitches

* Edit dialog should close now after clicking 'send invoice'. The code to close it was in place but didn't work due to an undefined js reference to the dialog instance. This was probably due to the fact that the ref is only there if you submit the form (as it's set when calling the submit button)
* The items / customers table refreshes now after an import finishes instead of just showing a notification.