### PR TITLE
int(1) to tinyint column updates

### DIFF
--- a/app/Database/Migrations/20230307000000_int_to_tinyint.php
+++ b/app/Database/Migrations/20230307000000_int_to_tinyint.php
@@ -1,0 +1,21 @@
+<?php
+
+namespace App\Database\Migrations;
+
+use CodeIgniter\Database\Migration;
+
+class IntToTinyint extends Migration
+{
+	public function up(): void
+	{
+		$this->db->query('ALTER TABLE ' . $this->db->prefixTable('customers') . ' MODIFY `consent` tinyint NOT NULL DEFAULT 0');
+		$this->db->query('ALTER TABLE ' . $this->db->prefixTable('cash_up') . ' MODIFY `note` tinyint NOT NULL DEFAULT 0');
+	}
+
+	public function down()
+	{
+		$this->db->query('ALTER TABLE ' . $this->db->prefixTable('customers') . ' MODIFY `consent` int NOT NULL DEFAULT 0');
+		$this->db->query('ALTER TABLE ' . $this->db->prefixTable('cash_up') . ' MODIFY `note` int NOT NULL DEFAULT 0');
+
+	}
+}


### PR DESCRIPTION
update int(1) columns in `_customers` and `_cash_up` tables to use tinyint finishes issue #3692 

Looking through each table after the migrations are run it looks like a lot of the old int(1) columns have been updated appropriately already.  These were the only remaining that looked like they would be good tinyint candidates.

Thanks.