### PR TITLE
Fixed missing function call

### DIFF
--- a/application/controllers/Items.php
+++ b/application/controllers/Items.php
@@ -914,7 +914,8 @@ class Items extends Secure_Controller
 						$is_failed_row = $this->data_error_check($row, $item_data, $allowed_stock_locations, $attribute_definition_names, $attribute_data);
 					}
 
-					$item_data = $this->item_lib->custom_array_filter($item_data);
+					//Remove FALSE, NULL, '' and empty strings but keep 0
+					$item_data = array_filter($item_data, 'strlen');
 
 					if(!$is_failed_row && $this->Item->save($item_data, $item_id))
 					{


### PR DESCRIPTION
This removes the function call to a function that doesn't exist anymore.
The replacement does the same job in one line of code.
Added comment to bring clarity to what the code is doing.

This code was producing an error message because custom_array_filter() no longer exists in the Item_lib.  I replaced it with this line which does the exact same function.