### PR TITLE
Update grunt to 1.4

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
     "POS"
   ],
   "devDependencies": {
-    "grunt": "~0.4.5",
+    "grunt-cli": "~1.4.0",
     "grunt-apigen": "^0.1.3",
     "grunt-bower": "^0.21.0",
     "grunt-bower-concat": "^1.0.0",

--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
     "POS"
   ],
   "devDependencies": {
-    "grunt-cli": "~1.4.0",
+    "grunt": "~1.4.0",
     "grunt-apigen": "^0.1.3",
     "grunt-bower": "^0.21.0",
     "grunt-bower-concat": "^1.0.0",


### PR DESCRIPTION
A CVE was found in the old version of Grunt. Update to the latest.