### PR TITLE
An attempt to resolve issue #4025.  

### DIFF
--- a/app/Controllers/Sales.php
+++ b/app/Controllers/Sales.php
@@ -547,7 +547,7 @@ class Sales extends Secure_Controller
 			}
 		}
 
-		$item_id_or_number_or_item_kit_or_receipt = (int)$this->request->getPost('item', FILTER_SANITIZE_FULL_SPECIAL_CHARS);
+		$item_id_or_number_or_item_kit_or_receipt = $this->request->getPost('item', FILTER_SANITIZE_FULL_SPECIAL_CHARS);
 		$this->token_lib->parse_barcode($quantity, $price, $item_id_or_number_or_item_kit_or_receipt);
 		$mode = $this->sale_lib->get_mode();
 		$quantity = ($mode == 'return') ? -$quantity : $quantity;

--- a/app/Libraries/Sale_lib.php
+++ b/app/Libraries/Sale_lib.php
@@ -1373,7 +1373,7 @@ class Sale_lib
 	 * @param string $stock_warning
 	 * @return bool
 	 */
-	public function add_item_kit(string $external_item_kit_id, int $item_location, float $discount, string $discount_type, bool $kit_price_option, bool $kit_print_option, string &$stock_warning): bool
+	public function add_item_kit(string $external_item_kit_id, int $item_location, float $discount, string $discount_type, bool $kit_price_option, bool $kit_print_option, ?string &$stock_warning): bool
 	{
 		//KIT #
 		$pieces = explode(' ', $external_item_kit_id);

--- a/app/Models/Item_kit.php
+++ b/app/Models/Item_kit.php
@@ -40,7 +40,7 @@ class Item_kit extends Model
 	/**
 	 * Check if a given item_id is an item kit
 	 */
-	public function is_valid_item_kit(int $item_kit_id): bool
+	public function is_valid_item_kit(string $item_kit_id): bool
 	{
 		if(!empty($item_kit_id))
 		{
@@ -98,7 +98,7 @@ class Item_kit extends Model
 	/**
 	 * Gets information about a particular item kit
 	 */
-	public function get_info(int $item_kit_id): object
+	public function get_info(string $item_kit_id): object
 	{
 		$builder = $this->db->table('item_kits');
 		$builder->select('


### PR DESCRIPTION
Since a kit item code is prefixed by "KIT" it's not going to work to always assume that the item id is numeric.  So "int"  needs to be replaced with "string".

I haven't yet fully tested the impact of this change, but I believe these changes were the only ones I made that allowed me to add a kit item to a sale.   But, I'm in a time crunch at the moment, so I'm submitting this as a draft and will do more testing this evening and finalize it then.