### PR TITLE
Added Default timezone in OSPOS Configs

### DIFF
--- a/app/Config/OSPOS.php
+++ b/app/Config/OSPOS.php
@@ -22,6 +22,8 @@ class OSPOS extends BaseConfig
 		parent::__construct();
 		$this->cache = Services::cache();
 		$this->set_settings();
+
+		date_default_timezone_set('America/New_York');
 	}
 
 	/**

--- a/app/Views/partial/footer.php
+++ b/app/Views/partial/footer.php
@@ -2,6 +2,9 @@
 
 use Config\OSPOS;
 
+// Set the correct timezone
+date_default_timezone_set('UTC'); // Replace 'UTC' with your desired timezone, e.g., 'America/New_York'
+
 ?>
 </div>
 		</div>


### PR DESCRIPTION
Fixed #4144

**Description :**

- Add a date_default_timezone_set() function in the OSPOS class (config.php) constructor to set a global timezone. 