### PR TITLE
Modify input validator

### DIFF
--- a/application/language/en-GB/attributes_lang.php
+++ b/application/language/en-GB/attributes_lang.php
@@ -1,6 +1,6 @@
-<?php 
+<?php
 
-$lang["attributes_attribute_value_invalid_chars"] = "Attribute value cannot contain ':' or '|'";
+$lang["attributes_attribute_value_invalid_chars"] = "Attribute value cannot contain '_' or '|'";
 $lang["attributes_confirm_delete"] = "Are you sure you want to delete the selected attribute(s)?";
 $lang["attributes_confirm_restore"] = "Are you sure you want to restore the selected attribute(s)?";
 $lang["attributes_definition_cannot_be_deleted"] = "Could not delete selected attribute(s)";

--- a/application/language/en-US/attributes_lang.php
+++ b/application/language/en-US/attributes_lang.php
@@ -1,6 +1,6 @@
-<?php 
+<?php
 
-$lang["attributes_attribute_value_invalid_chars"] = "Attribute value cannot contain ':' or '|'";
+$lang["attributes_attribute_value_invalid_chars"] = "Attribute value cannot contain '_' or '|'";
 $lang["attributes_confirm_delete"] = "Are you sure you want to delete the selected attribute(s)?";
 $lang["attributes_confirm_restore"] = "Are you sure you want to restore the selected attribute(s)?";
 $lang["attributes_definition_cannot_be_deleted"] = "Could not delete selected attribute(s)";

--- a/application/views/items/form.php
+++ b/application/views/items/form.php
@@ -515,7 +515,7 @@ $(document).ready(function()
 	});
 
 	$.validator.addMethod('valid_chars', function(value, element) {
-		return value.match(/(\||:)/g) == null;
+		return value.match(/(\||_)/g) == null;
 	}, "<?php echo $this->lang->line('attributes_attribute_value_invalid_chars'); ?>");
 
 	var init_validation = function() {


### PR DESCRIPTION
- Matched the allowed inputs to what is found in the validator for the
Attribute form (/views/attributes/form.php) for consistency.
- Removed the restriction on colon and added the restriction on
underscore.
- Modified the language line to indicate correct error.