### PR TITLE
Add english fallback if no translation (#3995)

### DIFF
--- a/app/Config/Services.php
+++ b/app/Config/Services.php
@@ -3,6 +3,8 @@
 namespace Config;
 
 use CodeIgniter\Config\BaseService;
+use CodeIgniter\HTTP\IncomingRequest;
+use Config\Services as AppServices;
 use HTMLPurifier;
 use HTMLPurifier_Config;
 
@@ -31,6 +33,29 @@ class Services extends BaseService
      *     return new \CodeIgniter\Example();
      * }
      */
+
+	/**
+	 * Responsible for loading the language string translations.
+	 *
+	 * @return MY_Language
+	 */
+	public static function language(?string $locale = null, bool $getShared = true)
+	{
+		if ($getShared) {
+			return static::getSharedInstance('language', $locale)->setLocale($locale);
+		}
+
+		if (AppServices::get('request') instanceof IncomingRequest) {
+			$requestLocale = AppServices::get('request')->getLocale();
+		} else {
+			$requestLocale = Locale::getDefault();
+		}
+
+		// Use '?:' for empty string check
+		$locale = $locale ?: $requestLocale;
+
+		return new \App\Libraries\MY_Language($locale);
+	}
 
 	private static $htmlPurifier;
 

--- a/app/Libraries/MY_Language.php
+++ b/app/Libraries/MY_Language.php
@@ -1,0 +1,44 @@
+<?php
+namespace app\Libraries;
+
+use CodeIgniter\Language\Language;
+
+class MY_Language extends Language {
+
+	public function getLine(string $line, array $args = [])
+	{
+// if no file is given, just parse the line
+		if ( ! str_contains($line, '.'))
+		{
+			return $this->formatMessage($line, $args);
+		}
+
+// Parse out the file name and the actual alias.
+// Will load the language file and strings.
+		[$file, $parsedLine] = $this->parseLine($line, $this->locale);
+
+		$output = $this->getTranslationOutput($this->locale, $file, $parsedLine);
+
+		if ($output === NULL && strpos($this->locale, '-'))
+		{
+			[$locale] = explode('-', $this->locale, 2);
+
+			[$file, $parsedLine] = $this->parseLine($line, $locale);
+
+			$output = $this->getTranslationOutput($locale, $file, $parsedLine);
+		}
+
+		// if still not found, try English
+		if ($output === NULL || $output === "")
+		{
+			[$file, $parsedLine] = $this->parseLine($line, 'en');
+
+			$output = $this->getTranslationOutput('en', $file, $parsedLine);
+		}
+
+		$output ??= $line;
+
+		return $this->formatMessage($output, $args);
+	}
+
+}


### PR DESCRIPTION
@BudsieBuds I have overridden the default CI4 behavior for loading language strings. The fallback was in place but it was not enabled in case the string did already exist in a translation. So I have extended the Language class with one of our own and made this minor modification to do the fallback also in this case.