### PR TITLE
CI4: Bugfix - add function to remove .env.bak issue #3826

### DIFF
--- a/app/Controllers/Config.php
+++ b/app/Controllers/Config.php
@@ -299,6 +299,12 @@ class Config extends Secure_Controller
 
 		if(check_encryption())	//TODO: Hungarian notation
 		{
+			if(!isset($this->encrypter))
+			{
+				helper('security');
+				$this->encrypter = Services::encrypter();
+			}
+			
 			$mailchimp_api_key = isset($this->config['mailchimp_api_key'])
 				? $this->encrypter->decrypt($this->config['mailchimp_api_key'])
 				: '';
@@ -306,6 +312,9 @@ class Config extends Secure_Controller
 			$mailchimp_list_id = isset($this->config['mailchimp_list_id'])
 				? $this->encrypter->decrypt($this->config['mailchimp_list_id'])
 				: '';
+
+			//Remove any backup of .env created by check_encryption()
+			remove_backup();
 		}
 		else
 		{

--- a/app/Database/Migrations/20220127000000_convert_to_ci4.php
+++ b/app/Database/Migrations/20220127000000_convert_to_ci4.php
@@ -71,6 +71,11 @@ class Convert_to_ci4 extends Migration
 				abort_encryption_conversion();
 				throw new RedirectException('login');
 			}
+			else 
+			{
+				//Remove any backup of .env created by check_encryption()
+				remove_backup();
+			}
 
 			$appconfig->batch_save($ci4_encrypted_data);
 		} catch(RedirectException $e)

--- a/app/Helpers/security_helper.php
+++ b/app/Helpers/security_helper.php
@@ -90,3 +90,14 @@ function abort_encryption_conversion()
 		log_message('info', "File $config_path has been updated to undo encryption conversion"); 
 	}
 }
+
+function remove_backup()
+{
+	$backup_path = WRITEPATH . '/backup/.env.bak';
+	if(unlink($backup_path) === false)
+	{
+		log_message('error', "Unable to remove $backup_path.");
+		return;
+	}
+	log_message('info', "File $backup_path has been removed"); 
+}


### PR DESCRIPTION
Added function remove_backup() to security_helper.php. Added a call to this from the two places that call check_encryption where the backup is created. Added more defensive code to Config.php to ensure the encrypter  objectexists before it is called to avoid a crash.