### PR TITLE
Add tax group constraint

### DIFF
--- a/application/controllers/Taxes.php
+++ b/application/controllers/Taxes.php
@@ -443,6 +443,8 @@ class Taxes extends Secure_Controller
 
 		$array_save = array();
 
+		$unique_tax_groups = [];
+
 		foreach($jurisdiction_id as $key => $val)
 		{
 			$array_save[] = array(
@@ -453,6 +455,19 @@ class Taxes extends Secure_Controller
 				'reporting_authority'=>$this->xss_clean($reporting_authority[$key]),
 				'tax_group_sequence'=>$this->xss_clean($tax_group_sequence[$key]),
 				'cascade_sequence'=>$this->xss_clean($cascade_sequence[$key]));
+
+			if (array_search($tax_group[$key], $unique_tax_groups) !== false)
+			{
+				echo json_encode(array(
+					'success' => FALSE,
+					'message' => $this->lang->line('taxes_tax_group_not_unique', $tax_group[$key])
+				));
+				return;
+			}
+			else
+			{
+				$unique_tax_groups[] = $tax_group[$key];
+			}
 		}
 
 		$success = $this->Tax_jurisdiction->save_jurisdictions($array_save);

--- a/application/language/en-GB/taxes_lang.php
+++ b/application/language/en-GB/taxes_lang.php
@@ -54,6 +54,7 @@ $lang["taxes_tax_codes_saved_successfully"] = "Tax Code changes saved";
 $lang["taxes_tax_codes_saved_unsuccessfully"] = "Tax Code changes not saved";
 $lang["taxes_tax_excluded"] = "Tax excluded";
 $lang["taxes_tax_group"] = "Tax Group";
+$lang["taxes_tax_group_not_unique"] = "Tax Group %1 is not unique";
 $lang["taxes_tax_group_sequence"] = "Tax Group Sequence";
 $lang["taxes_tax_included"] = "Tax included";
 $lang["taxes_tax_jurisdiction"] = "Tax Jurisdiction";

--- a/application/language/en-US/taxes_lang.php
+++ b/application/language/en-US/taxes_lang.php
@@ -54,6 +54,7 @@ $lang["taxes_tax_codes_saved_successfully"] = "Tax Code changes saved";
 $lang["taxes_tax_codes_saved_unsuccessfully"] = "Tax Code changes not saved";
 $lang["taxes_tax_excluded"] = "Tax excluded";
 $lang["taxes_tax_group"] = "Tax Group";
+$lang["taxes_tax_group_not_unique"] = "Tax Group %1 is not unique";
 $lang["taxes_tax_group_sequence"] = "Tax Group Sequence";
 $lang["taxes_tax_included"] = "Tax included";
 $lang["taxes_tax_jurisdiction"] = "Tax Jurisdiction";

--- a/application/migrations/20200215100000_taxgroupconstraint.php
+++ b/application/migrations/20200215100000_taxgroupconstraint.php
@@ -1,0 +1,20 @@
+<?php if (!defined('BASEPATH')) exit('No direct script access allowed');
+
+class Migration_taxgroupconstraint extends CI_Migration
+{
+	public function __construct()
+	{
+		parent::__construct();
+	}
+
+	public function up()
+	{
+		$this->db->query('ALTER TABLE ' . $this->db->dbprefix('tax_jurisdictions') . ' ADD CONSTRAINT tax_jurisdictions_uq1 UNIQUE (tax_group)');
+	}
+
+	public function down()
+	{
+		$this->db->query('ALTER TABLE ' . $this->db->dbprefix('tax_jurisdictions') . ' DROP INDEX tax_jurisdictions_uq1');
+	}
+}
+?>


### PR DESCRIPTION
This simple change will add a constraint on the tax_group field to force it to be unique so that duplicate tax groups cannot be added.  The update will not take place unless the tax_groups are unique.