### PR TITLE
fix Let's Encrypt fail on host install using docker

### DIFF
--- a/docker/data/nginx/nginx.tmpl
+++ b/docker/data/nginx/nginx.tmpl
@@ -29,8 +29,8 @@ http {
 		
 		client_max_body_size 10M;
 
-		ssl_certificate /etc/letsencrypt/live/ospos.ospos/fullchain.pem;
-		ssl_certificate_key /etc/letsencrypt/live/ospos.ospos/privkey.pem;
+		ssl_certificate /etc/letsencrypt/live/${WEB_DOMAIN}/fullchain.pem;
+		ssl_certificate_key /etc/letsencrypt/live/${WEB_DOMAIN}/privkey.pem;
 		include /etc/letsencrypt/options-ssl-nginx.conf;
 		ssl_dhparam /etc/letsencrypt/ssl-dhparams.pem;
 
@@ -50,8 +50,8 @@ http {
 		server_name          ${WEB_DOMAIN};
 		server_tokens        off;
 
-		ssl_certificate /etc/letsencrypt/live/ospos.ospos/fullchain.pem;
-		ssl_certificate_key /etc/letsencrypt/live/ospos.ospos/privkey.pem;
+		ssl_certificate /etc/letsencrypt/live/${WEB_DOMAIN}/fullchain.pem;
+		ssl_certificate_key /etc/letsencrypt/live/${WEB_DOMAIN}/privkey.pem;
 		include /etc/letsencrypt/options-ssl-nginx.conf;
 		ssl_dhparam /etc/letsencrypt/ssl-dhparams.pem;
 

--- a/docker/init-letsencrypt.sh
+++ b/docker/init-letsencrypt.sh
@@ -19,8 +19,8 @@ fi
 if [ ! -e "$data_path/conf/options-ssl-nginx.conf" ] || [ ! -e "$data_path/conf/ssl-dhparams.pem" ]; then
   echo "### Downloading recommended TLS parameters ..."
   mkdir -p "$data_path/conf"
-  curl -s https://github.com/certbot/certbot/blob/master/certbot-nginx/certbot_nginx/_internal/tls_configs/options-ssl-nginx.conf > "$data_path/conf/options-ssl-nginx.conf"
-  curl -s https://github.com/certbot/certbot/blob/master/certbot/certbot/ssl-dhparams.pem > "$data_path/conf/ssl-dhparams.pem"
+  curl -s https://raw.githubusercontent.com/certbot/certbot/master/certbot-nginx/certbot_nginx/_internal/tls_configs/options-ssl-nginx.conf > "$data_path/conf/options-ssl-nginx.conf"
+  curl -s https://raw.githubusercontent.com/certbot/certbot/master/certbot/certbot/ssl-dhparams.pem > "$data_path/conf/ssl-dhparams.pem"
   echo
 fi
 
@@ -61,7 +61,7 @@ case "$email" in
 esac
 
 # Enable staging mode if needed
-if [ $staging != "0" ]; then staging_arg="--staging"; fi
+if [ "$staging" != "0" ]; then staging_arg="--staging"; fi
 
 docker-compose run --rm --entrypoint "\
   certbot certonly --webroot -w /var/www/certbot \


### PR DESCRIPTION
nginx container keep crashing while installing using `docker/install-server.sh`. 