### PR TITLE
Add SameSite=Strict attribute + enable HTTPOnly for session (#1980)

### DIFF
--- a/application/config/config.php
+++ b/application/config/config.php
@@ -437,7 +437,7 @@ $config['sess_regenerate_destroy'] = FALSE;
 $config['cookie_prefix'] = '';
 $config['cookie_domain'] = '';
 $config['cookie_path'] = '/';
-$config['cookie_secure'] = FALSE;
+$config['cookie_secure'] = isset($_SERVER['HTTPS']) && $_SERVER['HTTPS'] == 'on';
 $config['cookie_httponly'] = TRUE;
 
 /*

--- a/application/config/config.php
+++ b/application/config/config.php
@@ -438,7 +438,7 @@ $config['cookie_prefix'] = '';
 $config['cookie_domain'] = '';
 $config['cookie_path'] = '/';
 $config['cookie_secure'] = FALSE;
-$config['cookie_httponly'] = FALSE;
+$config['cookie_httponly'] = TRUE;
 
 /*
 |--------------------------------------------------------------------------

--- a/application/core/MY_Security.php
+++ b/application/core/MY_Security.php
@@ -1,0 +1,35 @@
+<?php
+defined('BASEPATH') or exit('No direct script access allowed');
+
+class MY_Security extends CI_Security
+{
+
+    /**
+     * CSRF Set Cookie with samesite
+     *
+     * @codeCoverageIgnore
+     * @return  CI_Security
+     */
+    public function csrf_set_cookie()
+    {
+        $expire = time() + $this->_csrf_expire;
+        $secure_cookie = (bool)config_item('cookie_secure');
+
+        if ($secure_cookie && !is_https()) {
+            return FALSE;
+        }
+
+        setcookie($this->_csrf_cookie_name,
+            $this->_csrf_hash,
+            ['samesite' => 'Strict',
+                'secure' => config_item('cookie_httponly'),
+                'expires' => $expire,
+                'path' => config_item('cookie_path'),
+                'domain' => config_item('cookie_domain'),
+                'httponly' => config_item('cookie_httponly')]);
+
+        log_message('info', 'CSRF cookie sent');
+
+        return $this;
+    }
+}

--- a/application/core/MY_Security.php
+++ b/application/core/MY_Security.php
@@ -19,14 +19,26 @@ class MY_Security extends CI_Security
             return FALSE;
         }
 
-        setcookie($this->_csrf_cookie_name,
-            $this->_csrf_hash,
-            ['samesite' => 'Strict',
-                'secure' => $secure_cookie,
-                'expires' => $expire,
-                'path' => config_item('cookie_path'),
-                'domain' => config_item('cookie_domain'),
-                'httponly' => FALSE]);
+        if (PHP_VERSION_ID < 70300) {
+            setcookie($this->_csrf_cookie_name,
+                $this->_csrf_hash, $expire,
+                config_item('cookie_path'). '; samesite=strict',
+                config_item('cookie_domain'),
+                $secure_cookie,
+                FALSE);
+        }
+        else
+        {
+            setcookie($this->_csrf_cookie_name,
+                $this->_csrf_hash,
+                ['samesite' => 'Strict',
+                    'secure' => $secure_cookie,
+                    'expires' => $expire,
+                    'path' => config_item('cookie_path'),
+                    'domain' => config_item('cookie_domain'),
+                    'httponly' => FALSE]);
+        }
+
 
         log_message('info', 'CSRF cookie sent');
 

--- a/application/core/MY_Security.php
+++ b/application/core/MY_Security.php
@@ -19,19 +19,29 @@ class MY_Security extends CI_Security
             return FALSE;
         }
 
+        $path = config_item('cookie_path');
+
         if (PHP_VERSION_ID < 70300) {
+
+            if (is_https())
+            {
+                $path .= '; samesite=strict';
+            }
+
             setcookie($this->_csrf_cookie_name,
                 $this->_csrf_hash, $expire,
-                config_item('cookie_path'). '; samesite=strict',
+                $path,
                 config_item('cookie_domain'),
                 $secure_cookie,
                 FALSE);
         }
         else
         {
+            $samesite = is_https() ? 'None' : 'Strict';
+
             setcookie($this->_csrf_cookie_name,
                 $this->_csrf_hash,
-                ['samesite' => 'Strict',
+                ['samesite' => $samesite,
                     'secure' => $secure_cookie,
                     'expires' => $expire,
                     'path' => config_item('cookie_path'),

--- a/application/core/MY_Security.php
+++ b/application/core/MY_Security.php
@@ -3,7 +3,6 @@ defined('BASEPATH') or exit('No direct script access allowed');
 
 class MY_Security extends CI_Security
 {
-
     /**
      * CSRF Set Cookie with samesite
      *
@@ -15,18 +14,19 @@ class MY_Security extends CI_Security
         $expire = time() + $this->_csrf_expire;
         $secure_cookie = (bool)config_item('cookie_secure');
 
-        if ($secure_cookie && !is_https()) {
+        if ($secure_cookie && !is_https())
+        {
             return FALSE;
         }
 
         setcookie($this->_csrf_cookie_name,
             $this->_csrf_hash,
             ['samesite' => 'Strict',
-                'secure' => config_item('cookie_httponly'),
+                'secure' => $secure_cookie,
                 'expires' => $expire,
                 'path' => config_item('cookie_path'),
                 'domain' => config_item('cookie_domain'),
-                'httponly' => config_item('cookie_httponly')]);
+                'httponly' => FALSE]);
 
         log_message('info', 'CSRF cookie sent');
 


### PR DESCRIPTION
Added an override of the csrf token generation that includes SameSIte flag. Checked locally and indeed this attribute is being set on the cookie now.