### PR TITLE
Configure a serial device readout over websockets

### DIFF
--- a/application/language/en-US/config_lang.php
+++ b/application/language/en-US/config_lang.php
@@ -280,3 +280,7 @@ $lang["config_use_destination_based_tax"] = "Use Destination Based Tax";
 $lang["config_website"] = "Website";
 $lang["config_work_order_enable"] = "Work Order Support";
 $lang["config_work_order_format"] = "Work Order Format";
+$lang["config_serial_configuration"] = "Serial I/O";
+$lang["config_serialport_server_url"] = "Serialport Url";
+$lang["config_serialport_picker"] = "Choose device";
+$lang["config_serialport_connect"] = "Connect";

--- a/application/views/configs/manage.php
+++ b/application/views/configs/manage.php
@@ -68,6 +68,9 @@
 	<div class="tab-pane" id="barcode_tab">
 		<?php $this->load->view("configs/barcode_config"); ?>
 	</div>
+    <div class="tab-pane" id="serial_tab">
+        <?php $this->load->view("configs/serial_config"); ?>
+    </div>
 	<div class="tab-pane" id="stock_tab">
 		<?php $this->load->view("configs/stock_config"); ?>
 	</div>

--- a/application/views/configs/serial_config.php
+++ b/application/views/configs/serial_config.php
@@ -1,0 +1,150 @@
+<div id="page_title"><?php echo $this->lang->line('config_serial_configuration'); ?></div>
+<?php
+echo form_open('config/save_units/',array('id'=>'serial_config_form'));
+?>
+    <div id="config_wrapper">
+        <fieldset id="config_info">
+            <div id="required_fields_message"><?php echo $this->lang->line('common_fields_required_message'); ?></div>
+            <ul id="serial_error_message_box" class="error_message_box"></ul>
+            <legend><?php echo $this->lang->line("config_unit_info"); ?></legend>
+
+			<div class="field_row clearfix">
+				<?php echo form_label($this->lang->line('config_serialport_server_url').':', 'config_serialport_server_url',array('class'=>'wide')); ?>
+				<div class='form_field'>
+					<?php echo form_input(array(
+						'name'=>'serialport_server_url',
+						'id'=>'serialport_server_url',
+						'value'=>'ws://localhost:8989/ws',
+						'type'=>'text')); ?>
+					<input type="button" id="config_serialport_connect" value="<?php echo $this->lang->line('config_serialport_connect'); ?>" />
+				</div>
+
+			</div>
+
+			<div class="field_row hidden">
+				<?php echo form_label($this->lang->line('config_serialport_picker').':', 'config_serialport_picker',array('class'=>'wide')); ?>
+				<div class='form_field'>
+					<?php echo form_dropdown('input_device_picker', array(), ' ','id="input_device_picker"');?>
+					<?php echo form_dropdown('baud_rate_picker', array(), ' ','id="baud_rate_picker"');?>
+					<?php
+						foreach($item_units as $unit_id => $unit_data )
+						{
+							if (!empty($unit_data['unit_name']))
+							{
+								?>
+								<input type="checkbox" id="input_device_<?php echo $unit_data['unit_id']; ?>"
+									   class="input_device_check"/>
+								<?php echo $unit_data['unit_name'];
+							}
+						}
+						?>
+				</div>
+			</div>
+
+            <?php 
+            echo form_submit(array(
+                'name'=>'submit',
+                'id'=>'submit',
+                'value'=>$this->lang->line('common_submit'),
+                'class'=>'submit_button float_right')
+            );
+            ?>
+        </fieldset>
+    </div>
+<?php
+echo form_close();
+?>
+
+
+<script type='text/javascript'>
+
+//validation and submit handling
+$(document).ready(function()
+{
+	var unit_count = <?php echo sizeof($item_units); ?>;
+
+	$("#config_serialport_connect").prop("disabled", !$("#serialport_server_url").val().length);
+	$("#serialport_server_url").on('keyup', function() {
+		$("#config_serialport_connect").prop("disabled", !this.value.length);
+	});
+
+	if (window['localStorage'])
+	{
+
+		var url = serial_config.load_url();
+		$("#config_serialport_connect").click(function()
+		{
+			url = serial_config.save_url();
+			try {
+				var websocket = new WebSocket(url);
+
+				websocket.onopen = function(data) {
+					websocket.send("list");
+					websocket.send("baudrates");
+				};
+
+				var callbacks = 0;
+				websocket.onmessage = function(event)
+				{
+					try {
+						if (event.data.match(/.*(BaudRate|SerialPorts).*/g))
+						{
+							var data = JSON.parse(event.data);
+							callbacks++;
+							if (data.BaudRate)
+							{
+								serial_config.parse_baud_rates(data.BaudRate);
+							}
+							if (data.SerialPorts)
+							{
+								serial_config.parse_ports(data.SerialPorts);
+
+								$(".input_device_check").click(serial_config.save_serial_settings);
+								$("#baud_rate_picker").change(serial_config.save_serial_settings);
+								$("#input_device_picker").change(serial_config.load_serial_settings);
+								serial_config.load_configured_device();
+							}
+							callbacks > 1 && websocket.close();
+						}
+					} catch(e) {
+						console.log(e);
+					}
+				};
+			} catch(e) {
+				alert(e);
+			}
+
+		});
+
+	}
+
+	$('#serial_config_form').validate({
+		submitHandler:function(form)
+		{
+			$(form).ajaxSubmit({
+			success:function(response)
+			{
+				if(response.success)
+				{
+					set_feedback(response.message,'success_message',false);		
+				}
+				else
+				{
+					set_feedback(response.message,'error_message',true);		
+				}
+			},
+			dataType:'json'
+		});
+
+		},
+		errorLabelContainer: "#serial_error_message_box",
+ 		wrapper: "li",
+		rules: 
+		{
+   		},
+		messages: 
+		{
+		}
+	});
+});
+</script>

--- a/js/serial.config.js
+++ b/js/serial.config.js
@@ -1,0 +1,206 @@
+(function($) {
+    var serial_ports = [], baud_rates = [];
+    var settings = (localStorage['serial_settings'] && JSON.parse(localStorage['serial_settings'])) || {};
+    var default_baud_rate = 9600;
+
+    var load_baud_rate = function () {
+        var id = $(".input_device_check:checked").attr('id');
+        var serial_port = settings[id];
+        var baud_rate_index = serial_port && serial_port.baud_rate_index;
+        $("#baud_rate_picker").val(baud_rate_index);
+    };
+
+    var enable_disable_units = function () {
+        var selected = $(".input_device_check").is(":checked")
+        // select max. 2 inputs
+        var oversized = $(settings).size() > 2;
+        $(".input_device_check").each(function () {
+            $(this).prop("disabled", oversized || (selected && !$(this).is(":checked")));
+        });
+    };
+
+    var load_serial_device = function() {
+        $.each(settings, function(index, element) {
+            var device_index = element.device_index;
+            $("#input_device_picker").val(device_index);
+            return !element.device_index;
+        });
+    };
+
+    var load_configured_device = function() {
+        load_serial_device();
+        load_selected_units();
+        enable_disable_units();
+        load_baud_rate();
+    };
+
+    var load_selected_units = function () {
+        $.each(settings, function(index, element)
+        {
+            var value = $("#input_device_picker option:selected").val();
+            var checked =  element && element.device_index === value;
+            $("#"+index).prop("checked", checked);
+        });
+    };
+
+    var load_serial_settings = function() {
+        load_selected_units();
+        // if at least one checked, disable others!!
+        enable_disable_units();
+        load_baud_rate();
+    };
+
+    var save_serial_settings = function()
+    {
+        var device_index = $("#input_device_picker").val();
+        var id = $(".input_device_check:checked").attr('id');
+        // delete if unselected
+        if (!id)
+        {
+            $(".input_device_check").each(function(index) {
+                var id = $(this).attr('id');
+                var serial_setting = settings[id];
+                serial_setting && serial_setting.device_index ===
+                    $("#input_device_picker option:selected").val() && delete settings[id];
+                var text = $("#input_device_picker option:selected").text().replace(/\s\*/g, '');
+                $("#input_device_picker option:selected").text(text);
+            });
+        } else {
+            // find serial device settings
+            settings[id] = serial_ports[device_index];
+            // save baud rate
+            var baud_rate_index = $("#baud_rate_picker").val();
+            settings[id].baud_rate_index = baud_rate_index;
+            // save device index
+            settings[id].device_index = device_index;
+            // mark device text
+            var text = $("#input_device_picker option:selected").text();
+            !text.match(/\*$/g) && $("#input_device_picker option:selected").text(text + " *");
+        }
+        // write to localStorage
+        localStorage['serial_settings'] = JSON.stringify(settings);
+        enable_disable_units();
+    };
+
+    var load_url = function () {
+        var url = settings.url || $("#serialport_server_url").val();
+        $("serialport_server_url").val(url);
+        return url;
+    };
+
+    var save_url = function() {
+        var url = $("#serialport_server_url").val();
+        settings.url = url;
+        localStorage['serial_settings'] = JSON.stringify(settings);
+        return url;
+    };
+
+    var parse_baud_rates = function(nbaud_rates)
+    {
+        baud_rates = nbaud_rates;
+        $("#baud_rate_picker").empty();
+        $.each(baud_rates, function(index, baud_rate) {
+            $("#baud_rate_picker").append($("<option>", {value: index}).text(baud_rate));
+        });
+        load_baud_rate();
+    };
+
+    var parse_ports = function(nserial_ports)
+    {
+        serial_ports = nserial_ports;
+        $("#input_device_picker").empty().parents(".field_row").removeClass("hidden").addClass("clearfix");
+        $.each(serial_ports, function(index, serial_port) {
+            var configured = '';
+            $.each(settings, function(device_index, element) {
+                if (index == element.device_index) {
+                    configured = ' *';
+                }
+            });
+            $("#input_device_picker").append($("<option>", {value: index}).text(serial_port.Name + configured));
+        });
+    };
+
+    var get_settings = function(index)
+    {
+        return settings[index];
+    };
+
+    var fill_field = function(message, serial_port, index)
+    {
+        var object = jQuery.parseJSON(message.data);
+        if (object.P === serial_port.Name)
+        {
+            var re = /.*?(\d+\.\d+).*?/ig;
+            var result = re.exec(object.D.trim());
+            var float = parseFloat(result[1]);
+            if ($("." + index).is(":focus"))
+            {
+                return $("." + index + ":focus").val(float);
+            }
+            return $("." + index).first().val(float);
+        }
+    };
+
+    var enable_fields = function()
+    {
+        $("input[class*='input_device']").each(function(index, element) {
+            $.each($(element).attr("class").split(" "), function(index, className) {
+                if (serial_config.get_settings(className))
+                {
+                    $(element).prop("readonly", true);
+                    $(element).val() == "0" && $("#input_device_warning").removeClass("hidden");
+                }
+            });
+        });
+    };
+
+    var bind_keys = function ()
+    {
+        var keys = [8, 9], key = 0;
+        for (var index in settings)
+        {
+            if (typeof settings[index] == 'string')
+            {
+                continue;
+            }
+            // just attach F8 and F9 to first two serial devices found
+            (function(key, index) {
+                $(window).jkey('f' + key, function() {
+                    var serial_port = settings[index];
+                    var websocket = new WebSocket(settings.url);
+                    websocket.onopen = function (data) {
+                        var index = serial_port.baud_rate_index;
+                        var baud_rate = baud_rates[index];
+                        baud_rate = baud_rate ? baud_rate : default_baud_rate;
+                        websocket.send("open " + serial_port.Name + " " + baud_rate);
+                    };
+                    var field_to_fill;
+                    websocket.onmessage = function (message) {
+                        console.log(message.data);
+                        if (!field_to_fill && message.data.match(/\"D\":.*?(\d+\.\d+).*?/g))
+                        {
+                            field_to_fill = fill_field(message, serial_port, index);
+                            websocket.send("close " + serial_port.Name);
+                            var form_id = field_to_fill.parents("tr").index();
+                            $("#edit_form_" + form_id).submit();
+                        }
+                    }
+                });
+            })(keys[key++], index);
+        }
+        enable_fields();
+    };
+
+    window.serial_config = {
+        bind_keys : bind_keys,
+        load_url : load_url,
+        save_url : save_url,
+        save_serial_settings : save_serial_settings,
+        load_serial_settings : load_serial_settings,
+        parse_baud_rates : parse_baud_rates,
+        parse_ports : parse_ports,
+        get_settings : get_settings,
+        load_configured_device : load_configured_device
+    };
+
+})(jQuery);


### PR DESCRIPTION
@objecttothis I have briefly updated this patch as the original code also relied on another functionality that I won't probably merge in upstream (which was adding quantity 'units' to the system). I think in this version the allocation logic for deciding which input should go where is probably broken.

The idea was to have a set of predefined field identifiers in the config section that are then linked to a serial device input. You can then 'flag' those fields throughout the application by adding a html class attribute to them. A value readout was then triggered by hitting a predefined key on the keyboard.
At that point a scale readout was done and sent to this field. The readout format parsing is done through a regex and can be easily made configurable.

I'm not sure whether this can be useful for a bookstore but I think it certainly is for other types of stores. Currently I have on real usecase for it myself, so maybe I feel up to it I'll polish and test it so we can merge. Otherwise anyone else can pick it up and drive it home.