### PR TITLE
Fixed inventory after deleting receiving

### DIFF
--- a/application/models/Receiving.php
+++ b/application/models/Receiving.php
@@ -181,13 +181,13 @@ class Receiving extends CI_Model
 					'trans_user' => $employee_id,
 					'trans_comment' => 'Deleting receiving ' . $receiving_id,
 					'trans_location' => $item['item_location'],
-					'trans_inventory' => $item['quantity_purchased'] * -1
+					'trans_inventory' => $item['quantity_purchased'] * (-$item['receiving_quantity'])
 				);
 				// update inventory
 				$this->Inventory->insert($inv_data);
 
 				// update quantities
-				$this->Item_quantity->change_quantity($item['item_id'], $item['item_location'], $item['quantity_purchased'] * -1);
+				$this->Item_quantity->change_quantity($item['item_id'], $item['item_location'], $item['quantity_purchased'] * (-$item['receiving_quantity']));
 			}
 		}
 


### PR DESCRIPTION
When you add new/ update an item with a *receiving quantity* more than 1, (Let's say 63), so you then do a new receiving of that particular item, you will get the option to select pack as x63 or x1.

So if you select more that 1 Ship pack (receiving quantity), (in this eg. that is, x63) and finish the receiving successfully, your inventory of that item update with increment of 63 and inventory count details also, good.

But when you realize the receiving you just did had a mistake and  you go and delete it, the inventory reduction is wrongly calculated.
Instead of decreasing the inventory by 63, it reduces it by 1.

So i fixed it.