### PR TITLE
Add aggregate to fix only_full_group_by (#2538)

### DIFF
--- a/application/models/Item.php
+++ b/application/models/Item.php
@@ -115,7 +115,7 @@ class Item extends CI_Model
 		}
 		else
 		{
-			$this->db->select('items.item_id AS item_id');
+			$this->db->select('MAX(items.item_id) AS item_id');
 			$this->db->select('MAX(items.name) AS name');
 			$this->db->select('MAX(items.category) AS category');
 			$this->db->select('MAX(items.supplier_id) AS supplier_id');


### PR DESCRIPTION
Tried this locally and now items overview + details are loading when enabling running `SET sql_mode = 'ONLY_FULL_GROUP_BY';` on mariadb.