### PR TITLE
Use git tag in case of release (#2834)

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -30,12 +30,12 @@ script:
 env:
   global:
   - DOCKER_COMPOSE_VERSION=1.29.1
-  - TAG=$(echo ${TRAVIS_BRANCH} | sed s/feature\\///)
+  - BRANCH=$(echo ${TRAVIS_BRANCH} | sed s/feature\\///)
   - date=`date +%Y%m%d%H%M%S` && branch=${TRAVIS_BRANCH} && rev=`git rev-parse --short=6 HEAD` 
 after_success:
+  - TAG=${TRAVIS_TAG:-$BRANCH}
   - docker login -u="$DOCKER_USERNAME" -p="$DOCKER_PASSWORD" && docker tag "ospos:latest"
     "jekkos/opensourcepos:$TAG" && docker push "jekkos/opensourcepos:$TAG"
-  - TRAVIS_TAG=$(echo $branch.$version)
   - sudo mv dist/opensourcepos.tgz "dist/opensourcepos.$version.$rev.tgz"
 before_deploy:
   - npm set //npm.pkg.github.com/:_authToken "$NPM_TOKEN"


### PR DESCRIPTION
Currently we have the issue that demo server is not able to fetch the release container from docker hub. The reason is that the labels we use to push the container does not match the tag in git.

This change will set the docker hub tag to the git tag (in case of a release), or the branch name (in case the git tag is not present). 