### PR TITLE
Fix migration errors on clean install

### DIFF
--- a/application/config/migration.php
+++ b/application/config/migration.php
@@ -69,7 +69,7 @@ $config['migration_auto_latest'] = FALSE;
 | be upgraded / downgraded to.
 |
 */
-$config['migration_version'] = 20171126100000;
+$config['migration_version'] = 20180225100000;
 
 /*
 |--------------------------------------------------------------------------


### PR DESCRIPTION
When installing a clean instance on demo I see following error appear in the log. It looks like it's trying to run a couple of migrations for changes that are already in the database.sql. I bumper the migation date in migration.php so hopefully it will ignore those migrations and start from the next ones.

```
ospos_dev | [Fri Oct 23 10:53:02.813243 2020] [php7:notice] [pid 20] [client 172.18.0.1:49336] error: 1060, referer: http://localhost/
ospos_dev | [Fri Oct 23 10:53:02.813260 2020] [php7:notice] [pid 20] [client 172.18.0.1:49336] error: Duplicate column name 'menu_group', referer: http://localhost/
ospos_dev | [Fri Oct 23 10:53:02.813526 2020] [php7:notice] [pid 20] [client 172.18.0.1:49336] error: 1062, referer: http://localhost/
ospos_dev | [Fri Oct 23 10:53:02.813538 2020] [php7:notice] [pid 20] [client 172.18.0.1:49336] error: Duplicate entry 'office' for key 'PRIMARY', referer: http://localhost/
ospos_dev | [Fri Oct 23 10:53:02.813735 2020] [php7:notice] [pid 20] [client 172.18.0.1:49336] error: 1062, referer: http://localhost/
ospos_dev | [Fri Oct 23 10:53:02.813747 2020] [php7:notice] [pid 20] [client 172.18.0.1:49336] error: Duplicate entry 'office' for key 'PRIMARY', referer: http://localhost/
ospos_dev | [Fri Oct 23 10:53:02.813918 2020] [php7:notice] [pid 20] [client 172.18.0.1:49336] error: 1062, referer: http://localhost/
ospos_dev | [Fri Oct 23 10:53:02.813931 2020] [php7:notice] [pid 20] [client 172.18.0.1:49336] error: Duplicate entry 'office-1' for key 'PRIMARY', referer: http://localhost/
ospos_dev | [Fri Oct 23 10:53:02.824602 2020] [php7:notice] [pid 20] [client 172.18.0.1:49336] error: 1062, referer: http://localhost/
ospos_dev | [Fri Oct 23 10:53:02.824621 2020] [php7:notice] [pid 20] [client 172.18.0.1:49336] error: Duplicate entry 'work_order_enable' for key 'PRIMARY', referer: http://localhost/
ospos_dev | [Fri Oct 23 10:53:02.824835 2020] [php7:notice] [pid 20] [client 172.18.0.1:49336] error: 1060, referer: http://localhost/
ospos_dev | [Fri Oct 23 10:53:02.824850 2020] [php7:notice] [pid 20] [client 172.18.0.1:49336] error: Duplicate column name 'work_order_number', referer: http://localhost/
ospos_dev | [Fri Oct 23 10:53:02.857840 2020] [php7:notice] [pid 20] [client 172.18.0.1:49336] error: 1060, referer: http://localhost/
ospos_dev | [Fri Oct 23 10:53:02.857866 2020] [php7:notice] [pid 20] [client 172.18.0.1:49336] error: Duplicate column name 'language', referer: http://localhost/
ospos_dev | [Fri Oct 23 10:53:02.858093 2020] [php7:notice] [pid 20] [client 172.18.0.1:49336] error: 1062, referer: http://localhost/
ospos_dev | [Fri Oct 23 10:53:02.858104 2020] [php7:notice] [pid 20] [client 172.18.0.1:49336] error: Duplicate entry 'suggestions_first_column' for key 'PRIMARY', referer: http://localhost/
ospos_dev | [Fri Oct 23 10:53:02.858274 2020] [php7:notice] [pid 20] [client 172.18.0.1:49336] error: 1062, referer: http://localhost/
ospos_dev | [Fri Oct 23 10:53:02.858294 2020] [php7:notice] [pid 20] [client 172.18.0.1:49336] error: Duplicate entry 'allow_duplicate_barcodes' for key 'PRIMARY', referer: http://localhost/
ospos_dev | [Fri Oct 23 10:53:04.129048 2020] [php7:notice] [pid 20] [client 172.18.0.1:49336] error: 1062, referer: http://localhost/
ospos_dev | [Fri Oct 23 10:53:04.129074 2020] [php7:notice] [pid 20] [client 172.18.0.1:49336] error: Duplicate entry 'quote_default_comments' for key 'PRIMARY', referer: http://localhost/

```