### PR TITLE
CI4: Bugfix test sanity of config item

### DIFF
--- a/app/Controllers/Config.php
+++ b/app/Controllers/Config.php
@@ -305,11 +305,11 @@ class Config extends Secure_Controller
 				$this->encrypter = Services::encrypter();
 			}
 			
-			$mailchimp_api_key = isset($this->config['mailchimp_api_key'])
+			$mailchimp_api_key = (isset($this->config['mailchimp_api_key']) && !empty($this->config['mailchimp_api_key']))
 				? $this->encrypter->decrypt($this->config['mailchimp_api_key'])
 				: '';
 
-			$mailchimp_list_id = isset($this->config['mailchimp_list_id'])
+			$mailchimp_list_id = (isset($this->config['mailchimp_list_id']) && !empty($this->config['mailchimp_list_id']))
 				? $this->encrypter->decrypt($this->config['mailchimp_list_id'])
 				: '';
 

--- a/app/Libraries/Mailchimp_lib.php
+++ b/app/Libraries/Mailchimp_lib.php
@@ -41,7 +41,7 @@ class MailchimpConnector
 
 		$encrypter = Services::encrypter();
 
-		$mailchimp_api_key = isset($this->config['mailchimp_api_key'])
+		$mailchimp_api_key = (isset($this->config['mailchimp_api_key']) && !empty($this->config['mailchimp_api_key']))
 			? $this->config['mailchimp_api_key']
 			: '';
 


### PR DESCRIPTION
Add a !empty test when dereferencing mailchimp_api_key and mailchimp_list_id from the config array.