### PR TITLE
Correct some anomalies around bootstrap_tables_locale.php

### DIFF
--- a/app/Language/en-US/Attributes.php
+++ b/app/Language/en-US/Attributes.php
@@ -19,7 +19,7 @@ return [
 	"definition_unit" => "Measurement Unit",
 	"definition_values" => "Attribute Values",
 	"new" => "New Attribute",
-	"no_attributes_to_display" => "No Items to display",
+	"no_attributes_to_display" => "No Attributes to display",
 	"receipt_visibility" => "Receipt",
 	"show_in_items" => "Show in items",
 	"show_in_items_visibility" => "Items",

--- a/app/Language/en-US/Bootstrap_tables.php
+++ b/app/Language/en-US/Bootstrap_tables.php
@@ -4,8 +4,8 @@ return [
 	"tables_columns" => "Columns",
 	"tables_hide_show_pagination" => "Hide/Show pagination",
 	"tables_loading" => "Loading, please wait...",
-	"tables_page_from_to" => "Showing {0} to {1} of {2} rows",
+	"tables_page_from_to" => "Showing {pageFrom} to {pageTo} of {totalRows} rows",
 	"tables_refresh" => "Refresh",
-	"tables_rows_per_page" => "{0} rows per page",
+	"tables_rows_per_page" => "{pageNumber} rows per page",
 	"tables_toggle" => "Toggle",
 ];

--- a/app/Views/partial/bootstrap_tables_locale.php
+++ b/app/Views/partial/bootstrap_tables_locale.php
@@ -11,18 +11,18 @@
 			return "<?php echo lang('Bootstrap_tables.loading') ?>";
 		},
 		formatRecordsPerPage: function (pageNumber) {
-			return "<?php echo lang('Bootstrap_tables.rows_per_page') ?>".replace('{0}', pageNumber);
+			return "<?php echo lang('Bootstrap_tables.rows_per_page') ?>".replace('{pageNumber}', pageNumber);
 		},
 		formatShowingRows: function (pageFrom, pageTo, totalRows) {
-			return "<?php echo lang('Bootstrap_tables.page_from_to') ?>".replace('{0}', pageFrom).replace('{1}', pageTo).replace('{2}', totalRows);
+			return "<?php echo lang('Bootstrap_tables.tables_page_from_to') ?>".replace('{pageFrom}', pageFrom).replace('{pageTo}', pageTo).replace('{totalRows}', totalRows);    
 		},
 		formatSearch: function () {
 			return "<?php echo lang('Common.search') ?>";
 		},
 		formatNoMatches: function () {
 			return "<?php echo lang(preg_match('(customers|suppliers|employees)', $controller_name)
-				? 'common_no_persons_to_display'
-				: "$controller_name.no_$controller_name" . '_to_display')
+				? 'Common.no_persons_to_display'
+				: ucfirst($controller_name) . '.no_' . $controller_name . '_to_display')
 			?>";
 		},
 		formatPaginationSwitch: function () {


### PR DESCRIPTION
The lang() strings being processed by this code now function correctly and a typo in Languages/en-US/Attributes.php has been corrected.