### PR TITLE
Fix null error when sending by email a receipt of a sale that has no invoice

### DIFF
--- a/app/Controllers/Sales.php
+++ b/app/Controllers/Sales.php
@@ -989,7 +989,7 @@ class Sales extends Secure_Controller
 
             $text = $this->config['invoice_email_message'];
             $tokens = [
-                new Token_invoice_sequence($sale_data['invoice_number']),
+                new Token_invoice_sequence($number),
                 new Token_invoice_count('POS ' . $sale_data['sale_id']),
                 new Token_customer((array)$sale_data)
             ];


### PR DESCRIPTION
Fix null error when sending by email a receipt of a sale that has no invoice