### PR TITLE
Strip EXIF metadata from uploaded images

### DIFF
--- a/app/Controllers/Config.php
+++ b/app/Controllers/Config.php
@@ -3,6 +3,7 @@
 namespace App\Controllers;
 
 use App\Libraries\Barcode_lib;
+use App\Libraries\Image_lib;
 use App\Libraries\Mailchimp_lib;
 use App\Libraries\Receiving_lib;
 use App\Libraries\Sale_lib;
@@ -353,6 +354,9 @@ class Config extends Secure_Controller
         ];
 
         $file->move(FCPATH . 'uploads/', $file_info['raw_name'] . '.' . $file_info['file_ext'], true);
+
+        $image_lib = new Image_lib();
+        $image_lib->strip_exif(FCPATH . 'uploads/' . $file_info['raw_name'] . '.' . $file_info['file_ext']);
 
         return ($file_info);
     }

--- a/app/Controllers/Items.php
+++ b/app/Controllers/Items.php
@@ -3,6 +3,7 @@
 namespace App\Controllers;
 
 use App\Libraries\Barcode_lib;
+use App\Libraries\Image_lib;
 use App\Libraries\Item_lib;
 
 use App\Models\Attribute;
@@ -776,6 +777,10 @@ class Items extends Secure_Controller
         ];
 
         $file->move(FCPATH . 'uploads/item_pics/', $file_info['raw_name'] . '.' . $file_info['file_ext'], true);
+
+        $image_lib = new Image_lib();
+        $image_lib->strip_exif(FCPATH . 'uploads/item_pics/' . $file_info['raw_name'] . '.' . $file_info['file_ext']);
+
         return ($file_info);
     }
 

--- a/app/Libraries/Image_lib.php
+++ b/app/Libraries/Image_lib.php
@@ -1,0 +1,158 @@
+<?php
+
+namespace App\Libraries;
+
+class Image_lib
+{
+    public function strip_exif(string $filepath): bool
+    {
+        if (!file_exists($filepath)) {
+            return false;
+        }
+
+        $mimetype = mime_content_type($filepath);
+        $allowed_types = ['image/jpeg', 'image/jpg', 'image/png', 'image/gif', 'image/webp', 'image/bmp', 'image/tiff'];
+        
+        if (!in_array($mimetype, $allowed_types)) {
+            return false;
+        }
+
+        if ($mimetype === 'image/jpeg' || $mimetype === 'image/jpg') {
+            return $this->strip_exif_jpeg($filepath);
+        }
+        
+        if ($mimetype === 'image/png') {
+            return $this->strip_exif_png($filepath);
+        }
+        
+        if ($mimetype === 'image/gif') {
+            return $this->strip_exif_gif($filepath);
+        }
+        
+        if ($mimetype === 'image/webp') {
+            return $this->strip_exif_webp($filepath);
+        }
+
+        return true;
+    }
+
+    private function strip_exif_jpeg(string $filepath): bool
+    {
+        if (!function_exists('exif_read_data')) {
+            return $this->strip_exif_fallback($filepath);
+        }
+
+        $image_info = @getimagesize($filepath);
+        if ($image_info === false) {
+            return false;
+        }
+
+        $image = @imagecreatefromjpeg($filepath);
+        if ($image === false) {
+            return false;
+        }
+
+        $result = imagejpeg($image, $filepath, 100);
+        imagedestroy($image);
+        
+        return $result;
+    }
+
+    private function strip_exif_png(string $filepath): bool
+    {
+        $image = @imagecreatefrompng($filepath);
+        if ($image === false) {
+            return false;
+        }
+
+        imagealphablending($image, true);
+        imagesavealpha($image, true);
+        
+        $result = imagepng($image, $filepath, 9);
+        imagedestroy($image);
+        
+        return $result;
+    }
+
+    private function strip_exif_gif(string $filepath): bool
+    {
+        $image = @imagecreatefromgif($filepath);
+        if ($image === false) {
+            return false;
+        }
+
+        $result = imagegif($image, $filepath);
+        imagedestroy($image);
+        
+        return $result;
+    }
+
+    private function strip_exif_webp(string $filepath): bool
+    {
+        if (!function_exists('imagecreatefromwebp')) {
+            return false;
+        }
+
+        $image = @imagecreatefromwebp($filepath);
+        if ($image === false) {
+            return false;
+        }
+
+        $result = imagewebp($image, $filepath, 100);
+        imagedestroy($image);
+        
+        return $result;
+    }
+
+    private function strip_exif_fallback(string $filepath): bool
+    {
+        $content = file_get_contents($filepath);
+        if ($content === false) {
+            return false;
+        }
+
+        $markers = [];
+        $offset = 0;
+        
+        while ($offset < strlen($content)) {
+            if ($offset + 4 > strlen($content)) {
+                break;
+            }
+            
+            $marker = ord($content[$offset + 1]);
+            
+            if (ord($content[$offset]) !== 0xFF) {
+                break;
+            }
+            
+            if ($marker >= 0xE0 && $marker <= 0xEF) {
+                $marker_len = ord($content[$offset + 2]) * 256 + ord($content[$offset + 3]);
+                $markers[] = [$offset, $marker_len + 2];
+                $offset += $marker_len + 2;
+            } elseif ($marker === 0xD8 || $marker === 0xD9) {
+                $offset += 2;
+            } elseif ($marker === 0x00 || $marker === 0xD0 || $marker === 0xD1 || $marker === 0xD2 || $marker === 0xD3 || $marker === 0xD4 || $marker === 0xD5 || $marker === 0xD6 || $marker === 0xD7) {
+                $offset += 2;
+            } elseif ($marker === 0x01) {
+                $offset += 2;
+            } else {
+                if ($offset + 4 > strlen($content)) {
+                    break;
+                }
+                $marker_len = ord($content[$offset + 2]) * 256 + ord($content[$offset + 3]);
+                $offset += $marker_len + 2;
+            }
+        }
+
+        if (empty($markers)) {
+            return true;
+        }
+
+        $new_content = $content;
+        foreach (array_reverse($markers) as $marker_info) {
+            $new_content = substr_replace($new_content, '', $marker_info[0], $marker_info[1]);
+        }
+
+        return file_put_contents($filepath, $new_content) !== false;
+    }
+}


### PR DESCRIPTION
- Created Image_lib library to handle EXIF stripping for JPEG, PNG, GIF, and WebP images
- Uses GD library to re-encode images without EXIF data
- Added EXIF stripping to both company logo upload (Config controller) and item image upload (Items controller)
- Handles privacy concern by removing geolocation and device info from uploaded images

Fixes #4010