### PR TITLE
Increase timeout on migration (#2992)

### DIFF
--- a/application/controllers/Config.php
+++ b/application/controllers/Config.php
@@ -905,7 +905,7 @@ class Config extends Secure_Controller
 			$result = FALSE;
 
 			// Chmod the file
-			@chmod($config_path, 0777);
+			@chmod($config_path, 0770);
 
 			// Verify file permissions
 			if(is_writable($config_path))
@@ -920,7 +920,7 @@ class Config extends Secure_Controller
 			}
 
 			// Chmod the file
-			@chmod($config_path, 0444);
+			@chmod($config_path, 0440);
 
 			return $result;
 		}

--- a/application/controllers/Login.php
+++ b/application/controllers/Login.php
@@ -45,7 +45,7 @@ class Login extends CI_Controller
 
 		if (!$this->migration->is_latest())
 		{
-			set_time_limit(1200);
+			set_time_limit(3600);
 			// trigger any required upgrade before starting the application
 			$this->migration->latest();
 		}

--- a/application/views/configs/system_info.php
+++ b/application/views/configs/system_info.php
@@ -125,9 +125,6 @@
 					
 						if(!((substr(decoct(fileperms($logs)), -4) == 750) && (substr(decoct(fileperms($uploads)), -4) == 750) && (substr(decoct(fileperms($images)), -4) == 750) 
                              && ((substr(decoct(fileperms($importcustomers)), -4) == 640) || (substr(decoct(fileperms($importcustomers)), -4) == 660)))) {
-//							OR substr(decoct(fileperms($uploads)), -4) != 750 
-	//						OR substr(decoct(fileperms($images)), -4) != 750 
-		//					OR substr(decoct(fileperms($importcustomers)), -4) != 660) {
 							echo '<br><font color="red"><strong>' . $this->lang->line('config_security_issue') . '</strong> <br>' . $this->lang->line('config_perm_risk') . '</font><br>';
 						} 
 						else { 


### PR DESCRIPTION
* Increase timeout when running migations, seems tobe needed if database is a bit bigger
* File permissions after a encryption key config set to group readable now. I think ideally this would be owner readable but as we can't make sure that file permissiosn are owned by the process user, we keep it like this
* Minor cleanup