### PR TITLE
Fix PHP 8.4 errors

### DIFF
--- a/app/Controllers/Persons.php
+++ b/app/Controllers/Persons.php
@@ -13,7 +13,7 @@ abstract class Persons extends Secure_Controller
     /**
      * @param string|null $module_id
      */
-    public function __construct(string $module_id = null)
+    public function __construct(?string $module_id = null)
     {
         parent::__construct($module_id);
 

--- a/app/Controllers/Secure_Controller.php
+++ b/app/Controllers/Secure_Controller.php
@@ -32,7 +32,7 @@ class Secure_Controller extends BaseController
      * @param string|null $submodule_id
      * @param string|null $menu_group
      */
-    public function __construct(string $module_id = '', string $submodule_id = null, string $menu_group = null)
+    public function __construct(string $module_id = '', ?string $submodule_id = null, ?string $menu_group = null)
     {
         $this->employee = model(Employee::class);
         $this->module = model(Module::class);

--- a/app/Helpers/locale_helper.php
+++ b/app/Helpers/locale_helper.php
@@ -435,7 +435,7 @@ function to_quantity_decimals(?string $number): string
  * @param int $type
  * @return string
  */
-function to_decimals(?string $number, string $decimals = null, int $type = NumberFormatter::DECIMAL): string
+function to_decimals(?string $number, ?string $decimals = null, int $type = NumberFormatter::DECIMAL): string
 {
     if(!isset($number))
     {
@@ -479,7 +479,7 @@ function parse_tax(string $number): mixed
  * @param int|null $decimals
  * @return false|float|int|mixed|string
  */
-function parse_decimals(string $number, int $decimals = null): mixed
+function parse_decimals(string $number, ?int $decimals = null): mixed
 {
     if(empty($number))
     {

--- a/app/Libraries/Email_lib.php
+++ b/app/Libraries/Email_lib.php
@@ -53,7 +53,7 @@ class Email_lib
      * Email sending function
      * Example of use: $response = sendEmail('john@doe.com', 'Hello', 'This is a message', $filename);
      */
-    public function sendEmail(string $to, string $subject, string $message, string $attachment = null): bool
+    public function sendEmail(string $to, string $subject, string $message, ?string $attachment = null): bool
     {
         $email = $this->email;
 

--- a/app/Libraries/MY_Email.php
+++ b/app/Libraries/MY_Email.php
@@ -28,7 +28,7 @@ class MY_Email extends Email
      * @param string|null $attachment
      * @return bool
      */
-    public function sendMail(string $subject, string $body, string $to = null, string $reply_name = null, string $reply_mail = null, string $attachment = null): bool
+    public function sendMail(string $subject, string $body, ?string $to = null, ?string $reply_name = null, ?string $reply_mail = null, ?string $attachment = null): bool
     {
         $this->setReplyTo($reply_mail, $reply_name);
         $this->setFrom($this->default_sender_address, $this->default_sender_name, $this->default_bounce_address);

--- a/app/Libraries/Receiving_lib.php
+++ b/app/Libraries/Receiving_lib.php
@@ -274,7 +274,7 @@ class Receiving_lib
      * @param bool $include_deleted
      * @return bool
      */
-    public function add_item(int $item_id, int $quantity = 1, int $item_location = null, float $discount = 0, int $discount_type = 0, float $price = null, string $description = null, string $serialnumber = null, float $receiving_quantity = null, int $receiving_id = null, bool $include_deleted = false): bool
+    public function add_item(int $item_id, int $quantity = 1, ?int $item_location = null, float $discount = 0, int $discount_type = 0, ?float $price = null, ?string $description = null, ?string $serialnumber = null, ?float $receiving_quantity = null, ?int $receiving_id = null, bool $include_deleted = false): bool
     {
         $config = config(OSPOS::class)->settings;
 

--- a/app/Libraries/Sale_lib.php
+++ b/app/Libraries/Sale_lib.php
@@ -1030,7 +1030,7 @@ class Sale_lib
      * @param bool|null $line
      * @return bool
      */
-    public function add_item(int &$item_id, int $item_location, string $quantity = '1', string &$discount = '0.0', int $discount_type = 0, int $price_mode = PRICE_MODE_STANDARD, int $kit_price_option = null, int $kit_print_option = null, string $price_override = null, string $description = null, string $serialnumber = null, int $sale_id = null, bool $include_deleted = false, bool $print_option = null, bool $line = null): bool
+    public function add_item(int &$item_id, int $item_location, string $quantity = '1', string &$discount = '0.0', int $discount_type = 0, int $price_mode = PRICE_MODE_STANDARD, ?int $kit_price_option = null, ?int $kit_print_option = null, ?string $price_override = null, ?string $description = null, ?string $serialnumber = null, ?int $sale_id = null, bool $include_deleted = false, ?bool $print_option = null, ?bool $line = null): bool
     {
         $item_info = $this->item->get_info_by_id_or_number($item_id, $include_deleted);
 

--- a/app/Libraries/Tax_lib.php
+++ b/app/Libraries/Tax_lib.php
@@ -208,7 +208,7 @@ class Tax_lib
     /**
     * Updates the sales_tax array which is later saved to the `sales_taxes` table and used for printing taxes on receipts and invoices
     */
-    public function update_taxes(array &$taxes, string $tax_type, string $tax_group, string $tax_rate, string $tax_basis, string $item_tax_amount, int $tax_group_sequence, int $rounding_code, int $sale_id, string $name = '', int $tax_code_id = null, int $jurisdiction_id = null, int $tax_category_id = null): void
+    public function update_taxes(array &$taxes, string $tax_type, string $tax_group, string $tax_rate, string $tax_basis, string $item_tax_amount, int $tax_group_sequence, int $rounding_code, int $sale_id, string $name = '', ?int $tax_code_id = null, ?int $jurisdiction_id = null, ?int $tax_category_id = null): void
     {
         $tax_group_index = $this->clean('X' . (float)$tax_rate . '% ' . $tax_group);    //TODO: Not sure we should be casting to a float here.  The clean() function takes a string, so it just gets converted back to a string and there's risk of inaccuracies in the value displayed.
 

--- a/app/Models/Item.php
+++ b/app/Models/Item.php
@@ -572,7 +572,7 @@ class Item extends Model
      * @param string|null $seed
      * @return string
      */
-    public function get_search_suggestion_format(string $seed = null): string
+    public function get_search_suggestion_format(?string $seed = null): string
     {
         $config = config(OSPOS::class)->settings;
         $seed .= ',' . $config['suggestions_first_column'];
@@ -1124,7 +1124,7 @@ class Item extends Model
      * caution: must be used before item_quantities gets updated, otherwise the average price is wrong!
      *
      */
-    public function change_cost_price(int $item_id, float $items_received, float $new_price, float $old_price = null): bool
+    public function change_cost_price(int $item_id, float $items_received, float $new_price, ?float $old_price = null): bool
     {
         if($old_price === null)
         {
@@ -1188,7 +1188,7 @@ class Item extends Model
      * for a multipack environment then the item name should have the
      * pack appended to it
      */
-    public function get_item_name(string $as_name = null): string
+    public function get_item_name(?string $as_name = null): string
     {
         $config = config(OSPOS::class)->settings;
 

--- a/app/Models/Sale.php
+++ b/app/Models/Sale.php
@@ -1231,7 +1231,7 @@ class Sale extends Model
     /**
      * Retrieves all sales that are in a suspended state
      */
-    public function get_all_suspended(int $customer_id = null): array
+    public function get_all_suspended(?int $customer_id = null): array
     {
         if($customer_id == NEW_ENTRY)
         {


### PR DESCRIPTION
Add the missing explicit nullable markers, fixing the errors the PHP 8.4 linter throws. Please check if this doesn't break anything. If merged closes #4200.