### PR TITLE
Enable npm package uploads for unstable (#2834)

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -21,6 +21,8 @@ script:
   - docker run --rm -v $(pwd):/app jekkos/composer composer install
   - docker run --rm -v $(pwd):/app jekkos/composer php bin/install.php translations develop
   - sed -i "s/'\(dev\)'/'$rev'/g" application/config/config.php
+  - version=$(grep application_version application/config/config.php | sed "s/.*=\s'\(.*\)';/\1/g")
+  - npm version "$version-$branch-$rev" --force
   - docker run --rm -it -v $(pwd):/app -w /app opensourcepos/node-grunt-bower
     sh -c "npm install && bower install && grunt package"
   - docker build . --target ospos -t ospos
@@ -33,23 +35,31 @@ env:
 after_success:
   - docker login -u="$DOCKER_USERNAME" -p="$DOCKER_PASSWORD" && docker tag "ospos:latest"
     "jekkos/opensourcepos:$TAG" && docker push "jekkos/opensourcepos:$TAG"
-before_deploy:
-  - version=$(grep application_version application/config/config.php | sed "s/.*=\s'\(.*\)';/\1/g")
   - TRAVIS_TAG=$(echo $branch.$version)
-  - git tag -f "$branch.$version"
-  - sudo mv dist/opensourcepos.zip "dist/opensourcepos.$branch.$version.zip"
+  - sudo mv dist/opensourcepos.tgz "dist/opensourcepos.$version.$rev.tgz"
+before_deploy:
+  - npm set //npm.pkg.github.com/:_authToken "$NPM_TOKEN"
 deploy:
-  provider: releases
-  file: "dist/opensourcepos.$branch.$version.zip"
-  name: "OpensourcePos Unstable"
-  release_notes_file: WHATS_NEW.txt
-  prerelease: true
-  skip_cleanup: true
+  - provider: npm
+    file: dist/opensourcepos.$version.$rev.tgz
+    registry: npm.pkg.github.com
+    email: jeroen@steganos.dev
+    skip_cleanup: true
+    api_key:
+      secure: U7dldktSgysAqFdsrr/epmWi5rC1rOZPOo+L85W5O70Kvm/m1P3DLuLoAMTIKRISu2Bgoo6KfJLQl+8TRpgfUA19nEy6uL2BwlEhmfOXKROWUBOgt3xOSmCFYQfIv/ubC2sznXVyvla6b+GIsNQb2QiFcYr0wFkc9RCca9Eum+k=
+    on:
+      all_branches: true
+  - provider: releases
+    file: dist/opensourcepos.$version.$rev.tgz
+    name: "OpensourcePos $version"
+    release_notes_file: WHATS_NEW.txt
+    prerelease: true
+    skip_cleanup: true
 
-  user: jekkos
-  overwrite: true
-  api_key:
-    secure: Ax25mMRDfHVf/HjRwqxYJe2oMnWC4sc2aKIiUxAOviVJJSCl4GMWhcFlUNnFsDcKIg2ofEGMVD6b9cTBuOwPDvymUDFnLNCCgDWve+vRDdWaTkTipn77Qk4c9UO9VvuzlPSKopChefPHlQ0n1rEmAMiKIXuqjUlNGqybW4FLP4E=
-  on:
-    all_branches: true
-
+    user: jekkos
+    overwrite: true
+    api_key:
+      secure: Ax25mMRDfHVf/HjRwqxYJe2oMnWC4sc2aKIiUxAOviVJJSCl4GMWhcFlUNnFsDcKIg2ofEGMVD6b9cTBuOwPDvymUDFnLNCCgDWve+vRDdWaTkTipn77Qk4c9UO9VvuzlPSKopChefPHlQ0n1rEmAMiKIXuqjUlNGqybW4FLP4E=
+    on:
+      tags: true
+      branch: master

--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -105,7 +105,7 @@ module.exports = function(grunt) {
 		cssmin: {
 			target: {
 				files: {
-					'public/dist/<%= pkg.name %>.min.css': ['tmp/opensourcepos_bower.css', 'public/css/*.css', '!public/css/login.css', '!public/css/login.min.css', '!public/css/invoice_email.css', '!public/css/barcode_font.css', '!public/css/darkly.css'],
+					'public/dist/opensourcepos.min.css': ['tmp/opensourcepos_bower.css', 'public/css/*.css', '!public/css/login.css', '!public/css/login.min.css', '!public/css/invoice_email.css', '!public/css/barcode_font.css', '!public/css/darkly.css'],
 					'public/css/login.min.css': ['public/css/login.css']
 				}
 			}
@@ -116,7 +116,7 @@ module.exports = function(grunt) {
 					separator: ';'
 				},
 				files: {
-					'tmp/<%= pkg.name %>.js': ['public/dist/jquery/jquery.js', 'tmp/opensourcepos_bower.js', 'public/js/*.js']
+					'tmp/opensourcepos.js': ['public/dist/jquery/jquery.js', 'tmp/opensourcepos_bower.js', 'public/js/*.js']
 				}
 			},
 			sql: {
@@ -131,11 +131,11 @@ module.exports = function(grunt) {
 		},
 		uglify: {
 			options: {
-				banner: '/*! <%= pkg.name %> <%= grunt.template.today("dd-mm-yyyy") %> */\n'
+				banner: '/*! opensourcepos <%= grunt.template.today("dd-mm-yyyy") %> */\n'
 			},
 			dist: {
 				files: {
-					'public/dist/<%= pkg.name %>.min.js': ['tmp/<%= pkg.name %>.js']
+					'public/dist/opensourcepos.min.js': ['tmp/opensourcepos.js']
 				}
 			}
 		},
@@ -261,8 +261,9 @@ module.exports = function(grunt) {
 		compress: {
 			main: {
 				options: {
-					mode: 'zip',
-					archive: 'dist/opensourcepos.zip'
+					mode: 'tar',
+					archive: 'dist/opensourcepos.tgz',
+					level: 2
 				},
 				files: [
 					{

--- a/package.json
+++ b/package.json
@@ -1,7 +1,11 @@
 {
-  "name": "opensourcepos",
+  "name": "@opensourcepos/opensourcepos",
   "version": "3.3.6",
   "description": "Open Source Point of Sale is a web-based point of sale system written in the PHP language. It uses MySQL as the data storage back-end and has a simple user interface.",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/opensourcepos/opensourcepos"
+  },
   "main": "index.php",
   "license": "MIT",
   "authors": [
@@ -9,14 +13,13 @@
     "FrancescoUK <francesco.lodolo.uk - at - gmail.com>"
   ],
   "scripts": {
-    "clean": "grunt clean:composer & grunt clean:bower & grunt clean:npm",
     "install": "composer install & bower install",
-    "test": "echo \"Error: no test specified\" && exit 1",
-    "update": "npm update & composer self-update & composer update"
+    "update": "npm update & composer self-update & composer update",
+    "clean": "grunt clean:composer & grunt clean:bower & grunt clean:npm",
+    "test": "echo \"Error: no test specified\" && exit 1"
   },
-  "repository": {
-    "type": "git",
-    "url": "https://github.com/opensourcepos/opensourcepos"
+  "publishConfig": {
+    "registry": "https://npm.pkg.github.com/"
   },
   "keywords": [
     "point-of-sale",


### PR DESCRIPTION
I tried to do some changes in the CI setup some time ago. In this case instead of pushing to github release I try to use npm and publish unstable builds to github npm repo. I think it can only hold 500MB so let's see how far we get with this. I could eventually just spin up a npm repo using docker on a nas at home here to host the unstable builds in case it's not easy enough to remove older builds during deploy