### PR TITLE
Revert IntlFormatter refactor (#4126)

### DIFF
--- a/app/Libraries/Token_lib.php
+++ b/app/Libraries/Token_lib.php
@@ -19,26 +19,25 @@ class Token_lib
 	 */
 	public function render(string $tokened_text, array $tokens = [], $save = true): string
 	{
-		$config = config(OSPOS::class)->settings;
-		$formatter = new IntlDateFormatter(
-			$config['number_locale'], // Locale
-			IntlDateFormatter::FULL, // Date type
-			IntlDateFormatter::FULL // Time type
-		);
-
-		//Apply the transformation for the "%" tokens if any are used
-		if(str_contains($tokened_text, '%'))
+		// Apply the transformation for the "%" tokens if any are used
+		if(strpos($tokened_text, '%') !== false)
 		{
-
-			$tokened_text = $formatter->format(new DateTime());
+			$tokened_text = strftime($tokened_text);	//TODO: these need to be converted to IntlDateFormatter::format()
 		}
 
-		//Call scan to build an array of all tokens used in the text to be transformed
+		// Call scan to build an array of all of the tokens used in the text to be transformed
 		$token_tree = $this->scan($tokened_text);
 
 		if(empty($token_tree))
 		{
-			return str_contains($tokened_text, '%') ? $formatter->format(new DateTime()) : $tokened_text;
+			if(strpos($tokened_text, '%') !== false)
+			{
+				return strftime($tokened_text);
+			}
+			else
+			{
+				return $tokened_text;
+			}
 		}
 
 		$token_values = [];


### PR DESCRIPTION
@objecttothis I was checking the bug report from @odiea  and saw some refactoring was done that broke the quote number generation.The strformat was changed with an IntlFormatter->format that now always renders the full date instead of the token format as it is configured in the db.
I did check briefly if I could make it work in the spirit of your refactoring, but did not directly find a solution. THe format string cannot be used with this IntlFormatter so it seemed to be a dead end.

Fine if we revert this or was there a specific reason you wanted to refactor this?