### PR TITLE
Mobile Reponsive

### DIFF
--- a/application/views/partial/header.php
+++ b/application/views/partial/header.php
@@ -1,6 +1,7 @@
 <!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Strict//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd">
 <html xmlns="http://www.w3.org/1999/xhtml">
 <head>
+	<meta name="viewport" content="width=device-width, initial-scale=1, maximum-scale=1, user-scalable=0">
 	<meta http-equiv="content-type" content="text/html; charset=utf-8" />
 	<base href="<?php echo base_url();?>" />
 	<title><?php echo $this->config->item('company') . ' | ' . $this->lang->line('common_powered_by') . ' OSPOS ' . $this->config->item('application_version') ?></title>

--- a/application/views/sales/register.php
+++ b/application/views/sales/register.php
@@ -24,10 +24,7 @@ if(isset($success))
 	<?php echo form_open($controller_name."/change_mode", array('id'=>'mode_form', 'class'=>'form-horizontal panel panel-default')); ?>
 		<div class="panel-body form-group">
 			<ul>
-				<li class="pull-left first_li">
-					<label class="control-label"><?php echo $this->lang->line('sales_mode'); ?></label>
-				</li>
-				<li class="pull-left">
+				<li class="pull-left" style="margin-left: 0;">
 					<?php echo form_dropdown('mode', $modes, $mode, array('onchange'=>"$('#mode_form').submit();", 'class'=>'selectpicker show-menu-arrow', 'data-style'=>'btn-default btn-sm', 'data-width'=>'fit')); ?>
 				</li>
 				<?php
@@ -83,11 +80,8 @@ if(isset($success))
 	<?php echo form_open($controller_name."/add", array('id'=>'add_item_form', 'class'=>'form-horizontal panel panel-default')); ?>
 		<div class="panel-body form-group">
 			<ul>
-				<li class="pull-left first_li">
-					<label for="item" class='control-label'><?php echo $this->lang->line('sales_find_or_scan_item_or_receipt'); ?></label>
-				</li>
-				<li class="pull-left">
-					<?php echo form_input(array('name'=>'item', 'id'=>'item', 'class'=>'form-control input-sm', 'size'=>'50', 'tabindex'=>++$tabindex)); ?>
+				<li class="pull-left" style="margin-left: 0; width: 80%;">
+					<?php echo form_input(array('name'=>'item', 'id'=>'item', 'class'=>'form-control input-sm', 'size'=>'40', 'tabindex'=>++$tabindex)); ?>
 					<span class="ui-helper-hidden-accessible" role="status"></span>
 				</li>
 				<li class="pull-right">
@@ -106,14 +100,13 @@ if(isset($success))
 	<table class="sales_table_100" id="register">
 		<thead>
 			<tr>
-				<th style="width: 5%; "><?php echo $this->lang->line('common_delete'); ?></th>
-				<th style="width: 15%;"><?php echo $this->lang->line('sales_item_number'); ?></th>
-				<th style="width: 30%;"><?php echo $this->lang->line('sales_item_name'); ?></th>
+				<th style="width: 4%; "><?php echo '-'; ?></th>
+				<th style="width: 10%;"><?php echo $this->lang->line('sales_item_number'); ?></th>
+				<th style="width: 38%;"><?php echo $this->lang->line('sales_item_name'); ?></th>
 				<th style="width: 10%;"><?php echo $this->lang->line('sales_price'); ?></th>
-				<th style="width: 10%;"><?php echo $this->lang->line('sales_quantity'); ?></th>
-				<th style="width: 15%;"><?php echo $this->lang->line('sales_discount'); ?></th>
-				<th style="width: 10%;"><?php echo $this->lang->line('sales_total'); ?></th>
-				<th style="width: 5%; "><?php echo $this->lang->line('sales_update'); ?></th>
+				<th style="width: 17%;"><?php echo $this->lang->line('sales_quantity'); ?></th>
+				<th style="width: 17%;"><?php echo $this->lang->line('sales_total'); ?></th>
+				<th style="width: 4%; font-size: 16px;"><?php echo '*'; ?></th>
 			</tr>
 		</thead>
 
@@ -178,6 +171,14 @@ if(isset($success))
 									echo form_hidden('price', to_currency_no_money($item['price']));
 								}
 								?>
+								
+								<div class="input-group" style="padding-top: 5px;">
+									<?php echo form_input(array('name'=>'discount', 'class'=>'form-control input-sm', 'value'=>$item['discount_type'] ? to_currency_no_money($item['discount']) : to_decimals($item['discount']), 'tabindex'=>++$tabindex, 'onClick'=>'this.select();')); ?>
+									<span class="input-group-btn">
+										<?php echo form_checkbox(array('id'=>'discount_toggle', 'name'=>'discount_toggle', 'value'=>1, 'data-toggle'=>"toggle",'data-size'=>'small', 'data-onstyle'=>'success', 'data-on'=>'<b>'.$this->config->item('currency_symbol').'</b>', 'data-off'=>'<b>%</b>', 'data-line'=>$line, 'checked'=>$item['discount_type'])); ?>
+									</span>
+								</div>
+								
 							</td>
 
 							<td>
@@ -194,14 +195,7 @@ if(isset($success))
 								?>
 							</td>
 
-							<td>
-								<div class="input-group">
-									<?php echo form_input(array('name'=>'discount', 'class'=>'form-control input-sm', 'value'=>$item['discount_type'] ? to_currency_no_money($item['discount']) : to_decimals($item['discount']), 'tabindex'=>++$tabindex, 'onClick'=>'this.select();')); ?>
-									<span class="input-group-btn">
-										<?php echo form_checkbox(array('id'=>'discount_toggle', 'name'=>'discount_toggle', 'value'=>1, 'data-toggle'=>"toggle",'data-size'=>'small', 'data-onstyle'=>'success', 'data-on'=>'<b>'.$this->config->item('currency_symbol').'</b>', 'data-off'=>'<b>%</b>', 'data-line'=>$line, 'checked'=>$item['discount_type'])); ?>
-									</span>
-								</div>
-							</td>
+
 
 							<td>
 								<?php
@@ -307,81 +301,15 @@ if(isset($success))
 			if(isset($customer))
 			{
 			?>
-				<table class="sales_table_100">
-					<tr>
-						<th style="width: 55%;"><?php echo $this->lang->line("sales_customer"); ?></th>
-						<th style="width: 45%; text-align: right;"><?php echo anchor('customers/view/'.$customer_id, $customer, array('class' => 'modal-dlg', 'data-btn-submit' => $this->lang->line('common_submit'), 'title' => $this->lang->line('customers_update'))); ?></th>
-					</tr>
-					<?php
-					if(!empty($customer_email))
-					{
-					?>
-						<tr>
-							<th style="width: 55%;"><?php echo $this->lang->line("sales_customer_email"); ?></th>
-							<th style="width: 45%; text-align: right;"><?php echo $customer_email; ?></th>
-						</tr>
-					<?php
-					}
-					?>
-					<?php
-					if(!empty($customer_address))
-					{
-					?>
-						<tr>
-							<th style="width: 55%;"><?php echo $this->lang->line("sales_customer_address"); ?></th>
-							<th style="width: 45%; text-align: right;"><?php echo $customer_address; ?></th>
-						</tr>
-					<?php
-					}
-					?>
-					<?php
-					if(!empty($customer_location))
-					{
-					?>
-						<tr>
-							<th style="width: 55%;"><?php echo $this->lang->line("sales_customer_location"); ?></th>
-							<th style="width: 45%; text-align: right;"><?php echo $customer_location; ?></th>
-						</tr>
-					<?php
-					}
-					?>
-					<tr>
-						<th style="width: 55%;"><?php echo $this->lang->line("sales_customer_discount"); ?></th>
-						<th style="width: 45%; text-align: right;"><?php echo ($customer_discount_type == FIXED)?to_currency($customer_discount):$customer_discount . '%'; ?></th>
-					</tr>
-					<?php if($this->config->item('customer_reward_enable') == TRUE): ?>
-					<?php
-					if(!empty($customer_rewards))
-					{
-					?>
-						<tr>
-							<th style="width: 55%;"><?php echo $this->lang->line("rewards_package"); ?></th>
-							<th style="width: 45%; text-align: right;"><?php echo $customer_rewards['package_name']; ?></th>
-						</tr>
-						<tr>
-							<th style="width: 55%;"><?php echo $this->lang->line("customers_available_points"); ?></th>
-							<th style="width: 45%; text-align: right;"><?php echo $customer_rewards['points']; ?></th>
-						</tr>
-					<?php
-					}
-					?>
-					<?php endif; ?>
-					<tr>
-						<th style="width: 55%;"><?php echo $this->lang->line("sales_customer_total"); ?></th>
-						<th style="width: 45%; text-align: right;"><?php echo to_currency($customer_total); ?></th>
-					</tr>
-					<?php
-					if(!empty($mailchimp_info))
-					{
-					?>
-						<tr>
-							<th style="width: 55%;"><?php echo $this->lang->line("sales_customer_mailchimp_status"); ?></th>
-							<th style="width: 45%; text-align: right;"><?php echo $mailchimp_info['status']; ?></th>
-						</tr>
-					<?php
-					}
-					?>
-				</table>
+				<div id="payment_details" style="width: 100%; text-align: center">
+						<?php echo $mog_name .' | Email: ' . $customer_email; ?><br/>
+						<b style="text-transform: uppercase"><?php echo anchor('customers/view/'.$customer_id, $customer, array('class' => 'modal-dlg', 'data-btn-submit' => $this->lang->line('common_submit'), 'title' => $this->lang->line('customers_update'))); ?></b><br/>
+						<?php echo $customer_address; ?><br/>
+						<?php echo $this->lang->line("sales_customer_discount"); ?>:&nbsp;<?php echo ($customer_discount_type == FIXED)?to_currency($customer_discount):$customer_discount . '%'; ?><br/>
+						<b style="text-transform: uppercase"><?php echo $this->lang->line("sales_sums"); ?>:&nbsp;<?php echo to_currency($customer_total); ?></b>
+						<hr></hr>
+						<b><?php echo $this->lang->line("sales_customer_mailchimp_status"); ?>:&nbsp;</b><?php echo $mailchimp_info['status']; ?><?php echo $customer_account_number; ?>
+				</div>
 
 				<button class="btn btn-danger btn-sm" id="remove_customer_button" title="<?php echo $this->lang->line('common_remove').' '.$this->lang->line('customers_customer')?>">
 					<span class="glyphicon glyphicon-remove">&nbsp</span><?php echo $this->lang->line('common_remove').' '.$this->lang->line('customers_customer') ?>
@@ -524,7 +452,7 @@ if(isset($success))
 							</tr>
 						</table>
 					<?php echo form_close(); ?>
-
+				
 					<div class='btn btn-sm btn-success pull-right' id='add_payment_button' tabindex="<?php echo ++$tabindex; ?>"><span class="glyphicon glyphicon-credit-card">&nbsp</span><?php echo $this->lang->line('sales_add_payment'); ?></div>
 				<?php
 				}

--- a/application/views/sales/register.php
+++ b/application/views/sales/register.php
@@ -302,7 +302,7 @@ if(isset($success))
 			{
 			?>
 				<div id="payment_details" style="width: 100%; text-align: center">
-						<?php echo $mog_name .' | Email: ' . $customer_email; ?><br/>
+						<?php echo $customer_name .' | Email: ' . $customer_email; ?><br/>
 						<b style="text-transform: uppercase"><?php echo anchor('customers/view/'.$customer_id, $customer, array('class' => 'modal-dlg', 'data-btn-submit' => $this->lang->line('common_submit'), 'title' => $this->lang->line('customers_update'))); ?></b><br/>
 						<?php echo $customer_address; ?><br/>
 						<?php echo $this->lang->line("sales_customer_discount"); ?>:&nbsp;<?php echo ($customer_discount_type == FIXED)?to_currency($customer_discount):$customer_discount . '%'; ?><br/>

--- a/public/css/ospos.css
+++ b/public/css/ospos.css
@@ -189,3 +189,211 @@ label.required
 	padding-right:0;
 	padding-left: 0;
 }
+
+
+/*!
+ * Mogsama Responsive Custom (in 3.3.4 it's in /public/public/dist/opensourcepos.min.css
+ * Combine with viewport in partial/header and login page
+/*! 
+
+
+/* General */
+
+.wrapper {
+	background: #e9ebee;
+}
+
+#add_item_form ul li, #mode_form ul li {
+  margin-left: 0.5em;
+}
+
+.panel {
+	border-radius: 6px;
+	box-shadow: none;
+}
+
+.panel-default {
+	border: none;
+}
+
+
+.alert-info {
+	background:#fff;
+	border: none;
+	font-weight: 900;
+	font-size: 18px;
+}
+
+.module_item a {
+    font-size:  16px;
+    font-weight: 700;
+    margin-top: 20px;
+}
+
+.btn-info {
+	background: #F2FFED;
+	border: 1px solid #85EF60;
+	color: darkred;
+}
+
+.form-control {
+	box-shadow: none;
+}
+
+#select_customer {
+	margin-left: 0;
+	margin-right: 0;
+}
+
+/* Sales box */
+
+#register {
+	border-bottom: 1px solid #d7dce5;
+}
+
+
+#register th {
+	color: #FFF;
+	background-color: #006EA6;
+	height: 48px;
+}
+
+#register td {
+	background-color: #FFF;
+	padding: 10px 3px;
+	text-align: center;
+}
+
+#register tr:hover td {
+	background: #D0DAFD;
+}
+
+#register_wrapper {
+  font-size: 15px;
+}
+
+#overall_sale {
+	float: right;
+	padding-bottom: 0;
+	font-size: 14px;
+}
+
+.sales_table_100 {
+    font-size: 14px;
+}
+
+.input-sm {
+	padding: 0 0 0 5px;
+	margin-top: 1px;
+	font-size: 14px;
+}
+
+.ui-menu .ui-menu-item-wrapper {
+	font-size: 15px;
+}
+
+.btn-sm, .btn-group-sm>.btn {
+	font-size: 13px;
+}
+
+#add_item_form {
+    border-radius: 6px 6px 0 0;
+    margin-top: 10px;
+}
+
+#add_item_form, #overall_sale {
+    background-color: #fff;
+}
+
+#payment_details, #payment_totals, #sale_totals {
+    line-height: 2.0;
+	margin-top: 5px 0;
+    border-top: 1px dashed #D0D3D8;
+}
+
+#payment_details {
+    border: 1px solid #ccc;
+    border-radius: 6px;
+	margin-bottom: 10px;
+}
+
+#mode_form, #payment_details {
+    background-color: #f1ffec;
+	color: #67676C;
+	font-weight: 500;
+}
+
+/* Receipt printing */
+#receipt_wrapper #barcode {
+	visibility: hidden;
+}
+
+#receipt_items td {
+	border-bottom: 1px solid #CCC;
+	padding: 5px 0;
+}
+
+#receipt_items th {
+	border-bottom: 1px solid #CCC;	
+}
+
+
+.jumbotron.push-spaces {
+    padding: 10px;
+}
+
+#footer {
+    margin: 0;
+    padding: 0;
+	margin-top: 150px;
+}
+
+
+@media screen and (min-width: 240px) and (max-width: 991px) {
+	.container {
+		width: 100%;
+	}
+
+	.topbar {
+		height: 0px;
+		padding: 0;
+	}
+	
+	.navbar .navbar-nav>li>a, .navbar-brand {
+		float: right;
+	}
+
+	label {
+		line-height: 36px;
+	}
+	
+	#register_wrapper {
+		width: 100%;
+		margin-bottom: 50px;
+		padding: 0 10px;
+	}
+
+	#overall_sale {
+		width: 90%;
+		margin-right: 5%;
+	}
+
+}
+
+@media (min-width: 992px) {
+  .container {
+    width: 98%;
+  }
+}
+
+@media (min-width: 1200px) {
+  .container {
+    width: 95%;
+  }
+}
+
+@media (min-width: 1600px) {
+  .container {
+    width: 90%;
+  }
+}


### PR DESCRIPTION
I'm just a shop owner, I'm not very good in coding. So I think you just take my code and idea as an example to enhance yours. My idea is:

1. Bigger register_wrapper and overall_sale panel on mobile only using min and max width. So one above and one below.
![147132283-2fd6fc7c-5582-4d93-b1da-6972178c00cf](https://user-images.githubusercontent.com/12387985/147187585-68032252-da65-4292-a4ce-df6896613aea.jpg)
2. This is made for us to use in backend. So it should be as simple and minimal as possible. We don't need to be told this is customer's name, that is customer address, etc. As a result I removed quite a lot of language code. Now the button is positioned in one row only and looks nice.
3. I cannot get the person's comments to appear on register so I use Account number instead. I think it is better for the staff to see it on register panel immediately to act accordingly.

I'm quite happy with OSPOS right now. Hope my idea can help you on your project too.

P/S: In 3.3.4 the css styles I added is in /public/public/dist/opensourcepos.min.css but I can't find it in the current master branch.