### PR TITLE
Add cookie_prefix to csrf cookie name (#2638)

### DIFF
--- a/application/views/partial/header_js.php
+++ b/application/views/partial/header_js.php
@@ -16,7 +16,7 @@
 		from: "<?php echo $this->config->item('notify_vertical_position'); ?>"
 	}});
 
-	var cookie_name = "<?php echo $this->config->item('csrf_cookie_name'); ?>";
+	var cookie_name = "<?php echo $this->config->item('cookie_prefix').$this->config->item('csrf_cookie_name'); ?>";
 
 	var csrf_token = function() {
 		return Cookies.get(cookie_name);


### PR DESCRIPTION
@daN4cat I'm still not able to reproduce the 403, but after looking at the code I agree that the prefix should be prepended to the cookie name.
Could you verify if this fix works for you?

