### PR TITLE
Use POST to prevent CSRF logo attack (#3533)

### DIFF
--- a/application/views/configs/info_config.php
+++ b/application/views/configs/info_config.php
@@ -134,7 +134,7 @@ $(document).ready(function()
 {
 	$("a.fileinput-exists").click(function() {
 		$.ajax({
-			type: 'GET',
+			type: 'POST',
 			url: '<?php echo site_url("$controller_name/remove_logo"); ?>',
 			dataType: 'json'
 		})


### PR DESCRIPTION
A fix to make the logo removal work again.