### PR TITLE
[bug]changed the mount file name from database.sql to tables.sql

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -44,7 +44,7 @@ services:
         networks:
           - db_net
         volumes:
-          - ./database/database.sql:/docker-entrypoint-initdb.d/database.sql
+          - ./database/tables.sql:/docker-entrypoint-initdb.d/database.sql
           - mysql:/var/lib/mysql:rw
         environment:
           - MYSQL_ROOT_PASSWORD=pointofsale


### PR DESCRIPTION
there is no file named database.sql available in the database folder. I was able to use tables.sql to create my schema and was finally able to run the application after a migration at login. have raised the pull request anyways.