### PR TITLE
Mount database.sql from docker volume (#3352)

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -26,6 +26,7 @@ script:
     sh -c "npm install && bower install && grunt package"
   - docker build . --target ospos -t ospos
   - docker-compose -f docker-compose.test.yml up --abort-on-container-exit
+  - docker build database/ -t jekkos/opensourcepos:sqlscript
 env:
   global:
   - DOCKER_COMPOSE_VERSION=1.29.1
@@ -34,7 +35,7 @@ env:
 after_success:
   - TAG=${TRAVIS_TAG:-$BRANCH}
   - docker login -u="$DOCKER_USERNAME" -p="$DOCKER_PASSWORD" && docker tag "ospos:latest"
-    "jekkos/opensourcepos:$TAG" && docker push "jekkos/opensourcepos:$TAG"
+    "jekkos/opensourcepos:$TAG" && docker push "jekkos/opensourcepos:$TAG" && docker push "jekkos/opensourcepos:sqlscript"
   - sudo mv dist/opensourcepos.tgz "dist/opensourcepos.$version.$rev.tgz"
 before_deploy:
   - npm set //npm.pkg.github.com/:_authToken "$NPM_TOKEN"

--- a/database/Dockerfile
+++ b/database/Dockerfile
@@ -1,0 +1,5 @@
+FROM alpine:3.14
+MAINTAINER jekkos
+
+ADD database.sql /docker-entrypoint-initdb.d/database.sql
+VOLUME /docker-entrypoint-initdb.d

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -13,6 +13,9 @@ networks:
     db_net:
 
 services:
+    sqlscript:
+        image: jekkos/opensourcepos:sqlscript
+        command: /bin/sh -c 'exit 0'
     ospos:
         image: jekkos/opensourcepos:3.3.7
         restart: always
@@ -43,8 +46,9 @@ services:
           - "3306"
         networks:
           - db_net
+        volumes_from:
+          - sqlscript
         volumes:
-          - ./database/database.sql:/docker-entrypoint-initdb.d/database.sql
           - mysql:/var/lib/mysql:rw
         environment:
           - MYSQL_ROOT_PASSWORD=pointofsale


### PR DESCRIPTION
This change wraps the database.sql created in the CI pipeline in a docker container and then mounts this within mysql. If this works then users do not have to rely on building the project with grunt and can just start the compose w/o any other extra actions.