### PR TITLE
Adapt "In dev mode, allow blank root password."

### DIFF
--- a/app/Config/Database.php
+++ b/app/Config/Database.php
@@ -102,20 +102,9 @@ class Database extends Config
     {
         parent::__construct();
 
-		if(!getenv('database.development.hostname'))
-		{
-			$this->development['hostname'] =  getenv('database.development.hostname');
-		}
-
-		if(!getenv('database.development.hostname'))
-		{
-			$this->development['username'] =  getenv('database.development.username');
-		}
-
-		if(!getenv('database.development.hostname'))
-		{
-			$this->development['password'] =  getenv('database.development.password');
-		}
+        $this->development['hostname'] =  getenv('database.development.hostname') ? getenv('database.development.hostname') : 'localhost';
+        $this->development['username'] =  getenv('database.development.username') ? getenv('database.development.username') : 'admin';
+        $this->development['password'] =  getenv('database.development.password') ? getenv('database.development.password') : 'pointofsale';
 
         // Ensure that we always set the database group to 'tests' if
         // we are currently running an automated test suite, so that

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -33,10 +33,10 @@ services:
           - CI_ENVIRONMENT=production
           - FORCE_HTTPS=false
           - PHP_TIMEZONE=UTC
-          - MYSQL_USERNAME=admin
-          - MYSQL_PASSWORD=pointofsale
+          - database.development.username=admin
+          - database.development.password=pointofsale
           - MYSQL_DB_NAME=ospos
-          - MYSQL_HOST_NAME=mysql
+          - database.development.hostname=mysql
 
     mysql:
         image: mariadb:10.5


### PR DESCRIPTION
This reverts commit 8db87fd5aba43d47b70cf6e0032ff2074778da30.

@SteveIreland I saw you added a commit to add a blank password, if this is set through the env variable, wil lthat then work for you? I think I should have used the `development.* ` variables instead as those values are picked up from the config.php file, if I'm not mistaken