### PR TITLE
Start Daily Sales with selected customer

### DIFF
--- a/app/Controllers/Sales.php
+++ b/app/Controllers/Sales.php
@@ -96,8 +96,21 @@ class Sales extends Secure_Controller
 				'only_due' => lang('Sales.due_filter'),
 				'only_check' => lang('Sales.check_filter'),
 				'only_creditcard' => lang('Sales.credit_filter'),
-				'only_invoices' => lang('Sales.invoice_filter')
+				'only_invoices' => lang('Sales.invoice_filter'),
+				'selected_customer' => lang('Sales.selected_customer')
 			];
+
+			if($this->sale_lib->get_customer() != -1)
+			{
+				$selected_filters = ['selected_customer'];
+				$data['customer_selected'] = true;
+			}
+			else
+			{
+				$data['customer_selected'] = false;
+				$selected_filters = [];
+			}
+			$data['selected_filters'] = $selected_filters;
 
 			echo view('sales/manage', $data);
 		}
@@ -134,6 +147,7 @@ class Sales extends Secure_Controller
 			'only_cash' => false,
 			'only_due' => false,
 			'only_check' => false,
+			'selected_customer' => false,
 			'only_creditcard' => false,
 			'only_invoices' => $this->config['invoice_enable'] && $this->request->getGet('only_invoices', FILTER_SANITIZE_NUMBER_INT),
 			'is_valid_receipt' => $this->sale->is_valid_receipt($search)

--- a/app/Language/en-GB/Sales.php
+++ b/app/Language/en-GB/Sales.php
@@ -173,6 +173,7 @@ return [
 	"sales_tax" => "Sales Tax",
 	"sales_total" => "",
 	"select_customer" => "Select Customer",
+	"selected_customer" => "Selected Customer",
 	"send_invoice" => "Send Invoice",
 	"send_quote" => "Send Quote",
 	"send_receipt" => "Send Receipt",

--- a/app/Language/en/Sales.php
+++ b/app/Language/en/Sales.php
@@ -173,6 +173,7 @@ return [
 	"sales_tax" => "Sales Tax",
 	"sales_total" => "",
 	"select_customer" => "Select Customer",
+	"selected_customer" => "Selected Customer",
 	"send_invoice" => "Send Invoice",
 	"send_quote" => "Send Quote",
 	"send_receipt" => "Send Receipt",

--- a/app/Models/Sale.php
+++ b/app/Models/Sale.php
@@ -1559,6 +1559,13 @@ class Sale extends Model
 			$builder->where('sales_items.item_location', $filters['location_id']);
 		}
 
+		if($filters['selected_customer'] != false)
+		{
+			$sale_lib = new Sale_lib();
+			$builder->where('sales.customer_id', $sale_lib->get_customer());
+		}
+
+
 		if($filters['only_invoices'])
 		{
 			$builder->where('sales.invoice_number IS NOT NULL');

--- a/app/Views/sales/manage.php
+++ b/app/Views/sales/manage.php
@@ -3,6 +3,7 @@
  * @var string $controller_name
  * @var string $table_headers
  * @var array $filters
+ * @var array $selected_filters
  * @var array $config
  */
 ?>
@@ -74,7 +75,7 @@ $(document).ready(function()
 		</button>
 
 		<?= form_input (['name' => 'daterangepicker', 'class' => 'form-control input-sm', 'id' => 'daterangepicker']) ?>
-		<?= form_multiselect('filters[]', $filters, [''], ['id' => 'filters', 'data-none-selected-text'=>lang('Common.none_selected_text'), 'class' => 'selectpicker show-menu-arrow', 'data-selected-text-format' => 'count > 1', 'data-style' => 'btn-default btn-sm', 'data-width' => 'fit']) ?>
+		<?= form_multiselect('filters[]', $filters, $selected_filters, ['id' => 'filters', 'data-none-selected-text'=>lang('Common.none_selected_text'), 'class' => 'selectpicker show-menu-arrow', 'data-selected-text-format' => 'count > 1', 'data-style' => 'btn-default btn-sm', 'data-width' => 'fit']) ?>
 	</div>
 </div>
 


### PR DESCRIPTION
This is the small change that was mentioned in #4017 that will allow the user to select a customer for the register and then quickly check the daily sales without needing to filter on the customer.   The Daily Sales will initially show what sales happened on the same day, but the user can quickly change to a broader span of time for the selected customer. 

It's been tested on PHP 8.3.7 and MySQL 8.4, but I've had the same changes working on PHP 7 and MySQL 5.6.
