### PR TITLE
Fix: Handle image filenames with spaces in thumbnails

### DIFF
--- a/app/Controllers/Items.php
+++ b/app/Controllers/Items.php
@@ -147,6 +147,7 @@ class Items extends Secure_Controller
     {
         helper('file');
 
+        $pic_filename = rawurldecode($pic_filename);
         $file_extension = pathinfo($pic_filename, PATHINFO_EXTENSION);
         $images = glob("./uploads/item_pics/$pic_filename");
         $base_path = './uploads/item_pics/' . pathinfo($pic_filename, PATHINFO_FILENAME);
@@ -372,7 +373,7 @@ class Items extends Secure_Controller
             } else {
                 $images = glob("./uploads/item_pics/$item_info->pic_filename");
             }
-            $data['image_path']    = sizeof($images) > 0 ? base_url($images[0]) : '';
+            $data['image_path']    = sizeof($images) > 0 ? base_url(implode('/', array_map('rawurlencode', explode('/', ltrim($images[0], './'))))) : '';
         } else {
             $data['image_path']    = '';
         }

--- a/app/Helpers/tabular_helper.php
+++ b/app/Helpers/tabular_helper.php
@@ -470,7 +470,8 @@ function get_item_data_row(object $item): array
             : glob("./uploads/item_pics/$item->pic_filename");
 
         if (sizeof($images) > 0) {
-            $image .= '<a class="rollover" href="' . base_url($images[0]) . '"><img alt="Image thumbnail" src="' . site_url('items/PicThumb/' . pathinfo($images[0], PATHINFO_BASENAME)) . '"></a>';
+            $image_path = ltrim($images[0], './');
+            $image .= '<a class="rollover" href="' . base_url(implode('/', array_map('rawurlencode', explode('/', $image_path)))) . '"><img alt="Image thumbnail" src="' . site_url('items/PicThumb/' . rawurlencode(pathinfo($images[0], PATHINFO_BASENAME))) . '"></a>';
         }
     }
 


### PR DESCRIPTION
- URL-encode filenames when constructing image/thumbnail URLs
- Decode filename parameter in getPicThumb() controller
- Prevents Apache AH10411 error with spaces in rewritten URLs

Fixes #4372