### PR TITLE
Fixes #2920 issue 

### DIFF
--- a/application/libraries/Tax_lib.php
+++ b/application/libraries/Tax_lib.php
@@ -80,7 +80,7 @@ class Tax_lib
 					foreach($tax_info as $tax)
 					{
 						// This computes tax for each line item and adds it to the tax type total
-						$tax_basis = $this->CI->sale_lib->get_item_total($item['quantity'], $item['price'], $item['discount'], TRUE);
+						$tax_basis = $this->CI->sale_lib->get_item_total($item['quantity'], $item['price'], $item['discount'], $item['discount_type'], TRUE);
 						$tax_amount = 0.0;
 
 						if($this->CI->config->item('tax_included'))


### PR DESCRIPTION
Computing item tax basis with a base taxing configuration, non-included taxes, is not including discounts.