### PR TITLE
allow unattended scheme mode

### DIFF
--- a/README.md
+++ b/README.md
@@ -96,8 +96,6 @@ NOTE: If you're running non-release code, please make sure you always run the la
 
 - If the avatar pictures are not shown in items or at item save you get an error, please make sure your `public` and subdirs are assigned to the correct owner and the access permission is set to `750`.
 
-- If you install OSPOS in Docker behind a proxy that performs `ssloffloading`, you can enable the URL generated to be HTTPS instead of HTTP, by activating the environment variable `FORCE_HTTPS = 1`.
-
 - If you install OSPOS behind a proxy and OSPOS constantly drops your session, consider whitelisting the proxy IP address by setting `$config['proxy_ips'] = '<proxy ip>';` in the [main php config file](https://github.com/opensourcepos/opensourcepos/blob/master/application/config/config.php). In extreme instances, changing `$config['sess_match_ip'] = TRUE;` to `FALSE` may also help.
 
 - If you have suhosin installed and face an issue with CSRF, please make sure you read [issue #1492](https://github.com/opensourcepos/opensourcepos/issues/1492).

--- a/application/config/config.php
+++ b/application/config/config.php
@@ -65,7 +65,7 @@ $config['db_log_enabled'] = FALSE;
 | a PHP script and you can easily do that on your own.
 |
 */
-$config['base_url'] .= '//' . ((isset($_SERVER['HTTP_HOST'])) ? $_SERVER['HTTP_HOST'] : 'localhost') ;
+$config['base_url'] = '//' . ((isset($_SERVER['HTTP_HOST'])) ? $_SERVER['HTTP_HOST'] : 'localhost') ;
 $config['base_url'] .= str_replace(basename($_SERVER['SCRIPT_NAME']), '', $_SERVER['SCRIPT_NAME']);
 
 /*

--- a/application/config/config.php
+++ b/application/config/config.php
@@ -65,9 +65,7 @@ $config['db_log_enabled'] = FALSE;
 | a PHP script and you can easily do that on your own.
 |
 */
-$config['https_on'] = (isset($_SERVER['HTTPS']) && $_SERVER['HTTPS'] == 'on') || (isset($_ENV['FORCE_HTTPS']) && $_ENV['FORCE_HTTPS'] == 'true');
-$config['base_url'] = $config['https_on'] ? 'https' : 'http';
-$config['base_url'] .= '://' . ((isset($_SERVER['HTTP_HOST'])) ? $_SERVER['HTTP_HOST'] : 'localhost') ;
+$config['base_url'] .= '//' . ((isset($_SERVER['HTTP_HOST'])) ? $_SERVER['HTTP_HOST'] : 'localhost') ;
 $config['base_url'] .= str_replace(basename($_SERVER['SCRIPT_NAME']), '', $_SERVER['SCRIPT_NAME']);
 
 /*
@@ -438,7 +436,7 @@ $config['sess_regenerate_destroy'] = FALSE;
 $config['cookie_prefix'] = '';
 $config['cookie_domain'] = '';
 $config['cookie_path'] = '/';
-$config['cookie_secure'] = $config['https_on'];
+$config['cookie_secure'] = TRUE
 $config['cookie_httponly'] = TRUE;
 
 /*

--- a/docker-compose.nginx.yml
+++ b/docker-compose.nginx.yml
@@ -28,7 +28,6 @@ services:
           - logs:/app/application/logs
         environment:
           - CI_ENV=${OSPOS_CI_ENV}
-          - FORCE_HTTPS=true
           - PHP_TIMEZONE=UTC
           - MYSQL_USERNAME=${OSPOS_MYSQL_USERNAME}
           - MYSQL_PASSWORD=${OSPOS_MYSQL_PASSWORD}

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -31,7 +31,6 @@ services:
           - logs:/app/application/logs
         environment:
           - CI_ENV=production
-          - FORCE_HTTPS=false
           - PHP_TIMEZONE=UTC
           - MYSQL_USERNAME=admin
           - MYSQL_PASSWORD=pointofsale


### PR DESCRIPTION
Allow unattended scheme mode disregarding the mode server runs.
This basically means you can simultaneously connect say it to http://localhost:8080 (for example, might be exposed locally via a container) as well as at the same time you are free to connect via https://my.domain.tld. Both will work. 