### PR TITLE
Add transactions to missing config keys migration.

### DIFF
--- a/app/Database/Migrations/20250716170000_MissingConfigKeys.php
+++ b/app/Database/Migrations/20250716170000_MissingConfigKeys.php
@@ -11,12 +11,21 @@ class Migration_MissingConfigKeys extends Migration
      */
     public function up(): void
     {
-        error_log('Migrating config table');
+        error_log('Starting transaction...');
+        $db = db_connect();
+        $db->transStart();
 
         helper('migration');
-        execute_script(APPPATH . 'Database/Migrations/sqlscripts/3.4.2_missing_config_keys.sql');
 
-        error_log('Migrating config table');
+        // execute_script returns whether everything executed successfully
+        if (execute_script(APPPATH . 'Database/Migrations/sqlscripts/3.4.2_missing_config_keys.sql')) {
+            error_log('Migrated config table.');
+        }
+        else {
+            error_log('Failed to migrate config table.');
+        }
+
+        $db->transComplete();
     }
 
     /**


### PR DESCRIPTION
Adds a transaction to the missing config keys migration for better error handling. Also makes a very small change to the `execute_script()` helper: It now returns whether the script executed successfully (previously it returned nothing) to make other transactions easier to implement.