### PR TITLE
CI4: Bugfix correct the removal of env backup

### DIFF
--- a/app/Database/Migrations/20220127000000_convert_to_ci4.php
+++ b/app/Database/Migrations/20220127000000_convert_to_ci4.php
@@ -32,6 +32,8 @@ class Convert_to_ci4 extends Migration
 			check_encryption();
 		}
 
+		remove_backup();
+
 		error_log('Migrating to CodeIgniter4 formats completed');
 	}
 
@@ -69,12 +71,8 @@ class Convert_to_ci4 extends Migration
 			if(!$success)
 			{
 				abort_encryption_conversion();
-				throw new RedirectException('login');
-			}
-			else 
-			{
-				//Remove any backup of .env created by check_encryption()
 				remove_backup();
+				throw new RedirectException('login');
 			}
 
 			$appconfig->batch_save($ci4_encrypted_data);

--- a/app/Helpers/security_helper.php
+++ b/app/Helpers/security_helper.php
@@ -94,6 +94,10 @@ function abort_encryption_conversion()
 function remove_backup()
 {
 	$backup_path = WRITEPATH . '/backup/.env.bak';
+	if( ! file_exists($backup_path))
+	{
+		return;
+	}
 	if(unlink($backup_path) === false)
 	{
 		log_message('error', "Unable to remove $backup_path.");


### PR DESCRIPTION
The previous version of the migration script only removed the backup under one set of circumstances. This version attempts to  remove the backup in all cases once the script either succeeds and returns from function up(), or fails and redirects back to login from function convert_ci3_encrypted_data(). We now have to test if the file exists before attempting to remove it in the security_helper function remove_backup().