### PR TITLE
Update Item.php

### DIFF
--- a/application/models/Item.php
+++ b/application/models/Item.php
@@ -171,6 +171,7 @@ class Item extends CI_Model
 		if($attributes_enabled)
 		{
 			$format = $this->db->escape(dateformat_mysql());
+			$this->db->simple_query('SET SESSION group_concat_max_len=49152');
 			$this->db->select('GROUP_CONCAT(DISTINCT CONCAT_WS(\'_\', definition_id, attribute_value) ORDER BY definition_id SEPARATOR \'|\') AS attribute_values');
 			$this->db->select("GROUP_CONCAT(DISTINCT CONCAT_WS('_', definition_id, DATE_FORMAT(attribute_date, $format)) SEPARATOR '|') AS attribute_dtvalues");
 			$this->db->select('GROUP_CONCAT(DISTINCT CONCAT_WS(\'_\', definition_id, attribute_decimal) SEPARATOR \'|\') AS attribute_dvalues');


### PR DESCRIPTION
Set group_concat_max_len session variable to prevent count totals at the bottom of the tables becoming `1 to null of null items` when database includes significant number of item rows.