### PR TITLE
Fix for #2889 Tax calculation issue after changing Tax percent

### DIFF
--- a/application/controllers/Sales.php
+++ b/application/controllers/Sales.php
@@ -910,7 +910,7 @@ class Sales extends Secure_Controller
 		$data['payments'] = $this->sale_lib->get_payments();
 		$data['selected_payment_type'] = $this->sale_lib->get_payment_type();
 
-		$tax_details = $this->tax_lib->get_taxes($data['cart']);
+		$tax_details = $this->tax_lib->get_taxes($data['cart'], $sale_id);
 		$data['taxes'] = $this->Sale->get_sales_taxes($sale_id);
 		$data['discount'] = $this->sale_lib->get_discount();
 		$data['transaction_time'] = to_datetime(strtotime($sale_info['sale_time']));

--- a/application/libraries/Tax_lib.php
+++ b/application/libraries/Tax_lib.php
@@ -52,7 +52,7 @@ class Tax_lib
 	/**
 	 * Compute taxes for all items in the cart
 	 */
-	public function get_taxes(&$cart)
+	public function get_taxes(&$cart, $sale_id = -1)
 	{
 		$register_mode = $this->CI->sale_lib->get_mode();
 		$tax_decimals = tax_decimals();
@@ -72,7 +72,15 @@ class Tax_lib
 				{
 					// Start of current Base System tax calculations
 
-					$tax_info = $this->CI->Item_taxes->get_info($item['item_id']);
+					if($sale_id == -1)
+					{
+						$tax_info = $this->CI->Item_taxes->get_info($item['item_id']);
+					}
+					else
+					{
+						$tax_info = $this->CI->Sale->get_sales_item_taxes($sale_id, $item['item_id']);
+
+					}
 					$tax_group_sequence = 0;
 					$cascade_level = 0;
 					$cascade_basis_level = 0;

--- a/application/models/Sale.php
+++ b/application/models/Sale.php
@@ -807,6 +807,20 @@ class Sale extends CI_Model
 	}
 
 	/**
+	 * Return the taxes applied to a sale for a particular item
+	 */
+	public function get_sales_item_taxes($sale_id, $item_id)
+	{
+		$this->db->select('item_id, name, percent');
+		$this->db->from('sales_items_taxes');
+		$this->db->where('sale_id',$sale_id);
+		$this->db->where('item_id',$item_id);
+
+		//return an array of taxes for an item
+		return $this->db->get()->result_array();
+	}
+
+	/**
 	 * Deletes list of sales
 	 */
 	public function delete_list($sale_ids, $employee_id, $update_inventory = TRUE)


### PR DESCRIPTION
This resolves issue #2889.  Document reprint was retrieving current tax rates instead of retrieving the tax rates that were applied to the original sale.