### PR TITLE
Fix for attribute addition for items

### DIFF
--- a/app/Views/attributes/item.php
+++ b/app/Views/attributes/item.php
@@ -30,7 +30,7 @@ foreach($definition_values as $definition_id => $definition_value)
 	<div class='col-xs-8'>
 		<div class="input-group">
 			<?php
-				echo form_hidden("attribute_ids[$definition_id]", $definition_value['attribute_id']);
+				echo form_hidden("attribute_ids[$definition_id]", strval($definition_value['attribute_id']));
 				$attribute_value = $definition_value['attribute_value'];
 
 				switch($definition_value['definition_type'])


### PR DESCRIPTION
The form_hidden expects a string and the value inputted is always -1. So it should be casted to string