### PR TITLE
Add Kurdish language option to UI

### DIFF
--- a/app/Config/App.php
+++ b/app/Config/App.php
@@ -162,6 +162,7 @@ class App extends BaseConfig
         'az',
         'bg',
         'bs',
+        'ckb_IQ',
         'cs',
         'da',
         'de-CH',

--- a/app/Helpers/locale_helper.php
+++ b/app/Helpers/locale_helper.php
@@ -64,6 +64,7 @@ function get_languages(): array
         'az:azerbaijani' => 'Azerbaijani',
         'bg:bulgarian' => 'Bulgarian',
         'bs:bosnian' => 'Bosnian',
+		'ckb_IQ:centralkurdish' => 'Central Kurdish (Iraq)',
         'cs:czech' => 'Czech',
         'da:danish' => 'Danish',
         'de-CH:german' => 'German (Switzerland)',


### PR DESCRIPTION
Makes the Kurdish language selectable in the UI. As requested here: #4209.

@jekkos I do wonder why this language was added as ckb_IQ instead of the ISO 639-1 standard used for all other languages, in this case being `ku`. If you decide to change this for consistency, you should also change the following:

app/Config/App.php
`ckb_IQ',` to `'ku',`

app/Helpers/locale_helper.php
`'ckb_IQ:centralkurdish' => 'Central Kurdish (Iraq)',` to `'ku:kurdish' => 'Kurdish',`