### PR TITLE
Language fallback

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -10,7 +10,6 @@ RUN apt-get update && DEBIAN_FRONTEND=noninteractive apt-get install -y \
 RUN a2enmod rewrite
 RUN docker-php-ext-install mysqli bcmath intl gd
 RUN echo "date.timezone = \"\${PHP_TIMEZONE}\"" > /usr/local/etc/php/conf.d/timezone.ini
-RUN echo -e “$(hostname -i)\t$(hostname) $(hostname).localhost” >> /etc/hosts
 
 WORKDIR /app
 COPY . /app

--- a/application/core/MY_Lang.php
+++ b/application/core/MY_Lang.php
@@ -10,10 +10,17 @@ class MY_Lang extends CI_Lang
             $CI->config->set_item('language', $idiom);
             $loaded = $this->is_loaded;
             $this->is_loaded = array();
-                
+
             foreach($loaded as $file)
             {
-                $this->load(strtr($file, '', '_lang.php'));
+                $filename = strtr($file, '', '_lang.php');
+                $this->load($filename, 'english');
+                $array = $this->load($filename, $idiom, TRUE);
+                foreach($array as $lang_key => $lang_value) {
+                    if ($lang_value != '') {
+                        $this->language[$lang_key] = $lang_value;
+                    }
+                }
             }
         }
     }

--- a/application/hooks/load_config.php
+++ b/application/hooks/load_config.php
@@ -26,8 +26,8 @@ function load_config()
         $CI->config->set_item('language_code', 'en-US');
     }
 
-    _load_language_files($CI, '../vendor/codeigniter/framework/system/language', current_language());
-    _load_language_files($CI, '../application/language', current_language_code());
+    _load_language_files($CI, '../vendor/codeigniter/framework/system/language', current_language(), FALSE);
+    _load_language_files($CI, '../application/language', current_language_code(), TRUE);
 
     //Set timezone from config database
     if($CI->config->item('timezone'))
@@ -46,16 +46,33 @@ function load_config()
  * @param $CI
  * @param $path
  * @param $language
+ * @param $fallback
  */
-function _load_language_files($CI, $path, $language)
+function _load_language_files($CI, $path, $language, $fallback)
 {
     $map = directory_map($path . DIRECTORY_SEPARATOR . $language);
 
     foreach($map as $file)
 	{
+
         if(!is_array($file) && substr(strrchr($file, '.'), 1) == 'php')
 		{
-            $CI->lang->load(strtr($file, '', '_lang.php'), $language);
+            $filename = strtr($file, '', '_lang.php');
+            if ($fallback) {
+                $CI->lang->load($filename, 'en-US');
+
+                $array = $CI->lang->load($filename, $language, TRUE);
+                foreach($array as $lang_key => $lang_value) {
+                    if ($lang_value !== '') {
+                        $CI->lang->language[$lang_key] = $lang_value;
+                    }
+                }
+            }
+            else
+            {
+                $CI->lang->load($filename, $language);
+            }
+
         }
     }
 }


### PR DESCRIPTION
This change will only load language lines in case they have a translation. English is the default fallback and any existing translation in the configured language will be override the base language.

This will make the app a bit more usable in languages that do not have complete translations yet.