### PR TITLE
Add PHP_CodeSniffer IDE Linter and enforce PSR-12

### DIFF
--- a/.phpcs.xml
+++ b/.phpcs.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0"?>
+<ruleset name="OSPOSStandard">
+	<description>Custom Coding Standard based on PSR-12 for OpenSourcePOS</description>
+	<arg name="tab-width" value="4"/>
+	<rule ref="PSR12"/>
+</ruleset>

--- a/composer.json
+++ b/composer.json
@@ -51,7 +51,8 @@
 		"nexusphp/cs-config": "^3.6",
 		"phpunit/phpunit": "9.6.19",
 		"predis/predis": "^1.1||^2.0",
-		"roave/security-advisories": "dev-latest"
+		"roave/security-advisories": "dev-latest",
+		"squizlabs/php_codesniffer": "^3.10"
 	},
 	"autoload": {
 		"psr-4": {

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "48000f60a64f943cd782a03d365d0fd6",
+    "content-hash": "4ddf7fd713fe9ef8ce6a5cec4d014250",
     "packages": [
         {
             "name": "codeigniter4/framework",
@@ -5088,6 +5088,86 @@
                 }
             ],
             "time": "2024-02-07T10:39:02+00:00"
+        },
+        {
+            "name": "squizlabs/php_codesniffer",
+            "version": "3.10.3",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/PHPCSStandards/PHP_CodeSniffer.git",
+                "reference": "62d32998e820bddc40f99f8251958aed187a5c9c"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/PHPCSStandards/PHP_CodeSniffer/zipball/62d32998e820bddc40f99f8251958aed187a5c9c",
+                "reference": "62d32998e820bddc40f99f8251958aed187a5c9c",
+                "shasum": ""
+            },
+            "require": {
+                "ext-simplexml": "*",
+                "ext-tokenizer": "*",
+                "ext-xmlwriter": "*",
+                "php": ">=5.4.0"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^4.0 || ^5.0 || ^6.0 || ^7.0 || ^8.0 || ^9.3.4"
+            },
+            "bin": [
+                "bin/phpcbf",
+                "bin/phpcs"
+            ],
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "3.x-dev"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Greg Sherwood",
+                    "role": "Former lead"
+                },
+                {
+                    "name": "Juliette Reinders Folmer",
+                    "role": "Current lead"
+                },
+                {
+                    "name": "Contributors",
+                    "homepage": "https://github.com/PHPCSStandards/PHP_CodeSniffer/graphs/contributors"
+                }
+            ],
+            "description": "PHP_CodeSniffer tokenizes PHP, JavaScript and CSS files and detects violations of a defined set of coding standards.",
+            "homepage": "https://github.com/PHPCSStandards/PHP_CodeSniffer",
+            "keywords": [
+                "phpcs",
+                "standards",
+                "static analysis"
+            ],
+            "support": {
+                "issues": "https://github.com/PHPCSStandards/PHP_CodeSniffer/issues",
+                "security": "https://github.com/PHPCSStandards/PHP_CodeSniffer/security/policy",
+                "source": "https://github.com/PHPCSStandards/PHP_CodeSniffer",
+                "wiki": "https://github.com/PHPCSStandards/PHP_CodeSniffer/wiki"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/PHPCSStandards",
+                    "type": "github"
+                },
+                {
+                    "url": "https://github.com/jrfnl",
+                    "type": "github"
+                },
+                {
+                    "url": "https://opencollective.com/php_codesniffer",
+                    "type": "open_collective"
+                }
+            ],
+            "time": "2024-09-18T10:38:58+00:00"
         },
         {
             "name": "symfony/console",


### PR DESCRIPTION
- Added Composer Dev dependency
- Added rule file

@jekkos please take a look at my comments on Element. The tl;dr is that I couldn't get PHP CS Fixer to work properly.  PHP_CodeSniffer does have native PHPStorm support and can be setup via Github actions.  

If we decide to go with this, We probably should setup the github action so that it just gives warnings but still allows merging. That is unless we can get it to only check the files which have changes. If it checks the whole project, then it's going to hold Pull Requests up until the whole project is converted.  If warning mode isn't a thing then maybe we should just run it on IDEs first until the codebase is fully converted?

I couldn't find a way to tell PHP_CodeSniffer to require PSR-12 compliance but override some sniffs (such as space indenting).