### PR TITLE
Update Specific_supplier.php

### DIFF
--- a/application/models/reports/Specific_supplier.php
+++ b/application/models/reports/Specific_supplier.php
@@ -95,8 +95,8 @@ class Specific_supplier extends Report
 			$this->db->where('sale_type', SALE_TYPE_RETURN);
 		}
 
-		$this->db->group_by('sale_id');
-		$this->db->order_by('MAX(sale_date)');
+		$this->db->group_by('item_id');
+		$this->db->order_by('sale_id');
 
 		return $this->db->get()->result_array();
 	}


### PR DESCRIPTION
If items are grouped by sale_id then it will only show one line for each sale, even if multiple items are sold from supplier. Grouping by item_id will show multiple lines for each sale_id where an item from supplier is sold, thereby showing every item and matching the totals at the bottom of the report.