### PR TITLE
Allow json_encode partial rendering  (#3387)

### DIFF
--- a/application/views/reports/tabular.php
+++ b/application/views/reports/tabular.php
@@ -52,7 +52,7 @@
 				exportTypes: ['json', 'xml', 'csv', 'txt', 'sql', 'excel', 'pdf'],
 				pagination: true,
 				showColumns: true,
-				data: <?php echo json_encode($data); ?>,
+				data: <?php echo json_encode($data, JSON_PARTIAL_OUTPUT_ON_ERROR+JSON_THROW_ON_ERROR); ?>,
 				iconSize: 'sm',
 				paginationVAlign: 'bottom',
 				escape: false


### PR DESCRIPTION
@daN4cat the first flag should change the json_encode behavior and try to render the output even if it errors. Maybe something you can try instead of changing the % signs? We could check if the first flag succeeds to replace the character correctly.

I have not tested this, so I'm not sure if the flag combination works. Perhaps using the PARTIAL flag alone is enough to work around the issue. If it's not able to render at all then I would rather see a proper error message instead of the encode function failing silently (which seems to be the default behavior).