### PR TITLE
Handle missing mailchimp api key

### DIFF
--- a/app/Controllers/Config.php
+++ b/app/Controllers/Config.php
@@ -299,13 +299,13 @@ class Config extends Secure_Controller
 
 		if(check_encryption())	//TODO: Hungarian notation
 		{
-			$mailchimp_api_key = !isset($this->config['mailchimp_api_key'])
-				? ''
-				: $this->encrypter->decrypt($this->config['mailchimp_api_key']);
+			$mailchimp_api_key = isset($this->config['mailchimp_api_key'])
+				? $this->encrypter->decrypt($this->config['mailchimp_api_key'])
+				: '';
 
-			$mailchimp_list_id = !isset($this->config['mailchimp_list_id'])
-				? ''
-				: $this->encrypter->decrypt($this->config['mailchimp_list_id']);
+			$mailchimp_list_id = isset($this->config['mailchimp_list_id'])
+				? $this->encrypter->decrypt($this->config['mailchimp_list_id'])
+				: '';
 		}
 		else
 		{

--- a/app/Controllers/Config.php
+++ b/app/Controllers/Config.php
@@ -288,8 +288,16 @@ class Config extends Secure_Controller
 
 		if(check_encryption())	//TODO: Hungarian notation
 		{
-
-			$mailchimp_api_key = $this->config['mailchimp_api_key'];
+			//If mailchimp_api_key has not been configured react gracefully
+			if(isset($this->config['mailchimp_api_key']))
+			{
+			  $mailchimp_api_key = $this->config['mailchimp_api_key'];
+			}
+			else 
+			{
+			  $mailchimp_api_key = '';
+			}
+			
 			if(!empty($mailchimp_api_key))
 			{
 				$data['mailchimp']['api_key'] = $this->encrypter->decrypt($mailchimp_api_key);
@@ -299,7 +307,16 @@ class Config extends Secure_Controller
 				$data['mailchimp']['api_key'] = '';
 			}
 
-			$mailchimp_list_id = $this->config['mailchimp_list_id'];
+			//If mailchimp_list_id has not been configured react gracefully
+			if(isset($this->config['mailchimp_list_id']))
+			{
+			  $mailchimp_list_id = $this->config['mailchimp_list_id'];
+			}
+			else 
+			{
+			  $mailchimp_list_id = '';
+			}
+			
 			if(!empty($mailchimp_list_id))
 			{
 				$data['mailchimp']['list_id'] = $this->encrypter->decrypt($mailchimp_list_id);

--- a/app/Controllers/Config.php
+++ b/app/Controllers/Config.php
@@ -69,7 +69,16 @@ class Config extends Secure_Controller
 		$this->tax = model('Tax');
 		$this->config = config('OSPOS')->settings;
 		$this->db = Database::connect();
-		$this->encrypter = Services::encrypter();
+
+		helper('security');
+		if(check_encryption())
+		{
+			$this->encrypter = Services::encrypter();
+		}
+		else 
+		{
+			log_message('alert', 'Error preparing encryption key');
+		}
 	}
 
 	/*
@@ -288,43 +297,24 @@ class Config extends Secure_Controller
 
 		if(check_encryption())	//TODO: Hungarian notation
 		{
-			//If mailchimp_api_key has not been configured react gracefully
-			if(isset($this->config['mailchimp_api_key']))
-			{
-			  $mailchimp_api_key = $this->config['mailchimp_api_key'];
-			}
-			else 
-			{
-			  $mailchimp_api_key = '';
-			}
-			
-			if(!empty($mailchimp_api_key))
-			{
-				$data['mailchimp']['api_key'] = $this->encrypter->decrypt($mailchimp_api_key);
-			}
-			else
-			{
-				$data['mailchimp']['api_key'] = '';
-			}
 
-			//If mailchimp_list_id has not been configured react gracefully
-			if(isset($this->config['mailchimp_list_id']))
-			{
-			  $mailchimp_list_id = $this->config['mailchimp_list_id'];
-			}
-			else 
-			{
-			  $mailchimp_list_id = '';
-			}
+			$mailchimp_api_key = isset($this->config['mailchimp_api_key'])
+    			? $this->config['mailchimp_api_key']
+				: '';
+
+			$mailchimp_api_key = empty($mailchimp_api_key)
+    			? '' 
+				: $this->encrypter->decrypt($mailchimp_api_key);
+
+
+			$mailchimp_list_id = isset($this->config['mailchimp_list_id'])
+    			? $this->config['mailchimp_list_id']
+				: '';
 			
-			if(!empty($mailchimp_list_id))
-			{
-				$data['mailchimp']['list_id'] = $this->encrypter->decrypt($mailchimp_list_id);
-			}
-			else
-			{
-				$data['mailchimp']['list_id'] = '';
-			}
+			$mailchimp_list_id = empty($mailchimp_list_id)
+    			? '' 
+				: $this->encrypter->decrypt($mailchimp_list_id);
+
 		}
 		else
 		{

--- a/app/Controllers/Config.php
+++ b/app/Controllers/Config.php
@@ -277,7 +277,9 @@ class Config extends Secure_Controller
 		$data['tax_category_options'] = $this->tax_lib->get_tax_category_options();
 		$data['tax_jurisdiction_options'] = $this->tax_lib->get_tax_jurisdiction_options();
 		$data['show_office_group'] = $this->module->get_show_office_group();
-		$data['currency_code'] = $this->config['currency_code'];
+		$data['currency_code'] = isset($this->config['currency_code'])
+			? $this->config['currency_code']
+			: '' ;
 		$data['db_version'] = mysqli_get_server_info(db_connect()->mysqli);
 
 		// load all the license statements, they are already XSS cleaned in the private function
@@ -297,24 +299,13 @@ class Config extends Secure_Controller
 
 		if(check_encryption())	//TODO: Hungarian notation
 		{
+			$mailchimp_api_key = !isset($this->config['mailchimp_api_key'])
+				? ''
+				: $this->encrypter->decrypt($this->config['mailchimp_api_key']);
 
-			$mailchimp_api_key = isset($this->config['mailchimp_api_key'])
-    			? $this->config['mailchimp_api_key']
-				: '';
-
-			$mailchimp_api_key = empty($mailchimp_api_key)
-    			? '' 
-				: $this->encrypter->decrypt($mailchimp_api_key);
-
-
-			$mailchimp_list_id = isset($this->config['mailchimp_list_id'])
-    			? $this->config['mailchimp_list_id']
-				: '';
-			
-			$mailchimp_list_id = empty($mailchimp_list_id)
-    			? '' 
-				: $this->encrypter->decrypt($mailchimp_list_id);
-
+			$mailchimp_list_id = !isset($this->config['mailchimp_list_id'])
+				? ''
+				: $this->encrypter->decrypt($this->config['mailchimp_list_id']);
 		}
 		else
 		{

--- a/app/Libraries/Mailchimp_lib.php
+++ b/app/Libraries/Mailchimp_lib.php
@@ -41,17 +41,10 @@ class MailchimpConnector
 
 		$encrypter = Services::encrypter();
 
-		//If mailchimp_api_key has not been configured react gracefully
-		if(isset($this->config['mailchimp_api_key']))
-		{
-		  $mailchimp_api_key = $this->config['mailchimp_api_key'];
-		}
-		else 
-		{
-		  $mailchimp_api_key = '';
-		}
+		$mailchimp_api_key = isset($this->config['mailchimp_api_key'])
+			? $this->config['mailchimp_api_key']
+			: '';
 			
-
 		if(!empty($mailchimp_api_key))
 		{
 			$this->_api_key = empty($api_key)

--- a/app/Libraries/Mailchimp_lib.php
+++ b/app/Libraries/Mailchimp_lib.php
@@ -41,7 +41,16 @@ class MailchimpConnector
 
 		$encrypter = Services::encrypter();
 
-		$mailchimp_api_key = $config['mailchimp_api_key'];
+		//If mailchimp_api_key has not been configured react gracefully
+		if(isset($this->config['mailchimp_api_key']))
+		{
+		  $mailchimp_api_key = $this->config['mailchimp_api_key'];
+		}
+		else 
+		{
+		  $mailchimp_api_key = '';
+		}
+			
 
 		if(!empty($mailchimp_api_key))
 		{

--- a/app/Libraries/Mailchimp_lib.php
+++ b/app/Libraries/Mailchimp_lib.php
@@ -44,7 +44,7 @@ class MailchimpConnector
 		$mailchimp_api_key = isset($this->config['mailchimp_api_key'])
 			? $this->config['mailchimp_api_key']
 			: '';
-			
+
 		if(!empty($mailchimp_api_key))
 		{
 			$this->_api_key = empty($api_key)


### PR DESCRIPTION
Wrap calls to extract the key in defensive code so the system responds gracefully if the key is not set, instead of crashing