### PR TITLE
Fixed csv import when updating items that have a barcode

### DIFF
--- a/app/Controllers/Items.php
+++ b/app/Controllers/Items.php
@@ -1103,7 +1103,7 @@ class Items extends Secure_Controller
 						$item_data['is_serialized'] = empty($row['Item has Serial Number'])? '0' : '1';
 					}
 
-					if(!empty($row['Barcode']))
+					if(!empty($row['Barcode']) && !$is_update)
 					{
 						$item_data['item_number'] = $row['Barcode'];
 						$is_failed_row = $this->item->item_number_exists($item_data['item_number']);


### PR DESCRIPTION
If the item is being updated, the check if there is an existing item with the same barcode does not make sense.