### PR TITLE
Update SECURITY.md with published security advisories

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,9 +1,9 @@
 <!-- START doctoc generated TOC please keep comment here to allow auto update -->
 <!-- DON'T EDIT THIS SECTION, INSTEAD RE-RUN doctoc TO UPDATE -->
 
-
 - [Security Policy](#security-policy)
   - [Supported Versions](#supported-versions)
+  - [Security Advisories](#security-advisories)
   - [Reporting a Vulnerability](#reporting-a-vulnerability)
 
 <!-- END doctoc generated TOC please keep comment here to allow auto update -->
@@ -12,14 +12,35 @@
 
 ## Supported Versions
 
-We release patches for security vulnerabilities. Which versions are eligible to receive such patches depend on the CVSS v3.0 Rating:
+We release patches for security vulnerabilities.
 
-| CVSS v3.0 | Supported Versions                                 |
-| --------- | -------------------------------------------------- |
-| 7.3       | 3.3.5                                              |
-| 9.8       | 3.3.6                                              |
-| 6.8       | 3.4.2                                              |
+| Version   | Supported          |
+| --------- | ------------------ |
+| >= 3.4.2  | :white_check_mark: |
+| < 3.4.2   | :x:                |
+
+## Security Advisories
+
+The following security vulnerabilities have been published:
+
+### High Severity
+
+| CVE | Vulnerability | CVSS | Published | Fixed In | Credit |
+|-----|--------------|------|-----------|----------|--------|
+| [CVE-2025-68434](https://github.com/opensourcepos/opensourcepos/security/advisories/GHSA-wjm4-hfwg-5w5r) | CSRF leading to Admin Creation | 8.8 | 2025-12-17 | 3.4.2 | @Nixon-H, @jekkos |
+| [CVE-2025-68147](https://github.com/opensourcepos/opensourcepos/security/advisories/GHSA-xgr7-7pvw-fpmh) | Stored XSS in Return Policy | 8.1 | 2025-12-17 | 3.4.2 | @Nixon-H, @jekkos |
+| [CVE-2025-66924](https://github.com/opensourcepos/opensourcepos/security/advisories/GHSA-gv8j-f6gq-g59m) | Stored XSS in Item Kits | 7.2 | 2026-03-04 | 3.4.2 | @hungnqdz, @omkaryepre |
+
+### Medium Severity
+
+| CVE | Vulnerability | CVSS | Published | Fixed In | Credit |
+|-----|--------------|------|-----------|----------|--------|
+| [CVE-2025-68658](https://github.com/opensourcepos/opensourcepos/security/advisories/GHSA-32r8-8r9r-9chw) | Stored XSS in Company Name | 4.3 | 2026-01-13 | 3.4.2 | @hungnqdz |
+
+For a complete list including draft advisories, see our [GitHub Security Advisories page](https://github.com/opensourcepos/opensourcepos/security/advisories).
 
 ## Reporting a Vulnerability
 
-Please report (suspected) security vulnerabilities to **[jeroen@steganos.dev](mailto:jeroen@steganos.dev)**. You will receive a response from us within 48 hours. If the issue is confirmed, we will release a patch as soon as possible depending on complexity but historically within a few days.
+Please report (suspected) security vulnerabilities to **[jeroen@steganos.dev](mailto:jeroen@steganos.dev)**. 
+
+You will receive a response from us within 48 hours. If the issue is confirmed, we will release a patch as soon as possible depending on complexity but historically within a few days.


### PR DESCRIPTION
- Add Security Advisories section with 4 published CVEs
- Include CVE ID, vulnerability description, CVSS score, publication date, fixed version, and reporter credits
- Update supported versions table to reflect current state (>= 3.4.2)
- Add link to GitHub Security Advisories page for complete list

CVEs added:
- CVE-2025-68434: CSRF leading to Admin Creation (8.8)
- CVE-2025-68147: Stored XSS in Return Policy (8.1)
- CVE-2025-66924: Stored XSS in Item Kits (7.2)
- CVE-2025-68658: Stored XSS in Company Name (4.3)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Enhanced security advisories section with organized CVE listings by severity level.
  * Updated supported versions table for clearer version status reference.
  * Improved vulnerability reporting guidance for better readability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->