### PR TITLE
Use mediumblob for session data storage (#3006)

### DIFF
--- a/application/migrations/20210103000000_modify_session_datatype.php
+++ b/application/migrations/20210103000000_modify_session_datatype.php
@@ -1,0 +1,24 @@
+<?php if (!defined('BASEPATH')) exit('No direct script access allowed');
+
+class Migration_modify_session_datatype extends CI_Migration
+{
+	public function __construct()
+	{
+		parent::__construct();
+	}
+
+	public function up()
+	{
+		error_log('Migrating modify_session_datatype');
+
+		execute_script(APPPATH . 'migrations/sqlscripts/3.3.4_modify_session_datatype.sql');
+
+		error_log('Migrating modify_session_datatype');
+	}
+
+	public function down()
+	{
+	}
+}
+?>
+

--- a/application/migrations/sqlscripts/3.3.4_modify_session_datatype.sql
+++ b/application/migrations/sqlscripts/3.3.4_modify_session_datatype.sql
@@ -1,0 +1,2 @@
+ALTER TABLE `ospos_sessions`
+  MODIFY COLUMN `data` MEDIUMBLOB NOT NULL;


### PR DESCRIPTION
Use MEDIUMBLOB type for session data storage. This should increase the max amount of items that can be stored in a cart.