### PR TITLE
Fix DECIMAL attribute not respecting locale format

### DIFF
--- a/app/Controllers/Reports.php
+++ b/app/Controllers/Reports.php
@@ -1776,7 +1776,7 @@ class Reports extends Secure_Controller
     {
         $this->clearCache();
 
-        $definition_names = $this->attribute->get_definitions_by_flags(attribute::SHOW_IN_SALES);
+        $definition_names = $this->attribute->get_definitions_by_flags(attribute::SHOW_IN_SALES, true);
 
         $inputs = [
             'start_date'     => $start_date,
@@ -1789,7 +1789,12 @@ class Reports extends Secure_Controller
         $this->detailed_sales->create($inputs);
 
         $columns = $this->detailed_sales->getDataColumns();
-        $columns['details'] = array_merge($columns['details'], $definition_names);
+        // Extract just names for column headers
+        $definition_headers = [];
+        foreach ($definition_names as $definition_id => $definition_info) {
+            $definition_headers[$definition_id] = $definition_info['name'];
+        }
+        $columns['details'] = array_merge($columns['details'], $definition_headers);
 
         $headers = $columns;
 
@@ -1930,14 +1935,19 @@ class Reports extends Secure_Controller
     {
         $this->clearCache();
 
-        $definition_names = $this->attribute->get_definitions_by_flags(attribute::SHOW_IN_RECEIVINGS);
+        $definition_names = $this->attribute->get_definitions_by_flags(attribute::SHOW_IN_RECEIVINGS, true);
 
         $inputs = ['start_date' => $start_date, 'end_date' => $end_date, 'receiving_type' => $receiving_type, 'location_id' => $location_id, 'definition_ids' => array_keys($definition_names)];
 
         $this->detailed_receivings->create($inputs);
 
         $columns = $this->detailed_receivings->getDataColumns();
-        $columns['details'] = array_merge($columns['details'], $definition_names);
+        // Extract just names for column headers
+        $definition_headers = [];
+        foreach ($definition_names as $definition_id => $definition_info) {
+            $definition_headers[$definition_id] = $definition_info['name'];
+        }
+        $columns['details'] = array_merge($columns['details'], $definition_headers);
 
         $headers = $columns;
         $report_data = $this->detailed_receivings->getData($inputs);

--- a/app/Controllers/Reports.php
+++ b/app/Controllers/Reports.php
@@ -1790,11 +1790,11 @@ class Reports extends Secure_Controller
 
         $columns = $this->detailed_sales->getDataColumns();
         // Extract just names for column headers
-        $definition_headers = [];
-        foreach ($definition_names as $definition_id => $definition_info) {
-            $definition_headers[$definition_id] = $definition_info['name'];
+        $definitionHeaders = [];
+        foreach ($definition_names as $definition_id => $definitionInfo) {
+            $definitionHeaders[$definition_id] = $definitionInfo['name'];
         }
-        $columns['details'] = array_merge($columns['details'], $definition_headers);
+        $columns['details'] = array_merge($columns['details'], $definitionHeaders);
 
         $headers = $columns;
 
@@ -1943,11 +1943,11 @@ class Reports extends Secure_Controller
 
         $columns = $this->detailed_receivings->getDataColumns();
         // Extract just names for column headers
-        $definition_headers = [];
-        foreach ($definition_names as $definition_id => $definition_info) {
-            $definition_headers[$definition_id] = $definition_info['name'];
+        $definitionHeaders = [];
+        foreach ($definition_names as $definition_id => $definitionInfo) {
+            $definitionHeaders[$definition_id] = $definitionInfo['name'];
         }
-        $columns['details'] = array_merge($columns['details'], $definition_headers);
+        $columns['details'] = array_merge($columns['details'], $definitionHeaders);
 
         $headers = $columns;
         $report_data = $this->detailed_receivings->getData($inputs);

--- a/app/Helpers/tabular_helper.php
+++ b/app/Helpers/tabular_helper.php
@@ -408,7 +408,7 @@ function get_items_manage_table_headers(): string
 {
     $attribute = model(Attribute::class);
     $config = config(OSPOS::class)->settings;
-    $definitions_with_types = $attribute->get_definitions_by_flags($attribute::SHOW_IN_ITEMS, true);
+    $definitionsWithTypes = $attribute->get_definitions_by_flags($attribute::SHOW_IN_ITEMS, true);
 
     $headers = item_headers();
 
@@ -420,8 +420,8 @@ function get_items_manage_table_headers(): string
 
     $headers[] = ['item_pic' => lang('Items.image'), 'sortable' => false];
 
-    foreach ($definitions_with_types as $definition_id => $definition_info) {
-        $headers[] = [$definition_id => $definition_info['name'], 'sortable' => false];
+    foreach ($definitionsWithTypes as $definition_id => $definitionInfo) {
+        $headers[] = [$definition_id => $definitionInfo['name'], 'sortable' => false];
     }
 
     $headers[] = ['inventory' => '', 'escape' => false];
@@ -651,12 +651,12 @@ function expand_attribute_values(array $definition_names, array $row): array
     }
 
     $attribute_values = [];
-    foreach ($definition_names as $definition_id => $definition_info) {
+    foreach ($definition_names as $definition_id => $definitionInfo) {
         if (isset($indexed_values[$definition_id])) {
             $raw_value = $indexed_values[$definition_id];
             
             // Format DECIMAL attributes according to locale
-            if (is_array($definition_info) && isset($definition_info['type']) && $definition_info['type'] === DECIMAL) {
+            if (is_array($definitionInfo) && isset($definitionInfo['type']) && $definitionInfo['type'] === DECIMAL) {
                 $attribute_values["$definition_id"] = to_decimals($raw_value);
             } else {
                 $attribute_values["$definition_id"] = $raw_value;

--- a/app/Helpers/tabular_helper.php
+++ b/app/Helpers/tabular_helper.php
@@ -408,7 +408,7 @@ function get_items_manage_table_headers(): string
 {
     $attribute = model(Attribute::class);
     $config = config(OSPOS::class)->settings;
-    $definition_names = $attribute->get_definitions_by_flags($attribute::SHOW_IN_ITEMS);    // TODO: this should be made into a constant in constants.php
+    $definitions_with_types = $attribute->get_definitions_by_flags($attribute::SHOW_IN_ITEMS, true);
 
     $headers = item_headers();
 
@@ -420,8 +420,8 @@ function get_items_manage_table_headers(): string
 
     $headers[] = ['item_pic' => lang('Items.image'), 'sortable' => false];
 
-    foreach ($definition_names as $definition_id => $definition_name) {
-        $headers[] = [$definition_id => $definition_name, 'sortable' => false];
+    foreach ($definitions_with_types as $definition_id => $definition_info) {
+        $headers[] = [$definition_id => $definition_info['name'], 'sortable' => false];
     }
 
     $headers[] = ['inventory' => '', 'escape' => false];
@@ -479,7 +479,7 @@ function get_item_data_row(object $item): array
         $item->name .= NAME_SEPARATOR . $item->pack_name;
     }
 
-    $definition_names = $attribute->get_definitions_by_flags($attribute::SHOW_IN_ITEMS);
+    $definition_names = $attribute->get_definitions_by_flags($attribute::SHOW_IN_ITEMS, true);
 
     $columns = [
         'items.item_id' => $item->item_id,
@@ -634,7 +634,7 @@ function parse_attribute_values(array $columns, array $row): array
 }
 
 /**
- * @param array $definition_names
+ * @param array $definition_names Array of definition_id => ['name' => name, 'type' => type] or definition_id => name
  * @param array $row
  * @return array
  */
@@ -651,10 +651,16 @@ function expand_attribute_values(array $definition_names, array $row): array
     }
 
     $attribute_values = [];
-    foreach ($definition_names as $definition_id => $definition_name) {
+    foreach ($definition_names as $definition_id => $definition_info) {
         if (isset($indexed_values[$definition_id])) {
-            $attribute_value = $indexed_values[$definition_id];
-            $attribute_values["$definition_id"] = $attribute_value;
+            $raw_value = $indexed_values[$definition_id];
+            
+            // Format DECIMAL attributes according to locale
+            if (is_array($definition_info) && isset($definition_info['type']) && $definition_info['type'] === DECIMAL) {
+                $attribute_values["$definition_id"] = to_decimals($raw_value);
+            } else {
+                $attribute_values["$definition_id"] = $raw_value;
+            }
         } else {
             $attribute_values["$definition_id"] = "";
         }

--- a/app/Models/Attribute.php
+++ b/app/Models/Attribute.php
@@ -262,9 +262,10 @@ class Attribute extends Model
 
     /**
      * @param int $definition_flags
+     * @param bool $include_types If true, returns array with definition_id => ['name' => name, 'type' => type]
      * @return array
      */
-    public function get_definitions_by_flags(int $definition_flags): array
+    public function get_definitions_by_flags(int $definition_flags, bool $include_types = false): array
     {
         $builder = $this->db->table('attribute_definitions');
         $builder->where(new RawSql("definition_flags & $definition_flags"));    // TODO: we need to heed CI warnings to escape properly
@@ -273,6 +274,17 @@ class Attribute extends Model
         $builder->orderBy('definition_id');
 
         $results = $builder->get()->getResultArray();
+
+        if ($include_types) {
+            $definitions = [];
+            foreach ($results as $result) {
+                $definitions[$result['definition_id']] = [
+                    'name' => $result['definition_name'],
+                    'type' => $result['definition_type']
+                ];
+            }
+            return $definitions;
+        }
 
         return $this->to_array($results, 'definition_id', 'definition_name');
     }


### PR DESCRIPTION
## Summary

Fixes #2884

DECIMAL attribute values were displayed as raw database values instead of being formatted according to the user's locale settings.

## Problem

When displaying DECIMAL attribute values in table views (items table, sales reports, receiving reports), the values showed the raw numeric format from the database (e.g., `1234.56`) instead of respecting the locale-specific format (e.g., European locales showing `1.234,56`).

This was inconsistent with DATE attributes, which already received locale-based formatting.

## Solution

1. **Modified `Attribute::get_definitions_by_flags()`** to optionally return definition types along with names via a new `` parameter

2. **Updated `expand_attribute_values()` in `tabular_helper.php`** to:
   - Detect when a definition is of type `DECIMAL`
   - Apply `to_decimals()` locale formatting to those values
   - Leave other types (TEXT, DROPDOWN, DATE, CHECKBOX) unchanged

3. **Updated callers** in:
   - `get_items_manage_table_headers()` 
   - `get_item_data_row()`
   - Reports (detailed_sales, detailed_receivings)

## Files Changed

- `app/Models/Attribute.php` - Added `` parameter to `get_definitions_by_flags()`
- `app/Helpers/tabular_helper.php` - Added DECIMAL formatting in `expand_attribute_values()` and updated header generation
- `app/Controllers/Reports.php` - Updated detailed_sales and detailed_receivings to pass types

## Testing

Before: DECIMAL values displayed as `1234.56` regardless of locale
After: DECIMAL values use locale format (e.g., `1.234,56` for European locales)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Fixed column header formatting in detailed sales and receivings reports to properly display definition names.

* **Improvements**
  * Enhanced numeric attribute formatting with locale-aware handling across reports.
  * Improved attribute value display based on data type, with better formatting for numeric attributes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->