### PR TITLE
Correct bug preventing new item creation

### DIFF
--- a/application/controllers/Items.php
+++ b/application/controllers/Items.php
@@ -566,7 +566,7 @@ class Items extends Secure_Controller
 			$success = TRUE;
 			$new_item = FALSE;
 
-			if($item_id === NEW_ITEM)
+			if($item_id == NEW_ITEM)
 			{
 				$item_id = $item_data['item_id'];
 				$new_item = TRUE;


### PR DESCRIPTION
The `===` (type comparison equality operator) was preventing new items from being created because $item_id was coming through as a string and not an integer.

closes #3298 