### PR TITLE
Add unit test for locale_helper (#2748)

### DIFF
--- a/application/tests/helpers/Locale_helper_test.php
+++ b/application/tests/helpers/Locale_helper_test.php
@@ -1,0 +1,22 @@
+<?php
+/**
+ * @backupGlobals disabled
+ */
+class Locale_helper_test extends UnitTestCase
+{
+    public function test_parse_decimals_precision()
+    {
+        $decimals = parse_decimals(2.22, 2);
+
+        $this->assertEquals(2.22, $decimals);
+    }
+
+    public function test_format_decimals()
+    {
+        $decimals = to_decimals(5, 2);
+
+        $this->assertEquals(5.00, $decimals);
+    }
+
+
+}

--- a/application/tests/libraries/Barcode_lib_test.php
+++ b/application/tests/libraries/Barcode_lib_test.php
@@ -9,7 +9,6 @@ class Barcode_lib_test extends UnitTestCase
 		$this->resetInstance();
 
 		$this->obj = $this->newLibrary('Barcode_lib');
-
 	}
 
 	public function test_barcode_weight_first()
@@ -21,8 +20,8 @@ class Barcode_lib_test extends UnitTestCase
 		$this->obj->parse_barcode_fields($quantity, $item_number);
 
 		echo $quantity;
-		$this->assertEquals($quantity, 123.456);
-		$this->assertEquals($item_number, "50000");
+		$this->assertEquals(123.456, $quantity);
+		$this->assertEquals("50000", $item_number);
 	}
 
 	public function test_barcode_weight_last()
@@ -33,7 +32,7 @@ class Barcode_lib_test extends UnitTestCase
 		$quantity = 0;
 		$this->obj->parse_barcode_fields($quantity, $item_number);
 
-		$this->assertEquals($quantity, 50.001);
-		$this->assertEquals($item_number, 123456);
+		$this->assertEquals(50.001, $quantity);
+		$this->assertEquals(123456, $item_number);
 	}
 }


### PR DESCRIPTION
@objecttothis if the build for this PR is green it will show that we are getting the expected output from the `locale_helper`. 

This might be a good starting point to extend the test further (in case you have an idea where exactly the issue might be). In the mean time I try to demonstrate how we should start using unit tests to verify functionality while guarding against regressions when developing new features.