### PR TITLE
Minor improvements to migrations to report to the log any failures and remove unnecessary key definitions.

### DIFF
--- a/app/Database/Migrations/20170502221506_sales_tax_data.php
+++ b/app/Database/Migrations/20170502221506_sales_tax_data.php
@@ -153,6 +153,13 @@ class Migration_Sales_Tax_Data extends Migration
 			. $this->db->prefixTable('sales_taxes')
 			. ' as ST ON SIT.sale_id = ST.sale_id WHERE ST.sale_id is null GROUP BY SIT.sale_id, ST.sale_id'
 			. ' ORDER BY SIT.sale_id) as US')->getResultArray();
+
+		if(!$result)
+		{
+			error_log('Database error in 20170502221506_sales_tax_data.php related to sales_taxes or sales_items_taxes.');
+			return 0;
+		}
+
 		return $result[0]['COUNT(*)'] ?: 0;
 	}
 

--- a/app/Database/Migrations/20200202000000_taxamount.php
+++ b/app/Database/Migrations/20200202000000_taxamount.php
@@ -133,6 +133,13 @@ class Migration_TaxAmount extends Migration
 			. ' as ST ON SIT.sale_id = ST.sale_id GROUP BY SIT.sale_id, ST.sale_id'
 			. ' ORDER BY SIT.sale_id) as US')->getResultArray();
 
+		if(!$result)
+		{
+			error_log('Database error in 20200202000000_taxamount.php related to sales_taxes or sales_items_taxes.');
+			return 0;
+		}
+
+
 		return $result[0]['COUNT(*)'] ?: 0;
 	}
 

--- a/app/Database/Migrations/20240630000001_fix_keys_for_db_upgrade.php
+++ b/app/Database/Migrations/20240630000001_fix_keys_for_db_upgrade.php
@@ -3,6 +3,7 @@
 namespace App\Database\Migrations;
 
 use CodeIgniter\Database\Migration;
+use Config\Database;
 
 class Migration_fix_keys_for_db_upgrade extends Migration
 {
@@ -22,6 +23,10 @@ class Migration_fix_keys_for_db_upgrade extends Migration
 		$this->db->query('ALTER TABLE ' . $this->db->prefixTable('sales_items_taxes')
 			. ' ADD CONSTRAINT ospos_sales_items_taxes_ibfk_1 FOREIGN KEY (sale_id, item_id, line) '
 			. ' REFERENCES ' . $this->db->prefixTable('sales_items') . ' (sale_id, item_id, line)');
+
+		$this->delete_index('customers', 'person_id');
+		$this->delete_index('employees', 'person_id');
+		$this->delete_index('suppliers', 'person_id');
 	}
 
 	/**
@@ -40,5 +45,17 @@ class Migration_fix_keys_for_db_upgrade extends Migration
 		$this->db->query('ALTER TABLE ' . $this->db->prefixTable('sales_items_taxes')
 			. ' ADD CONSTRAINT ospos_sales_items_taxes_ibfk_1 FOREIGN KEY (sale_id) '
 			. ' REFERENCES ' . $this->db->prefixTable('sales_items') . ' (sale_id)');
+	}
+
+	private function delete_index(string $table, string $index): void
+	{
+		$result = $this->db->query('SELECT COUNT(*) FROM information_schema.statistics WHERE table_schema = DATABASE() AND table_name = \'' . $this->db->getPrefix() . "$table' AND index_name = '$index'");
+		$index_exists = $result->getRowArray()['COUNT(*)'] > 0;
+
+		if($index_exists)
+		{
+			$forge = Database::forge();
+			$forge->dropKey($table, $index, false);
+		}
 	}
 }


### PR DESCRIPTION
This includes a few tweaks to better handle detected database errors during migration so that they are reported when detected via CI4's new query failure.  It also removes three unnecessary person_id indexes if detected after migration.