### PR TITLE
Barcode format rework

### DIFF
--- a/application/controllers/Receivings.php
+++ b/application/controllers/Receivings.php
@@ -9,6 +9,7 @@ class Receivings extends Secure_Controller
 		parent::__construct('receivings');
 
 		$this->load->library('receiving_lib');
+		$this->load->library('token_lib');
 		$this->load->library('barcode_lib');
 	}
 
@@ -90,7 +91,7 @@ class Receivings extends Secure_Controller
 
 		$mode = $this->receiving_lib->get_mode();
 		$item_id_or_number_or_item_kit_or_receipt = $this->input->post('item');
-		$this->barcode_lib->parse_barcode_fields($quantity, $item_id_or_number_or_item_kit_or_receipt);
+		$this->token_lib->parse_barcode($quantity, $price, $item_id_or_number_or_item_kit_or_receipt);
 		$quantity = ($mode == 'receive' || $mode == 'requisition') ? $quantity : -$quantity;
 		$item_location = $this->receiving_lib->get_stock_source();
 		$discount = $this->config->item('default_receivings_discount');

--- a/application/controllers/Sales.php
+++ b/application/controllers/Sales.php
@@ -13,9 +13,9 @@ class Sales extends Secure_Controller
 		parent::__construct('sales');
 
 		$this->load->library('sale_lib');
-		$this->load->library('barcode_lib');
 		$this->load->library('email_lib');
 		$this->load->library('token_lib');
+		$this->load->library('barcode_lib');
 	}
 
 	public function index()
@@ -398,7 +398,7 @@ class Sales extends Secure_Controller
 		}
 
 		$item_id_or_number_or_item_kit_or_receipt = $this->input->post('item');
-		$this->barcode_lib->parse_barcode_fields($quantity, $item_id_or_number_or_item_kit_or_receipt);
+		$this->token_lib->parse_barcode($quantity, $price, $item_id_or_number_or_item_kit_or_receipt);
 		$mode = $this->sale_lib->get_mode();
 		$quantity = ($mode == 'return') ? -$quantity : $quantity;
 		$item_location = $this->sale_lib->get_sale_location();
@@ -427,7 +427,7 @@ class Sales extends Secure_Controller
 
 			if(!empty($kit_item_id))
 			{
-				if(!$this->sale_lib->add_item($kit_item_id, $quantity, $item_location, $discount, $discount_type))
+				if(!$this->sale_lib->add_item($kit_item_id, $quantity, $item_location, $discount, $discount_type, PRICE_MODE_STANDARD, NULL, NULL, $price))
 				{
 					$data['error'] = $this->lang->line('sales_unable_to_add_item');
 				}
@@ -450,7 +450,7 @@ class Sales extends Secure_Controller
 		}
 		else
 		{
-			if(!$this->sale_lib->add_item($item_id_or_number_or_item_kit_or_receipt, $quantity, $item_location, $discount, $discount_type))
+			if(!$this->sale_lib->add_item($item_id_or_number_or_item_kit_or_receipt, $quantity, $item_location, $discount, $discount_type, PRICE_MODE_STANDARD, NULL, NULL, $price))
 			{
 				$data['error'] = $this->lang->line('sales_unable_to_add_item');
 			}

--- a/application/libraries/Barcode_lib.php
+++ b/application/libraries/Barcode_lib.php
@@ -49,32 +49,6 @@ class Barcode_lib
 		return $data;
 	}
 
-	public function parse_barcode_fields(&$quantity, &$item_id_or_number_or_item_kit_or_receipt)
-	{
-		$barcode_formats = json_decode($this->CI->config->item('barcode_formats'));
-
-		if(!empty($barcode_formats))
-		{
-			foreach($barcode_formats as $barcode_format)
-			{
-				if(preg_match("/$barcode_format/", $item_id_or_number_or_item_kit_or_receipt, $matches) && sizeof($matches) > 1)
-				{
-					$qtyfirst = strpos('d', $barcode_format) - strpos('w', $barcode_format) < 0;
-					$quantity = $matches[$qtyfirst ? 1 : 2];
-					if(strstr($barcode_format, '02'))
-					{
-						$quantity = $quantity / 1000;
-					}
-					$item_id_or_number_or_item_kit_or_receipt = $matches[$qtyfirst ? 2  : 1];
-
-					return;
-				}
-			}
-		}
-
-		$quantity = 1;
-	}
-
 	public function validate_barcode($barcode)
 	{
 		$barcode_type = $this->CI->config->item('barcode_type');

--- a/application/libraries/Sale_lib.php
+++ b/application/libraries/Sale_lib.php
@@ -718,7 +718,6 @@ class Sale_lib
 			return FALSE;
 		}
 
-		$price = 0.00;
 		$cost_price = 0.00;
 		$item_id = $item_info->item_id;
 		$item_type = $item_info->item_type;

--- a/application/libraries/Token_lib.php
+++ b/application/libraries/Token_lib.php
@@ -88,10 +88,10 @@ class Token_lib
 			foreach($barcode_formats as $barcode_format)
 			{
 				$parsed_results = $this->parse($item_id_or_number_or_item_kit_or_receipt, $barcode_format, $barcode_tokens);
-				$quantity = (isset($parsed_results['W'])) ? (int) $parsed_results['W'] / 1000 : 1;
+				$quantity = (isset($parsed_results['W'])) ? (int) $parsed_results['W'] / pow(10, $this->CI->config->item('quantity_decimals')) : 1;
 				$item_id_or_number_or_item_kit_or_receipt = (isset($parsed_results['I'])) ?
 					$parsed_results['I'] : $item_id_or_number_or_item_kit_or_receipt;
-				$price = (isset($parsed_results['P'])) ? (double) $parsed_results['P'] : NULL;
+				$price = (isset($parsed_results['P'])) ? (double) $parsed_results['P']  / pow(10, $this->CI->config->item('currency_decimals') - 1) : NULL;
 			}
 		}
 	}

--- a/application/libraries/Token_lib.php
+++ b/application/libraries/Token_lib.php
@@ -78,6 +78,24 @@ class Token_lib
 		return $token_tree;
 	}
 
+	public function parse_barcode(&$quantity, &$price,  &$item_id_or_number_or_item_kit_or_receipt)
+	{
+		$barcode_formats = json_decode($this->CI->config->item('barcode_formats'));
+		$barcode_tokens = Token::get_barcode_tokens();
+
+		if(!empty($barcode_formats))
+		{
+			foreach($barcode_formats as $barcode_format)
+			{
+				$parsed_results = $this->parse($item_id_or_number_or_item_kit_or_receipt, $barcode_format, $barcode_tokens);
+				$quantity = (isset($parsed_results['W'])) ? (int) $parsed_results['W'] / 1000 : 1;
+				$item_id_or_number_or_item_kit_or_receipt = (isset($parsed_results['I'])) ?
+					$parsed_results['I'] : $item_id_or_number_or_item_kit_or_receipt;
+				$price = (isset($parsed_results['P'])) ? (double) $parsed_results['P'] : NULL;
+			}
+		}
+	}
+
 	public function parse($string, $pattern, $tokens = array())
 	{
 		$token_tree = $this->scan($pattern);

--- a/application/models/tokens/Token.php
+++ b/application/models/tokens/Token.php
@@ -8,6 +8,9 @@ require_once(APPPATH . 'models/tokens/Token_quote_sequence.php');
 require_once(APPPATH . 'models/tokens/Token_work_order_sequence.php');
 require_once(APPPATH . 'models/tokens/Token_suspended_invoice_count.php');
 require_once(APPPATH . 'models/tokens/Token_year_invoice_count.php');
+require_once(APPPATH . 'models/tokens/Token_barcode_price.php');
+require_once(APPPATH . 'models/tokens/Token_barcode_weight.php');
+require_once(APPPATH . 'models/tokens/Token_barcode_ean.php');
 
 /**
  * Token class

--- a/application/tests/libraries/Token_lib_test.php
+++ b/application/tests/libraries/Token_lib_test.php
@@ -1,0 +1,70 @@
+<?php
+/**
+ * @backupGlobals disabled
+ */
+class Token_lib_test extends UnitTestCase
+{
+
+    public function setUp()
+    {
+        $this->resetInstance();
+
+        $this->obj = $this->newLibrary('Token_lib');
+    }
+
+    public function test_token_parser()
+    {
+        $tokens = Token::get_barcode_tokens();
+
+        $parsed_tokens = $this->obj->parse("0250200000abc", "02{P:2}{W:6}{I:3}", $tokens);
+
+        $this->assertEquals($parsed_tokens['I'], 'abc');
+        $this->assertEquals($parsed_tokens['P'], '50');
+        $this->assertEquals($parsed_tokens['W'], '200000');
+
+    }
+
+    public function test_barcode_item_number_and_quantity()
+    {
+        $this->CI->config->set_item('barcode_formats', json_encode(array("02{I:5}{W:6}")));
+
+        $item_number = "0250000123456";
+        $quantity = 0;
+        $this->obj->parse_barcode($quantity, $price, $item_number);
+
+        $this->assertEquals($quantity, 123.456);
+        $this->assertEquals($item_number, "50000");
+        $this->assertEquals($price, NULL);
+    }
+
+    public function test_barcode_quantity_and_item_number()
+    {
+        $this->CI->config->set_item('barcode_formats', json_encode(array("02{I:6}{W:5}{P:2}")));
+
+        $item_number = "021234565000110";
+        $quantity = 0;
+        $this->obj->parse_barcode($quantity, $price, $item_number);
+
+
+        $this->assertEquals($price, 10);
+        $this->assertEquals($item_number, 123456);
+        $this->assertEquals($quantity, 50.001);
+    }
+
+    public function test_no_barcode_format()
+    {
+        $this->CI->config->set_item('barcode_formats', json_encode(array("")));
+
+        $item_number = "021234565000110";
+        $quantity = 0;
+
+        $this->obj->parse_barcode($quantity, $price, $item_number);
+
+        $this->assertEquals($quantity, 1);
+        $this->assertEquals($price, 0);
+        $this->assertEquals($item_number, "021234565000110");
+    }
+
+}
+
+?>

--- a/application/tests/libraries/Token_lib_test.php
+++ b/application/tests/libraries/Token_lib_test.php
@@ -10,6 +10,9 @@ class Token_lib_test extends UnitTestCase
         $this->resetInstance();
 
         $this->obj = $this->newLibrary('Token_lib');
+        $this->CI->config->set_item('currency_decimals', 3);
+        $this->CI->config->set_item('quantity_decimals', 3);
+
     }
 
     public function test_token_parser()
@@ -46,7 +49,7 @@ class Token_lib_test extends UnitTestCase
         $this->obj->parse_barcode($quantity, $price, $item_number);
 
 
-        $this->assertEquals($price, 10);
+        $this->assertEquals($price, 0.10);
         $this->assertEquals($item_number, 123456);
         $this->assertEquals($quantity, 50.001);
     }


### PR DESCRIPTION
This rework allows us to use barcode formats with the token system originally developed by @SteveIreland . Also an extra $price variable was added that can be used with a barcode scanner to fill in item parameters in sales and receivings directly.

Also added a couple of units tests to show how the functionality is working.