### PR TITLE
Item thumbnail creation ported to CI4 

### DIFF
--- a/application/controllers/Items.php
+++ b/application/controllers/Items.php
@@ -82,8 +82,6 @@ class Items extends Secure_Controller
 
 	public function pic_thumb($pic_filename)
 	{
-		$this->load->helper('file');
-		// $this->load->library('image_lib');
 
 		$file_extension = pathinfo($pic_filename, PATHINFO_EXTENSION);
 		$images = glob('./uploads/item_pics/' . $pic_filename);

--- a/application/controllers/Items.php
+++ b/application/controllers/Items.php
@@ -83,7 +83,7 @@ class Items extends Secure_Controller
 	public function pic_thumb($pic_filename)
 	{
 		$this->load->helper('file');
-		$this->load->library('image_lib');
+		// $this->load->library('image_lib');
 
 		$file_extension = pathinfo($pic_filename, PATHINFO_EXTENSION);
 		$images = glob('./uploads/item_pics/' . $pic_filename);
@@ -97,17 +97,18 @@ class Items extends Secure_Controller
 
 			if(sizeof($images) < 2 && !file_exists($thumb_path))
 			{
-				$config['image_library'] = 'gd2';
-				$config['source_image']  = $image_path;
-				$config['maintain_ratio'] = TRUE;
-				$config['create_thumb'] = TRUE;
-				$config['width'] = 52;
-				$config['height'] = 32;
 
-				$this->image_lib->initialize($config);
-				$this->image_lib->resize();
+				$image_library = 'gd';
+				$source_image  = $image_path;
+				$maintain_ratio = TRUE;
+				$width = 52;
+				$height = 32;
 
-				$thumb_path = $this->image_lib->full_dst_path;
+				\Config\Services::image($image_library)
+				->withFile($source_image)
+				->resize($width, $height, $maintain_ratio)
+				->save($thumb_path);
+
 			}
 			$this->output->set_content_type(get_mime_by_extension($thumb_path));
 			$this->output->set_output(file_get_contents($thumb_path));


### PR DESCRIPTION
This PR brings closure to issue [3543](https://github.com/opensourcepos/opensourcepos/issues/3453).

The thumbnail creation in app/Controllers/Items:pic_thumb() has now been ported to use CI4 service **image**. Let me know if I've missed anything.

