### PR TITLE
Fix SQL injection in suggestions column configuration

### DIFF
--- a/app/Controllers/Config.php
+++ b/app/Controllers/Config.php
@@ -386,9 +386,9 @@ class Config extends Secure_Controller
             'gcaptcha_enable'                   => $this->request->getPost('gcaptcha_enable') != null,
             'gcaptcha_secret_key'               => $this->request->getPost('gcaptcha_secret_key'),
             'gcaptcha_site_key'                 => $this->request->getPost('gcaptcha_site_key'),
-            'suggestions_first_column'          => $this->_validate_suggestions_column($this->request->getPost('suggestions_first_column')),
-            'suggestions_second_column'         => $this->_validate_suggestions_column($this->request->getPost('suggestions_second_column')),
-            'suggestions_third_column'          => $this->_validate_suggestions_column($this->request->getPost('suggestions_third_column')),
+            'suggestions_first_column'          => $this->validateSuggestionsColumn($this->request->getPost('suggestions_first_column'), 'first'),
+            'suggestions_second_column'         => $this->validateSuggestionsColumn($this->request->getPost('suggestions_second_column'), 'other'),
+            'suggestions_third_column'          => $this->validateSuggestionsColumn($this->request->getPost('suggestions_third_column'), 'other'),
             'giftcard_number'                   => $this->request->getPost('giftcard_number'),
             'derive_sale_quantity'              => $this->request->getPost('derive_sale_quantity') != null,
             'multi_pack_enabled'                => $this->request->getPost('multi_pack_enabled') != null,
@@ -979,13 +979,24 @@ class Config extends Secure_Controller
     }
 
     /**
-     * Validates suggestions column name to prevent SQL injection.
+     * Validates suggestions column configuration to prevent SQL injection.
      *
-     * @param string|null $column
-     * @return string
+     * @param mixed $column The column value from POST
+     * @param string $fieldType Either 'first' or 'other' to determine default fallback
+     * @return string Validated column name
      */
-    private function _validate_suggestions_column(?string $column): string
+    private function validateSuggestionsColumn(mixed $column, string $fieldType): string
     {
-        return in_array($column, Item::ALLOWED_SUGGESTIONS_COLUMNS_WITH_EMPTY, true) ? $column : 'name';
+        if (!is_string($column)) {
+            return $fieldType === 'first' ? 'name' : '';
+        }
+
+        $allowed = $fieldType === 'first' 
+            ? Item::ALLOWED_SUGGESTIONS_COLUMNS 
+            : Item::ALLOWED_SUGGESTIONS_COLUMNS_WITH_EMPTY;
+
+        $fallback = $fieldType === 'first' ? 'name' : '';
+
+        return in_array($column, $allowed, true) ? $column : $fallback;
     }
 }

--- a/app/Controllers/Config.php
+++ b/app/Controllers/Config.php
@@ -11,6 +11,7 @@ use App\Models\Appconfig;
 use App\Models\Attribute;
 use App\Models\Customer_rewards;
 use App\Models\Dinner_table;
+use App\Models\Item;
 use App\Models\Module;
 use App\Models\Enums\Rounding_mode;
 use App\Models\Stock_location;
@@ -985,8 +986,6 @@ class Config extends Secure_Controller
      */
     private function _validate_suggestions_column(?string $column): string
     {
-        $valid_columns = ['', 'name', 'item_number', 'description', 'cost_price', 'unit_price'];
-
-        return in_array($column, $valid_columns, true) ? $column : 'name';
+        return in_array($column, Item::ALLOWED_SUGGESTIONS_COLUMNS_WITH_EMPTY, true) ? $column : 'name';
     }
 }

--- a/app/Controllers/Config.php
+++ b/app/Controllers/Config.php
@@ -385,9 +385,9 @@ class Config extends Secure_Controller
             'gcaptcha_enable'                   => $this->request->getPost('gcaptcha_enable') != null,
             'gcaptcha_secret_key'               => $this->request->getPost('gcaptcha_secret_key'),
             'gcaptcha_site_key'                 => $this->request->getPost('gcaptcha_site_key'),
-            'suggestions_first_column'          => $this->request->getPost('suggestions_first_column'),
-            'suggestions_second_column'         => $this->request->getPost('suggestions_second_column'),
-            'suggestions_third_column'          => $this->request->getPost('suggestions_third_column'),
+            'suggestions_first_column'          => $this->_validate_suggestions_column($this->request->getPost('suggestions_first_column')),
+            'suggestions_second_column'         => $this->_validate_suggestions_column($this->request->getPost('suggestions_second_column')),
+            'suggestions_third_column'          => $this->_validate_suggestions_column($this->request->getPost('suggestions_third_column')),
             'giftcard_number'                   => $this->request->getPost('giftcard_number'),
             'derive_sale_quantity'              => $this->request->getPost('derive_sale_quantity') != null,
             'multi_pack_enabled'                => $this->request->getPost('multi_pack_enabled') != null,
@@ -975,5 +975,18 @@ class Config extends Secure_Controller
         $success = $this->appconfig->save(['company_logo' => '']);
 
         return $this->response->setJSON(['success' => $success]);
+    }
+
+    /**
+     * Validates suggestions column name to prevent SQL injection.
+     *
+     * @param string|null $column
+     * @return string
+     */
+    private function _validate_suggestions_column(?string $column): string
+    {
+        $valid_columns = ['', 'name', 'item_number', 'description', 'cost_price', 'unit_price'];
+
+        return in_array($column, $valid_columns, true) ? $column : 'name';
     }
 }

--- a/app/Models/Item.php
+++ b/app/Models/Item.php
@@ -16,6 +16,9 @@ use stdClass;
  */
 class Item extends Model
 {
+    public const ALLOWED_SUGGESTIONS_COLUMNS = ['name', 'item_number', 'description', 'cost_price', 'unit_price'];
+    public const ALLOWED_SUGGESTIONS_COLUMNS_WITH_EMPTY = ['', 'name', 'item_number', 'description', 'cost_price', 'unit_price'];
+
     protected $table = 'items';
     protected $primaryKey = 'item_id';
     protected $useAutoIncrement = true;
@@ -532,18 +535,17 @@ class Item extends Model
     public function get_search_suggestion_format(?string $seed = null): string
     {
         $config = config(OSPOS::class)->settings;
-        $valid_columns = ['name', 'item_number', 'description', 'cost_price', 'unit_price'];
         
-        $suggestions_first_column = in_array($config['suggestions_first_column'], $valid_columns, true) 
+        $suggestions_first_column = in_array($config['suggestions_first_column'], self::ALLOWED_SUGGESTIONS_COLUMNS, true) 
             ? $config['suggestions_first_column'] 
             : 'name';
         $seed .= ',' . $suggestions_first_column;
 
-        if ($config['suggestions_second_column'] !== '' && in_array($config['suggestions_second_column'], $valid_columns, true)) {
+        if ($config['suggestions_second_column'] !== '' && in_array($config['suggestions_second_column'], self::ALLOWED_SUGGESTIONS_COLUMNS, true)) {
             $seed .= ',' . $config['suggestions_second_column'];
         }
 
-        if ($config['suggestions_third_column'] !== '' && in_array($config['suggestions_third_column'], $valid_columns, true)) {
+        if ($config['suggestions_third_column'] !== '' && in_array($config['suggestions_third_column'], self::ALLOWED_SUGGESTIONS_COLUMNS, true)) {
             $seed .= ',' . $config['suggestions_third_column'];
         }
 
@@ -557,16 +559,15 @@ class Item extends Model
     public function get_search_suggestion_label(object $result_row): string
     {
         $config = config(OSPOS::class)->settings;
-        $valid_columns = ['name', 'item_number', 'description', 'cost_price', 'unit_price'];
 
         $label = '';
-        $label1 = in_array($config['suggestions_first_column'], $valid_columns, true) 
+        $label1 = in_array($config['suggestions_first_column'], self::ALLOWED_SUGGESTIONS_COLUMNS, true) 
             ? $config['suggestions_first_column'] 
             : 'name';
-        $label2 = in_array($config['suggestions_second_column'], $valid_columns, true) 
+        $label2 = in_array($config['suggestions_second_column'], self::ALLOWED_SUGGESTIONS_COLUMNS, true) 
             ? $config['suggestions_second_column'] 
             : '';
-        $label3 = in_array($config['suggestions_third_column'], $valid_columns, true) 
+        $label3 = in_array($config['suggestions_third_column'], self::ALLOWED_SUGGESTIONS_COLUMNS, true) 
             ? $config['suggestions_third_column'] 
             : '';
 

--- a/app/Models/Item.php
+++ b/app/Models/Item.php
@@ -532,13 +532,18 @@ class Item extends Model
     public function get_search_suggestion_format(?string $seed = null): string
     {
         $config = config(OSPOS::class)->settings;
-        $seed .= ',' . $config['suggestions_first_column'];
+        $valid_columns = ['name', 'item_number', 'description', 'cost_price', 'unit_price'];
+        
+        $suggestions_first_column = in_array($config['suggestions_first_column'], $valid_columns, true) 
+            ? $config['suggestions_first_column'] 
+            : 'name';
+        $seed .= ',' . $suggestions_first_column;
 
-        if ($config['suggestions_second_column'] !== '') {
+        if ($config['suggestions_second_column'] !== '' && in_array($config['suggestions_second_column'], $valid_columns, true)) {
             $seed .= ',' . $config['suggestions_second_column'];
         }
 
-        if ($config['suggestions_third_column'] !== '') {
+        if ($config['suggestions_third_column'] !== '' && in_array($config['suggestions_third_column'], $valid_columns, true)) {
             $seed .= ',' . $config['suggestions_third_column'];
         }
 
@@ -552,11 +557,18 @@ class Item extends Model
     public function get_search_suggestion_label(object $result_row): string
     {
         $config = config(OSPOS::class)->settings;
+        $valid_columns = ['name', 'item_number', 'description', 'cost_price', 'unit_price'];
 
         $label = '';
-        $label1 = $config['suggestions_first_column'];
-        $label2 = $config['suggestions_second_column'];
-        $label3 = $config['suggestions_third_column'];
+        $label1 = in_array($config['suggestions_first_column'], $valid_columns, true) 
+            ? $config['suggestions_first_column'] 
+            : 'name';
+        $label2 = in_array($config['suggestions_second_column'], $valid_columns, true) 
+            ? $config['suggestions_second_column'] 
+            : '';
+        $label3 = in_array($config['suggestions_third_column'], $valid_columns, true) 
+            ? $config['suggestions_third_column'] 
+            : '';
 
         $this->format_result_numbers($result_row);
 

--- a/app/Models/Item.php
+++ b/app/Models/Item.php
@@ -536,16 +536,16 @@ class Item extends Model
     {
         $config = config(OSPOS::class)->settings;
         
-        $suggestions_first_column = in_array($config['suggestions_first_column'], self::ALLOWED_SUGGESTIONS_COLUMNS, true) 
+        $suggestionsFirstColumn = $this->suggestionColumnIsAllowed($config['suggestions_first_column'])
             ? $config['suggestions_first_column'] 
             : 'name';
-        $seed .= ',' . $suggestions_first_column;
+        $seed .= ',' . $suggestionsFirstColumn;
 
-        if ($config['suggestions_second_column'] !== '' && in_array($config['suggestions_second_column'], self::ALLOWED_SUGGESTIONS_COLUMNS, true)) {
+        if ($config['suggestions_second_column'] !== '' && $this->suggestionColumnIsAllowed($config['suggestions_second_column'])) {
             $seed .= ',' . $config['suggestions_second_column'];
         }
 
-        if ($config['suggestions_third_column'] !== '' && in_array($config['suggestions_third_column'], self::ALLOWED_SUGGESTIONS_COLUMNS, true)) {
+        if ($config['suggestions_third_column'] !== '' && $this->suggestionColumnIsAllowed($config['suggestions_third_column'])) {
             $seed .= ',' . $config['suggestions_third_column'];
         }
 
@@ -561,13 +561,13 @@ class Item extends Model
         $config = config(OSPOS::class)->settings;
 
         $label = '';
-        $label1 = in_array($config['suggestions_first_column'], self::ALLOWED_SUGGESTIONS_COLUMNS, true) 
+        $label1 = $this->suggestionColumnIsAllowed($config['suggestions_first_column']) 
             ? $config['suggestions_first_column'] 
             : 'name';
-        $label2 = in_array($config['suggestions_second_column'], self::ALLOWED_SUGGESTIONS_COLUMNS, true) 
+        $label2 = $this->suggestionColumnIsAllowed($config['suggestions_second_column']) 
             ? $config['suggestions_second_column'] 
             : '';
-        $label3 = in_array($config['suggestions_third_column'], self::ALLOWED_SUGGESTIONS_COLUMNS, true) 
+        $label3 = $this->suggestionColumnIsAllowed($config['suggestions_third_column']) 
             ? $config['suggestions_third_column'] 
             : '';
 
@@ -591,6 +591,17 @@ class Item extends Model
         }
 
         return $label;
+    }
+
+    /**
+     * Validates if a column name is in the allowed suggestions columns.
+     *
+     * @param string $columnName
+     * @return bool
+     */
+    private function suggestionColumnIsAllowed(string $columnName): bool
+    {
+        return in_array($columnName, self::ALLOWED_SUGGESTIONS_COLUMNS, true);
     }
 
     /**

--- a/tests/Models/Item_test.php
+++ b/tests/Models/Item_test.php
@@ -1,0 +1,64 @@
+<?php
+
+namespace Tests\Models;
+
+use CodeIgniter\Test\CIUnitTestCase;
+use App\Models\Item;
+
+class Item_test extends CIUnitTestCase
+{
+    public function testSuggestionsColumnValidationRejectsSQLInjection(): void
+    {
+        $malicious_columns = [
+            'name, SLEEP(5)',
+            'name; DROP TABLE items',
+            "name' OR '1'='1",
+            'name UNION SELECT * FROM users',
+            'name--comment'
+        ];
+
+        $valid_columns = ['name', 'item_number', 'description', 'cost_price', 'unit_price'];
+
+        foreach ($malicious_columns as $malicious) {
+            $this->assertNotContains($malicious, $valid_columns, "Malicious input should be rejected: $malicious");
+        }
+    }
+
+    public function testSuggestionsColumnValidationAcceptsValidColumns(): void
+    {
+        $valid_columns = ['name', 'item_number', 'description', 'cost_price', 'unit_price', ''];
+
+        foreach ($valid_columns as $column) {
+            $validated = $this->validateSuggestionsColumn($column);
+            
+            if ($column === '') {
+                $this->assertTrue($validated === '' || $validated === 'name', "Empty column should be valid or default to name");
+            } else {
+                $this->assertContains($validated, ['name', 'item_number', 'description', 'cost_price', 'unit_price'], "Valid column should be preserved: $column");
+            }
+        }
+    }
+
+    public function testSuggestionsColumnValidationDefaultsToNameForInvalidInput(): void
+    {
+        $invalid_inputs = [
+            'invalid_column',
+            'SELECT * FROM items',
+            '<?php echo "test"; ?>',
+            '<script>alert("xss")</script>',
+            'name OR 1=1'
+        ];
+
+        foreach ($invalid_inputs as $invalid) {
+            $validated = $this->validateSuggestionsColumn($invalid);
+            $this->assertEquals('name', $validated, "Invalid input should default to 'name': $invalid");
+        }
+    }
+
+    private function validateSuggestionsColumn(?string $column): string
+    {
+        $valid_columns = ['', 'name', 'item_number', 'description', 'cost_price', 'unit_price'];
+
+        return in_array($column, $valid_columns, true) ? $column : 'name';
+    }
+}

--- a/tests/Models/Item_test.php
+++ b/tests/Models/Item_test.php
@@ -17,24 +17,20 @@ class Item_test extends CIUnitTestCase
             'name--comment'
         ];
 
-        $valid_columns = ['name', 'item_number', 'description', 'cost_price', 'unit_price'];
-
         foreach ($malicious_columns as $malicious) {
-            $this->assertNotContains($malicious, $valid_columns, "Malicious input should be rejected: $malicious");
+            $this->assertNotContains($malicious, Item::ALLOWED_SUGGESTIONS_COLUMNS, "Malicious input should be rejected: $malicious");
         }
     }
 
     public function testSuggestionsColumnValidationAcceptsValidColumns(): void
     {
-        $valid_columns = ['name', 'item_number', 'description', 'cost_price', 'unit_price', ''];
-
-        foreach ($valid_columns as $column) {
+        foreach (Item::ALLOWED_SUGGESTIONS_COLUMNS_WITH_EMPTY as $column) {
             $validated = $this->validateSuggestionsColumn($column);
             
             if ($column === '') {
                 $this->assertTrue($validated === '' || $validated === 'name', "Empty column should be valid or default to name");
             } else {
-                $this->assertContains($validated, ['name', 'item_number', 'description', 'cost_price', 'unit_price'], "Valid column should be preserved: $column");
+                $this->assertContains($validated, Item::ALLOWED_SUGGESTIONS_COLUMNS, "Valid column should be preserved: $column");
             }
         }
     }
@@ -57,8 +53,6 @@ class Item_test extends CIUnitTestCase
 
     private function validateSuggestionsColumn(?string $column): string
     {
-        $valid_columns = ['', 'name', 'item_number', 'description', 'cost_price', 'unit_price'];
-
-        return in_array($column, $valid_columns, true) ? $column : 'name';
+        return in_array($column, Item::ALLOWED_SUGGESTIONS_COLUMNS_WITH_EMPTY, true) ? $column : 'name';
     }
 }

--- a/tests/Models/Item_test.php
+++ b/tests/Models/Item_test.php
@@ -9,6 +9,7 @@ class Item_test extends CIUnitTestCase
 {
     public function testSuggestionsColumnValidationRejectsSQLInjection(): void
     {
+        // These malicious values should not be in the allowed columns list
         $malicious_columns = [
             'name, SLEEP(5)',
             'name; DROP TABLE items',
@@ -18,41 +19,39 @@ class Item_test extends CIUnitTestCase
         ];
 
         foreach ($malicious_columns as $malicious) {
-            $this->assertNotContains($malicious, Item::ALLOWED_SUGGESTIONS_COLUMNS, "Malicious input should be rejected: $malicious");
+            $this->assertNotContains($malicious, Item::ALLOWED_SUGGESTIONS_COLUMNS, 
+                "Malicious input should not be in allowed columns: $malicious");
         }
     }
 
     public function testSuggestionsColumnValidationAcceptsValidColumns(): void
     {
-        foreach (Item::ALLOWED_SUGGESTIONS_COLUMNS_WITH_EMPTY as $column) {
-            $validated = $this->validateSuggestionsColumn($column);
-            
-            if ($column === '') {
-                $this->assertTrue($validated === '' || $validated === 'name', "Empty column should be valid or default to name");
-            } else {
-                $this->assertContains($validated, Item::ALLOWED_SUGGESTIONS_COLUMNS, "Valid column should be preserved: $column");
-            }
+        // Valid columns should be preserved
+        $valid_columns = ['name', 'item_number', 'description', 'cost_price', 'unit_price'];
+
+        foreach ($valid_columns as $column) {
+            $this->assertContains($column, Item::ALLOWED_SUGGESTIONS_COLUMNS, 
+                "Valid column should be in allowed list: $column");
         }
     }
 
-    public function testSuggestionsColumnValidationDefaultsToNameForInvalidInput(): void
+    public function testSuggestionsColumnValidationHandlesEmptyString(): void
     {
-        $invalid_inputs = [
-            'invalid_column',
-            'SELECT * FROM items',
-            '<?php echo "test"; ?>',
-            '<script>alert("xss")</script>',
-            'name OR 1=1'
-        ];
-
-        foreach ($invalid_inputs as $invalid) {
-            $validated = $this->validateSuggestionsColumn($invalid);
-            $this->assertEquals('name', $validated, "Invalid input should default to 'name': $invalid");
-        }
+        // Empty string should only be allowed for second and third columns
+        $this->assertContains('', Item::ALLOWED_SUGGESTIONS_COLUMNS_WITH_EMPTY, 
+            'Empty string should be allowed for optional columns');
     }
 
-    private function validateSuggestionsColumn(?string $column): string
+    public function testSuggestionsColumnValidationConstantsAreConsistent(): void
     {
-        return in_array($column, Item::ALLOWED_SUGGESTIONS_COLUMNS_WITH_EMPTY, true) ? $column : 'name';
+        // Ensure the constants are properly defined
+        $this->assertCount(5, Item::ALLOWED_SUGGESTIONS_COLUMNS, 
+            'Should have exactly 5 allowed columns');
+        $this->assertCount(6, Item::ALLOWED_SUGGESTIONS_COLUMNS_WITH_EMPTY, 
+            'Should have exactly 6 allowed columns including empty');
+        
+        // Ensure empty string is only in WITH_EMPTY variant
+        $this->assertNotContains('', Item::ALLOWED_SUGGESTIONS_COLUMNS, 
+            'Empty string should not be in required columns list');
     }
 }


### PR DESCRIPTION
Fixes critical SQL injection vulnerability in suggestions column configuration. See commit for details.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Strengthened validation for search suggestion columns so only whitelisted fields are accepted; the primary suggestion always falls back to the item name and secondary/tertiary suggestions are shown only when valid.

* **Tests**
  * Added unit tests covering suggestion column validation: accepts valid fields, allows empty secondary values, and rejects malicious/invalid inputs.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->