### PR TITLE
Fix IDOR vulnerability in password change (GHSA-mcc2-8rp2-q6ch)

### DIFF
--- a/app/Controllers/Home.php
+++ b/app/Controllers/Home.php
@@ -46,7 +46,7 @@ class Home extends Secure_Controller
 
         $employeeId = $employeeId === NEW_ENTRY ? $currentPersonId : $employeeId;
 
-        if (!$this->employee->can_modify_employee($employeeId, $currentPersonId)) {
+        if (!$this->employee->isAdmin($currentPersonId) && $employeeId !== $currentPersonId) {
             header('Location: ' . base_url('no_access/home/home'));
             exit();
         }
@@ -71,7 +71,7 @@ class Home extends Secure_Controller
 
         $employeeId = $employeeId === NEW_ENTRY ? $currentUser->person_id : $employeeId;
 
-        if (!$this->employee->can_modify_employee($employeeId, $currentUser->person_id)) {
+        if (!$this->employee->isAdmin($currentUser->person_id) && $employeeId !== $currentUser->person_id) {
             return $this->response->setStatusCode(403)->setJSON([
                 'success' => false,
                 'message' => lang('Employees.unauthorized_modify')

--- a/app/Controllers/Home.php
+++ b/app/Controllers/Home.php
@@ -36,10 +36,10 @@ class Home extends Secure_Controller
     /**
      * Load "change employee password" form
      *
-     * @return string
+     * @return ResponseInterface|string
      * @noinspection PhpUnused
      */
-    public function getChangePassword(int $employeeId = NEW_ENTRY): string
+    public function getChangePassword(int $employeeId = NEW_ENTRY)
     {
         $loggedInEmployee = $this->employee->get_logged_in_employee_info();
         $currentPersonId = $loggedInEmployee->person_id;
@@ -47,8 +47,7 @@ class Home extends Secure_Controller
         $employeeId = $employeeId === NEW_ENTRY ? $currentPersonId : $employeeId;
 
         if (!$this->employee->isAdmin($currentPersonId) && $employeeId !== $currentPersonId) {
-            header('Location: ' . base_url('no_access/home/home'));
-            exit();
+            return $this->response->setStatusCode(403)->setBody(lang('Employees.unauthorized_modify'));
         }
 
         $person_info = $this->employee->get_info($employeeId);

--- a/tests/Controllers/HomeTest.php
+++ b/tests/Controllers/HomeTest.php
@@ -232,20 +232,21 @@ class HomeTest extends CIUnitTestCase
     /**
      * Create a non-admin employee for testing
      * 
+     * @param array $overrides Optional overrides for username, email, password, etc.
      * @return int The person_id of the created employee
      */
-    protected function createNonAdminEmployee(): int
+    protected function createNonAdminEmployee(array $overrides = []): int
     {
         $personData = [
-            'first_name'   => 'NonAdmin',
-            'last_name'    => 'User',
-            'email'        => 'nonadmin@test.com',
-            'phone_number' => '555-1234'
+            'first_name'   => $overrides['first_name'] ?? 'NonAdmin',
+            'last_name'    => $overrides['last_name'] ?? 'User',
+            'email'        => $overrides['email'] ?? 'nonadmin@test.com',
+            'phone_number' => $overrides['phone_number'] ?? '555-1234'
         ];
         
         $employeeData = [
-            'username'      => 'nonadmin',
-            'password'      => password_hash('password123', PASSWORD_DEFAULT),
+            'username'      => $overrides['username'] ?? 'nonadmin',
+            'password'      => password_hash($overrides['password'] ?? 'password123', PASSWORD_DEFAULT),
             'hash_version'  => 2,
             'language_code' => 'en',
             'language'      => 'english'
@@ -291,8 +292,7 @@ class HomeTest extends CIUnitTestCase
         
         $response = $this->get('/home/changePassword/1');
         
-        $response->assertRedirect();
-        $this->assertStringContainsString('no_access', $response->getRedirectUrl());
+        $response->assertStatus(403);
     }
     
     /**
@@ -435,35 +435,15 @@ class HomeTest extends CIUnitTestCase
         $nonAdminId1 = $this->createNonAdminEmployee();
         $this->loginAs($nonAdminId1);
         
-        // Try to access another user's password form (user ID 1 is admin, which is already tested)
-        // Create a second non-admin by modifying the first approach
-        $personData = [
-            'first_name'   => 'Other',
-            'last_name'    => 'User',
-            'email'        => 'other@test.com',
-            'phone_number' => '555-5678'
-        ];
-        
-        $employeeData = [
-            'username'      => 'otheruser',
-            'password'      => password_hash('password456', PASSWORD_DEFAULT),
-            'hash_version'  => 2,
-            'language_code' => 'en',
-            'language'      => 'english'
-        ];
-        
-        $grantsData = [
-            ['permission_id' => 'customers', 'menu_group' => 'home'],
-        ];
-        
-        $employeeModel = model(Employee::class);
-        $employeeModel->save_employee($personData, $employeeData, $grantsData, NEW_ENTRY);
-        $otherUserId = $employeeModel->get_found_rows('');
+        $otherUserId = $this->createNonAdminEmployee([
+            'username' => 'otheruser',
+            'email' => 'other@test.com',
+            'password' => 'password456'
+        ]);
         
         $response = $this->get('/home/changePassword/' . $otherUserId);
         
-        $response->assertRedirect();
-        $this->assertStringContainsString('no_access', $response->getRedirectUrl());
+        $response->assertStatus(403);
     }
 
     /**
@@ -477,29 +457,11 @@ class HomeTest extends CIUnitTestCase
         $nonAdminId1 = $this->createNonAdminEmployee();
         $this->loginAs($nonAdminId1);
         
-        // Create a second user to target
-        $personData = [
-            'first_name'   => 'Victim',
-            'last_name'    => 'User',
-            'email'        => 'victim@test.com',
-            'phone_number' => '555-9999'
-        ];
-        
-        $employeeData = [
-            'username'      => 'victimuser',
-            'password'      => password_hash('victimpass123', PASSWORD_DEFAULT),
-            'hash_version'  => 2,
-            'language_code' => 'en',
-            'language'      => 'english'
-        ];
-        
-        $grantsData = [
-            ['permission_id' => 'customers', 'menu_group' => 'home'],
-        ];
-        
-        $employeeModel = model(Employee::class);
-        $employeeModel->save_employee($personData, $employeeData, $grantsData, NEW_ENTRY);
-        $victimId = $employeeModel->get_found_rows('');
+        $victimId = $this->createNonAdminEmployee([
+            'username' => 'victimuser',
+            'email' => 'victim@test.com',
+            'password' => 'victimpass123'
+        ]);
         
         $response = $this->post('/home/save/' . $victimId, [
             'username' => 'victimuser',
@@ -512,6 +474,7 @@ class HomeTest extends CIUnitTestCase
         $this->assertFalse($result['success']);
         
         // Verify victim's password was NOT changed
+        $employeeModel = model(Employee::class);
         $victim = $employeeModel->get_info($victimId);
         $this->assertTrue(password_verify('victimpass123', $victim->password), 
             'Non-admin should not be able to change another non-admin password');

--- a/tests/Controllers/HomeTest.php
+++ b/tests/Controllers/HomeTest.php
@@ -423,4 +423,97 @@ class HomeTest extends CIUnitTestCase
         $response->assertStatus(200);
         $response->assertSee('nonadmin');
     }
+
+    /**
+     * Test non-admin cannot view another non-admin's password form
+     * IDOR vulnerability fix: GHSA-mcc2-8rp2-q6ch
+     * 
+     * @return void
+     */
+    public function testNonAdminCannotViewOtherNonAdminPasswordForm(): void
+    {
+        $nonAdminId1 = $this->createNonAdminEmployee();
+        $this->loginAs($nonAdminId1);
+        
+        // Try to access another user's password form (user ID 1 is admin, which is already tested)
+        // Create a second non-admin by modifying the first approach
+        $personData = [
+            'first_name'   => 'Other',
+            'last_name'    => 'User',
+            'email'        => 'other@test.com',
+            'phone_number' => '555-5678'
+        ];
+        
+        $employeeData = [
+            'username'      => 'otheruser',
+            'password'      => password_hash('password456', PASSWORD_DEFAULT),
+            'hash_version'  => 2,
+            'language_code' => 'en',
+            'language'      => 'english'
+        ];
+        
+        $grantsData = [
+            ['permission_id' => 'customers', 'menu_group' => 'home'],
+        ];
+        
+        $employeeModel = model(Employee::class);
+        $employeeModel->save_employee($personData, $employeeData, $grantsData, NEW_ENTRY);
+        $otherUserId = $employeeModel->get_found_rows('');
+        
+        $response = $this->get('/home/changePassword/' . $otherUserId);
+        
+        $response->assertRedirect();
+        $this->assertStringContainsString('no_access', $response->getRedirectUrl());
+    }
+
+    /**
+     * Test non-admin cannot change another non-admin's password
+     * IDOR vulnerability fix: GHSA-mcc2-8rp2-q6ch
+     * 
+     * @return void
+     */
+    public function testNonAdminCannotChangeOtherNonAdminPassword(): void
+    {
+        $nonAdminId1 = $this->createNonAdminEmployee();
+        $this->loginAs($nonAdminId1);
+        
+        // Create a second user to target
+        $personData = [
+            'first_name'   => 'Victim',
+            'last_name'    => 'User',
+            'email'        => 'victim@test.com',
+            'phone_number' => '555-9999'
+        ];
+        
+        $employeeData = [
+            'username'      => 'victimuser',
+            'password'      => password_hash('victimpass123', PASSWORD_DEFAULT),
+            'hash_version'  => 2,
+            'language_code' => 'en',
+            'language'      => 'english'
+        ];
+        
+        $grantsData = [
+            ['permission_id' => 'customers', 'menu_group' => 'home'],
+        ];
+        
+        $employeeModel = model(Employee::class);
+        $employeeModel->save_employee($personData, $employeeData, $grantsData, NEW_ENTRY);
+        $victimId = $employeeModel->get_found_rows('');
+        
+        $response = $this->post('/home/save/' . $victimId, [
+            'username' => 'victimuser',
+            'current_password' => 'victimpass123',
+            'password' => 'hacked123456'
+        ]);
+        
+        $response->assertStatus(403);
+        $result = json_decode($response->getJSON(), true);
+        $this->assertFalse($result['success']);
+        
+        // Verify victim's password was NOT changed
+        $victim = $employeeModel->get_info($victimId);
+        $this->assertTrue(password_verify('victimpass123', $victim->password), 
+            'Non-admin should not be able to change another non-admin password');
+    }
 }


### PR DESCRIPTION
## Summary

- Fixes IDOR vulnerability allowing authenticated non-admin users to change other users' passwords by manipulating the `employee_id` parameter
- Replaces overly-permissive `can_modify_employee()` check with stricter authorization for password operations
- Users can now only change their own password; admins can still change any user's password

## Impact

**Before fix:** Any authenticated user could change any other non-admin user's password by accessing:
- `GET /home/changePassword/{employee_id}`
- `POST /home/save/{employee_id}`

**After fix:** 
- Users can only access/change their own password
- Admins can still change any user's password
- Non-admins attempting to access other users' passwords receive 403 Forbidden

## Test plan

- [x] Added tests for non-admin → non-admin IDOR attack (both GET and POST)
- [x] Existing tests cover admin → non-admin and non-admin → admin scenarios
- [x] Verified fix logic: `!isAdmin(current) && target !== current` → deny

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Enforced permission checks so only admins can change other users' passwords; users can still change their own. Unauthorized attempts now return proper 403 Forbidden responses (page or JSON) instead of redirects.

* **Tests**
  * Added tests covering non-admin attempts to view or change another user's password to verify access is denied and no password changes occur.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->