### PR TITLE
Add default-timezone to update copyright

### DIFF
--- a/app/Views/partial/footer.php
+++ b/app/Views/partial/footer.php
@@ -2,6 +2,9 @@
 
 use Config\OSPOS;
 
+// Set the correct timezone
+date_default_timezone_set('UTC'); // Replace 'UTC' with your desired timezone, e.g., 'America/New_York'
+
 ?>
 </div>
 		</div>


### PR DESCRIPTION
Fixed: #4144 

## **Description :**

### 1) Set the Timezone:

- The line date_default_timezone_set('UTC'); ensures the server uses the correct timezone for generating the current year.

### 2) Dynamic Year:

- The date('Y') function will now correctly fetch the year based on the updated timezone.

