### PR TITLE
Use custom rule to account for all locales

### DIFF
--- a/app/Controllers/Sales.php
+++ b/app/Controllers/Sales.php
@@ -633,9 +633,9 @@ class Sales extends Secure_Controller
 		$data = [];
 
 		$rules = [
-			'price' => 'trim|required|numeric',
-			'quantity' => 'trim|required|numeric',
-			'discount' => 'trim|permit_empty|numeric',
+			'price' => 'trim|required|decimal_locale',
+			'quantity' => 'trim|required|decimal_locale',
+			'discount' => 'trim|permit_empty|decimal_locale',
 		];
 
 		if($this->validate($rules))


### PR DESCRIPTION
This fixes a problem where validation fails when locales which use a comma (,) as the decimal separator don't pass the numeric validation rule.
closing #4115 