### PR TITLE
Removing LEFT JOIN of supplier table

### DIFF
--- a/application/models/Item.php
+++ b/application/models/Item.php
@@ -259,7 +259,6 @@ class Item extends CI_Model
 	public function get_all($stock_location_id = -1, $rows = 0, $limit_from = 0)
 	{
 		$this->db->from('items');
-		$this->db->join('suppliers', 'suppliers.person_id = items.supplier_id', 'left');
 
 		if($stock_location_id > -1)
 		{
@@ -289,9 +288,7 @@ class Item extends CI_Model
 		$this->db->select('GROUP_CONCAT(attribute_value SEPARATOR \'|\') AS attribute_values');
 		$this->db->select('GROUP_CONCAT(attribute_decimal SEPARATOR \'|\') AS attribute_dvalues');
 		$this->db->select('GROUP_CONCAT(attribute_date SEPARATOR \'|\') AS attribute_dtvalues');
-		$this->db->select("MAX(". $this->db->dbprefix('suppliers') .".company_name) AS company_name");
 		$this->db->from('items');
-		$this->db->join('suppliers', 'suppliers.person_id = items.supplier_id', 'left');
 		$this->db->join('attribute_links', 'attribute_links.item_id = items.item_id', 'left');
 		$this->db->join('attribute_values', 'attribute_links.attribute_id = attribute_values.attribute_id', 'left');
 		$this->db->where('items.item_id', $item_id);


### PR DESCRIPTION
per #2788 the Supplier table results from Item->get_all() and Item->get_info() are not used anywhere and causing a bug where the duplicate fields between the items table and the suppliers table (deleted and category) are returning just one value to the results.  This creates the undesired effect of expecting items.deleted and items.category but getting values from suppliers.deleted and suppliers.category.