### PR TITLE
Adjust a theme to handle feature development using non-theme supported classes.

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -1,6 +1,6 @@
 module.exports = function(grunt) {
 
-    grunt.initConfig({
+	grunt.initConfig({
 		pkg: grunt.file.readJSON('package.json'),
 		wiredep: {
 			task: {
@@ -53,7 +53,7 @@ module.exports = function(grunt) {
 		cssmin: {
 			target: {
 				files: {
-					'public/dist/<%= pkg.name %>.min.css': ['tmp/opensourcepos_bower.css', 'public/css/*.css', '!public/css/login.css', '!public/css/invoice_email.css', '!public/css/barcode_font.css']
+					'public/dist/<%= pkg.name %>.min.css': ['tmp/opensourcepos_bower.css', 'public/css/*.css', '!public/css/login.css', '!public/css/invoice_email.css', '!public/css/barcode_font.css', '!public/css/darkly.css']
 				}
 			}
 		},
@@ -106,7 +106,7 @@ module.exports = function(grunt) {
 					closeTag: '<!-- end css template tags -->',
 					ignorePath: '../../../public/'
 				},
-				src: ['public/css/*.css', '!public/css/login.css', '!public/css/invoice_email.css', '!public/css/barcode_font.css'],
+				src: ['public/css/*.css', '!public/css/login.css', '!public/css/invoice_email.css', '!public/css/barcode_font.css', '!public/css/darkly.css'],
 				dest: 'application/views/partial/header.php',
 			},
 			mincss_header: {
@@ -125,7 +125,7 @@ module.exports = function(grunt) {
 					scriptTemplate: '<rel type="text/css" src="{{ path }}"></rel>',
 					openTag: '<!-- start css template tags -->',
 					closeTag: '<!-- end css template tags -->',
-                    ignorePath: '../../public/'
+					ignorePath: '../../public/'
 				},
 				src: ['public/css/login.css'],
 				dest: 'application/views/login.php'
@@ -145,7 +145,7 @@ module.exports = function(grunt) {
 					scriptTemplate: '<script type="text/javascript" src="{{ path }}"></script>',
 					openTag: '<!-- start minjs template tags -->',
 					closeTag: '<!-- end minjs template tags -->',
-                    ignorePath: '../../../public/'
+					ignorePath: '../../../public/'
 				},
 				src: ['public/dist/*min.js'],
 				dest: 'application/views/partial/header.php'
@@ -255,17 +255,17 @@ module.exports = function(grunt) {
 		}
 	});
 
-    require('load-grunt-tasks')(grunt);
-    grunt.loadNpmTasks('grunt-mocha-webdriver');
+	require('load-grunt-tasks')(grunt);
+	grunt.loadNpmTasks('grunt-mocha-webdriver');
 	grunt.loadNpmTasks('grunt-composer');
 	grunt.loadNpmTasks('grunt-apigen');
-    grunt.loadNpmTasks('grunt-contrib-compress');
-    
-    grunt.registerTask('default', ['wiredep', 'bower_concat', 'bowercopy', 'concat', 'uglify', 'cssmin', 'tags', 'cachebreaker']);
-    grunt.registerTask('update', ['composer:update', 'bower:update']);
-    grunt.registerTask('genlicense', ['clean:license', 'license', 'bower-licensechecker']);
-    grunt.registerTask('package', ['default', 'compress']);
-    grunt.registerTask('packages', ['composer:update']);
-    grunt.registerTask('gendocs', ['apigen:generate']);
+	grunt.loadNpmTasks('grunt-contrib-compress');
+
+	grunt.registerTask('default', ['wiredep', 'bower_concat', 'bowercopy', 'concat', 'uglify', 'cssmin', 'tags', 'cachebreaker']);
+	grunt.registerTask('update', ['composer:update', 'bower:update']);
+	grunt.registerTask('genlicense', ['clean:license', 'license', 'bower-licensechecker']);
+	grunt.registerTask('package', ['default', 'compress']);
+	grunt.registerTask('packages', ['composer:update']);
+	grunt.registerTask('gendocs', ['apigen:generate']);
 
 };

--- a/application/views/partial/header.php
+++ b/application/views/partial/header.php
@@ -77,6 +77,12 @@
 		<link rel="stylesheet" type="text/css" href="dist/jquery-ui/jquery-ui.min.css"/>
 		<link rel="stylesheet" type="text/css" href="dist/opensourcepos.min.css?rel=397f582d3d"/>
 		<!-- end mincss template tags -->
+
+		<!-- Tweaks to the UI for a particular theme should drop here  -->
+	<?php if ($this->config->item('theme') != 'flatly' && file_exists($_SERVER['DOCUMENT_ROOT'] . '/public/css/' . $this->config->item('theme') . '.css')) { ?>
+		<link rel="stylesheet" type="text/css" href="<?php echo 'css/' . $this->config->item('theme') . '.css' ?>"/>
+	<?php } ?>
+
 		<!-- start minjs template tags -->
 		<script type="text/javascript" src="dist/opensourcepos.min.js?rel=1ca975c3b9"></script>
 		<!-- end minjs template tags -->

--- a/public/css/darkly.css
+++ b/public/css/darkly.css
@@ -1,0 +1,33 @@
+/* Since flatly is the default theme, all css design should use flatly as the starting point. */
+/* Any css color attributes that need to be overridden for a particular theme */
+/* should be included in a css file file named. */
+
+.fixed-table-container tbody .selected td {
+	background-color:#757575
+}
+
+/* Receivings & Sales */
+
+#register td {
+	background-color:#757575;
+}
+
+#add_item_form,#overall_sale {
+	background-color:#757575
+}
+
+#mode_form,#payment_details {
+	background-color:#757575
+}
+
+/* Reports > Graphical Reports */
+
+.ct-label {
+	fill:#eee;
+	color:#eee;
+}
+
+text.ct-axis-title{
+	fill:#eee;
+	color:#eee;
+}


### PR DESCRIPTION
This resolves the issue reported with #2949.  It provides a mechanism to override the color style that might have been used to make the flatly theme work well with the custom development.  The stylesheet has the same name as the theme but resides in the public/css folder.  This includes darkly.css as an example.  It uses the provided color override specs provided by the issue reporter Syed.