### PR TITLE
Fix stored XSS vulnerability in Attribute Definitions (GHSA-rvfg-ww4r-rwqf)

### DIFF
--- a/app/Controllers/Attributes.php
+++ b/app/Controllers/Attributes.php
@@ -65,7 +65,7 @@ class Attributes extends Secure_Controller
     public function postSaveAttributeValue(): ResponseInterface
     {
         $success = $this->attribute->saveAttributeValue(
-            html_entity_decode($this->request->getPost('attribute_value')),
+            htmlspecialchars(html_entity_decode($this->request->getPost('attribute_value')), ENT_QUOTES, 'UTF-8'),
             $this->request->getPost('definition_id', FILTER_SANITIZE_NUMBER_INT),
             $this->request->getPost('item_id', FILTER_SANITIZE_NUMBER_INT) ?? false,
             $this->request->getPost('attribute_id', FILTER_SANITIZE_NUMBER_INT) ?? false
@@ -108,10 +108,10 @@ class Attributes extends Secure_Controller
 
         // Save definition data
         $definition_data = [
-            'definition_name'  => $this->request->getPost('definition_name'),
-            'definition_unit'  => $this->request->getPost('definition_unit') != '' ? $this->request->getPost('definition_unit') : null,
+            'definition_name'  => $this->request->getPost('definition_name', FILTER_SANITIZE_FULL_SPECIAL_CHARS),
+            'definition_unit'  => $this->request->getPost('definition_unit') != '' ? $this->request->getPost('definition_unit', FILTER_SANITIZE_FULL_SPECIAL_CHARS) : null,
             'definition_flags' => $definition_flags,
-            'definition_fk'    => $this->request->getPost('definition_group') != '' ? $this->request->getPost('definition_group') : null
+            'definition_fk'    => $this->request->getPost('definition_group') != '' ? $this->request->getPost('definition_group', FILTER_SANITIZE_NUMBER_INT) : null
         ];
 
         if ($this->request->getPost('definition_type') != null) {
@@ -126,7 +126,7 @@ class Attributes extends Secure_Controller
                 $definition_values = json_decode(html_entity_decode($this->request->getPost('definition_values')));
 
                 foreach ($definition_values as $definition_value) {
-                    $this->attribute->saveAttributeValue($definition_value, $definition_data['definition_id']);
+                    $this->attribute->saveAttributeValue(htmlspecialchars($definition_value, ENT_QUOTES, 'UTF-8'), $definition_data['definition_id']);
                 }
 
                 return $this->response->setJSON([

--- a/app/Controllers/Attributes.php
+++ b/app/Controllers/Attributes.php
@@ -108,24 +108,14 @@ class Attributes extends Secure_Controller
 
         // Validate definition_group (definition_fk) foreign key
         $definition_group_input = $this->request->getPost('definition_group');
-        $definition_fk = null;
+        $definition_fk = $this->validateDefinitionGroup($definition_group_input);
 
-        if ($definition_group_input !== '' && $definition_group_input !== null) {
-            $definition_group_id = (int) $definition_group_input;
-
-            // Must be a positive integer, exist in attribute_definitions, and be of type GROUP
-            if ($definition_group_id <= 0
-                || !$this->attribute->exists($definition_group_id)
-                || $this->attribute->getAttributeInfo($definition_group_id)->definition_type !== GROUP
-            ) {
-                return $this->response->setJSON([
-                    'success' => false,
-                    'message' => lang('Attributes.definition_invalid_group'),
-                    'id'      => NEW_ENTRY
-                ]);
-            }
-
-            $definition_fk = $definition_group_id;
+        if ($definition_fk === false) {
+            return $this->response->setJSON([
+                'success' => false,
+                'message' => lang('Attributes.definition_invalid_group'),
+                'id'      => NEW_ENTRY
+            ]);
         }
 
         // Save definition data
@@ -170,6 +160,32 @@ class Attributes extends Secure_Controller
                 'id'      => NEW_ENTRY
             ]);
         }
+    }
+
+    /**
+     * Validates a definition_group foreign key.
+     * Returns the validated integer ID, null if empty, or false if invalid.
+     *
+     * @param mixed $definition_group_input
+     * @return int|null|false
+     */
+    private function validateDefinitionGroup(mixed $definition_group_input): int|null|false
+    {
+        if ($definition_group_input === '' || $definition_group_input === null) {
+            return null;
+        }
+
+        $definition_group_id = (int) $definition_group_input;
+
+        // Must be a positive integer, exist in attribute_definitions, and be of type GROUP
+        if ($definition_group_id <= 0
+            || !$this->attribute->exists($definition_group_id)
+            || $this->attribute->getAttributeInfo($definition_group_id)->definition_type !== GROUP
+        ) {
+            return false;
+        }
+
+        return $definition_group_id;
     }
 
     /**

--- a/app/Controllers/Attributes.php
+++ b/app/Controllers/Attributes.php
@@ -65,7 +65,7 @@ class Attributes extends Secure_Controller
     public function postSaveAttributeValue(): ResponseInterface
     {
         $success = $this->attribute->saveAttributeValue(
-            htmlspecialchars(html_entity_decode($this->request->getPost('attribute_value')), ENT_QUOTES, 'UTF-8'),
+            html_entity_decode($this->request->getPost('attribute_value')),
             $this->request->getPost('definition_id', FILTER_SANITIZE_NUMBER_INT),
             $this->request->getPost('item_id', FILTER_SANITIZE_NUMBER_INT) ?? false,
             $this->request->getPost('attribute_id', FILTER_SANITIZE_NUMBER_INT) ?? false
@@ -108,8 +108,8 @@ class Attributes extends Secure_Controller
 
         // Save definition data
         $definition_data = [
-            'definition_name'  => $this->request->getPost('definition_name', FILTER_SANITIZE_FULL_SPECIAL_CHARS),
-            'definition_unit'  => $this->request->getPost('definition_unit') != '' ? $this->request->getPost('definition_unit', FILTER_SANITIZE_FULL_SPECIAL_CHARS) : null,
+            'definition_name'  => $this->request->getPost('definition_name'),
+            'definition_unit'  => $this->request->getPost('definition_unit') != '' ? $this->request->getPost('definition_unit') : null,
             'definition_flags' => $definition_flags,
             'definition_fk'    => $this->request->getPost('definition_group') != '' ? $this->request->getPost('definition_group', FILTER_SANITIZE_NUMBER_INT) : null
         ];
@@ -126,7 +126,7 @@ class Attributes extends Secure_Controller
                 $definition_values = json_decode(html_entity_decode($this->request->getPost('definition_values')));
 
                 foreach ($definition_values as $definition_value) {
-                    $this->attribute->saveAttributeValue(htmlspecialchars($definition_value, ENT_QUOTES, 'UTF-8'), $definition_data['definition_id']);
+                    $this->attribute->saveAttributeValue($definition_value, $definition_data['definition_id']);
                 }
 
                 return $this->response->setJSON([

--- a/app/Controllers/Attributes.php
+++ b/app/Controllers/Attributes.php
@@ -113,27 +113,11 @@ class Attributes extends Secure_Controller
         if ($definition_group_input !== '' && $definition_group_input !== null) {
             $definition_group_id = (int) $definition_group_input;
 
-            // Must be a positive integer
-            if ($definition_group_id <= 0) {
-                return $this->response->setJSON([
-                    'success' => false,
-                    'message' => lang('Attributes.definition_invalid_group'),
-                    'id'      => NEW_ENTRY
-                ]);
-            }
-
-            // Must exist in attribute_definitions
-            if (!$this->attribute->exists($definition_group_id)) {
-                return $this->response->setJSON([
-                    'success' => false,
-                    'message' => lang('Attributes.definition_invalid_group'),
-                    'id'      => NEW_ENTRY
-                ]);
-            }
-
-            // Must be of type GROUP
-            $group_info = $this->attribute->getAttributeInfo($definition_group_id);
-            if ($group_info->definition_type !== GROUP) {
+            // Must be a positive integer, exist in attribute_definitions, and be of type GROUP
+            if ($definition_group_id <= 0
+                || !$this->attribute->exists($definition_group_id)
+                || $this->attribute->getAttributeInfo($definition_group_id)->definition_type !== GROUP
+            ) {
                 return $this->response->setJSON([
                     'success' => false,
                     'message' => lang('Attributes.definition_invalid_group'),

--- a/app/Controllers/Attributes.php
+++ b/app/Controllers/Attributes.php
@@ -106,12 +106,50 @@ class Attributes extends Secure_Controller
             $definition_flags |= $flag;
         }
 
+        // Validate definition_group (definition_fk) foreign key
+        $definition_group_input = $this->request->getPost('definition_group');
+        $definition_fk = null;
+
+        if ($definition_group_input !== '' && $definition_group_input !== null) {
+            $definition_group_id = (int) $definition_group_input;
+
+            // Must be a positive integer
+            if ($definition_group_id <= 0) {
+                return $this->response->setJSON([
+                    'success' => false,
+                    'message' => lang('Attributes.definition_invalid_group'),
+                    'id'      => NEW_ENTRY
+                ]);
+            }
+
+            // Must exist in attribute_definitions
+            if (!$this->attribute->exists($definition_group_id)) {
+                return $this->response->setJSON([
+                    'success' => false,
+                    'message' => lang('Attributes.definition_invalid_group'),
+                    'id'      => NEW_ENTRY
+                ]);
+            }
+
+            // Must be of type GROUP
+            $group_info = $this->attribute->getAttributeInfo($definition_group_id);
+            if ($group_info->definition_type !== GROUP) {
+                return $this->response->setJSON([
+                    'success' => false,
+                    'message' => lang('Attributes.definition_invalid_group'),
+                    'id'      => NEW_ENTRY
+                ]);
+            }
+
+            $definition_fk = $definition_group_id;
+        }
+
         // Save definition data
         $definition_data = [
             'definition_name'  => $this->request->getPost('definition_name'),
             'definition_unit'  => $this->request->getPost('definition_unit') != '' ? $this->request->getPost('definition_unit') : null,
             'definition_flags' => $definition_flags,
-            'definition_fk'    => $this->request->getPost('definition_group') != '' ? $this->request->getPost('definition_group', FILTER_SANITIZE_NUMBER_INT) : null
+            'definition_fk'    => $definition_fk
         ];
 
         if ($this->request->getPost('definition_type') != null) {

--- a/app/Language/ar-EG/Attributes.php
+++ b/app/Language/ar-EG/Attributes.php
@@ -5,7 +5,7 @@ return [
     "confirm_delete"                   => "هل أنت متأكد من أنك تريد حذف الميزات المحددة ؟",
     "confirm_restore"                  => "هل أنت متأكد من أنك تريد استعادة السمة (السمات) المحددة؟",
     "definition_cannot_be_deleted"     => "لا يمكن حذف السمات المحددة",
-    "definition_invalid_group" => "The selected group does not exist or is invalid.",
+    "definition_invalid_group" => "المجموعة المحددة غير موجودة أو غير صالحة.",
     "definition_error_adding_updating" => "لا يمكن إضافة السمة {0} أو تحديثها. يرجى التحقق من سجل الخطأ.",
     "definition_flags"                 => "رؤية الميزات",
     "definition_group"                 => "المجموعة",

--- a/app/Language/ar-EG/Attributes.php
+++ b/app/Language/ar-EG/Attributes.php
@@ -5,6 +5,7 @@ return [
     "confirm_delete"                   => "هل أنت متأكد من أنك تريد حذف الميزات المحددة ؟",
     "confirm_restore"                  => "هل أنت متأكد من أنك تريد استعادة السمة (السمات) المحددة؟",
     "definition_cannot_be_deleted"     => "لا يمكن حذف السمات المحددة",
+    "definition_invalid_group" => "The selected group does not exist or is invalid.",
     "definition_error_adding_updating" => "لا يمكن إضافة السمة {0} أو تحديثها. يرجى التحقق من سجل الخطأ.",
     "definition_flags"                 => "رؤية الميزات",
     "definition_group"                 => "المجموعة",

--- a/app/Language/ar-LB/Attributes.php
+++ b/app/Language/ar-LB/Attributes.php
@@ -5,7 +5,7 @@ return [
     "confirm_delete"                   => "هل أنت متأكد من أنك تريد حذف الميزات المحددة ؟",
     "confirm_restore"                  => "هل أنت متأكد من أنك تريد استعادة السمة (السمات) المحددة؟",
     "definition_cannot_be_deleted"     => "لا يمكن حذف السمات المحددة",
-    "definition_invalid_group" => "The selected group does not exist or is invalid.",
+    "definition_invalid_group" => "المجموعة المحددة غير موجودة أو غير صالحة.",
     "definition_error_adding_updating" => "لا يمكن إضافة السمة {0} أو تحديثها. يرجى التحقق من سجل الخطأ.",
     "definition_flags"                 => "رؤية الميزات",
     "definition_group"                 => "المجموعة",

--- a/app/Language/ar-LB/Attributes.php
+++ b/app/Language/ar-LB/Attributes.php
@@ -5,6 +5,7 @@ return [
     "confirm_delete"                   => "هل أنت متأكد من أنك تريد حذف الميزات المحددة ؟",
     "confirm_restore"                  => "هل أنت متأكد من أنك تريد استعادة السمة (السمات) المحددة؟",
     "definition_cannot_be_deleted"     => "لا يمكن حذف السمات المحددة",
+    "definition_invalid_group" => "The selected group does not exist or is invalid.",
     "definition_error_adding_updating" => "لا يمكن إضافة السمة {0} أو تحديثها. يرجى التحقق من سجل الخطأ.",
     "definition_flags"                 => "رؤية الميزات",
     "definition_group"                 => "المجموعة",

--- a/app/Language/az/Attributes.php
+++ b/app/Language/az/Attributes.php
@@ -5,7 +5,7 @@ return [
     "confirm_delete"                   => "Seçilmiş Atributları silmək istədiyinizdən əminsinizmi?",
     "confirm_restore"                  => "Seçilmiş atributları bərpa etmək istədiyinizə əminsinizmi?",
     "definition_cannot_be_deleted"     => "Seçilmiş xüsusiyyətləri silmək olmadı",
-    "definition_invalid_group" => "The selected group does not exist or is invalid.",
+    "definition_invalid_group" => "",
     "definition_error_adding_updating" => "{0} -in atributları əlavə oluna və yenilənə bilmədi. Lütfən XƏTA loq faylını yoxlayın.",
     "definition_flags"                 => "Atribut görünüşü",
     "definition_group"                 => "Qrup",

--- a/app/Language/az/Attributes.php
+++ b/app/Language/az/Attributes.php
@@ -5,6 +5,7 @@ return [
     "confirm_delete"                   => "Seçilmiş Atributları silmək istədiyinizdən əminsinizmi?",
     "confirm_restore"                  => "Seçilmiş atributları bərpa etmək istədiyinizə əminsinizmi?",
     "definition_cannot_be_deleted"     => "Seçilmiş xüsusiyyətləri silmək olmadı",
+    "definition_invalid_group" => "The selected group does not exist or is invalid.",
     "definition_error_adding_updating" => "{0} -in atributları əlavə oluna və yenilənə bilmədi. Lütfən XƏTA loq faylını yoxlayın.",
     "definition_flags"                 => "Atribut görünüşü",
     "definition_group"                 => "Qrup",

--- a/app/Language/bg/Attributes.php
+++ b/app/Language/bg/Attributes.php
@@ -5,6 +5,7 @@ return [
     "confirm_delete"                   => "",
     "confirm_restore"                  => "",
     "definition_cannot_be_deleted"     => "",
+    "definition_invalid_group" => "The selected group does not exist or is invalid.",
     "definition_error_adding_updating" => "",
     "definition_flags"                 => "",
     "definition_group"                 => "",

--- a/app/Language/bg/Attributes.php
+++ b/app/Language/bg/Attributes.php
@@ -5,7 +5,7 @@ return [
     "confirm_delete"                   => "",
     "confirm_restore"                  => "",
     "definition_cannot_be_deleted"     => "",
-    "definition_invalid_group" => "The selected group does not exist or is invalid.",
+    "definition_invalid_group" => "",
     "definition_error_adding_updating" => "",
     "definition_flags"                 => "",
     "definition_group"                 => "",

--- a/app/Language/bs/Attributes.php
+++ b/app/Language/bs/Attributes.php
@@ -5,7 +5,7 @@ return [
     "confirm_delete"                   => "Da li ste sigurni da želite da izbrišete izabrani atribut?",
     "confirm_restore"                  => "Da li ste sigurni da želite vratiti izabrane atribute?",
     "definition_cannot_be_deleted"     => "Nije moguće izbrisati izabrane atribut",
-    "definition_invalid_group" => "The selected group does not exist or is invalid.",
+    "definition_invalid_group" => "",
     "definition_error_adding_updating" => "Atribut {0} nije moguće dodati ili ažurirati. Molimo provjerite dnevnik grešaka.",
     "definition_flags"                 => "Vidljivost atributa",
     "definition_group"                 => "Grupa",

--- a/app/Language/bs/Attributes.php
+++ b/app/Language/bs/Attributes.php
@@ -5,6 +5,7 @@ return [
     "confirm_delete"                   => "Da li ste sigurni da želite da izbrišete izabrani atribut?",
     "confirm_restore"                  => "Da li ste sigurni da želite vratiti izabrane atribute?",
     "definition_cannot_be_deleted"     => "Nije moguće izbrisati izabrane atribut",
+    "definition_invalid_group" => "The selected group does not exist or is invalid.",
     "definition_error_adding_updating" => "Atribut {0} nije moguće dodati ili ažurirati. Molimo provjerite dnevnik grešaka.",
     "definition_flags"                 => "Vidljivost atributa",
     "definition_group"                 => "Grupa",

--- a/app/Language/ckb/Attributes.php
+++ b/app/Language/ckb/Attributes.php
@@ -5,6 +5,7 @@ return [
     "confirm_delete"                   => "ئایا دڵنیای کە دەتەوێت تایبەتمەندییە هەڵبژێردراوەکە(کان) بسڕیتەوە؟",
     "confirm_restore"                  => "ئایا دڵنیای کە دەتەوێت تایبەتمەندییە هەڵبژێردراوەکە(کان) بگەڕێنیتەوە؟",
     "definition_cannot_be_deleted"     => "نەتوانرا تایبەتمەندی هەڵبژێردراو بسڕدرێتەوە",
+    "definition_invalid_group" => "The selected group does not exist or is invalid.",
     "definition_error_adding_updating" => "تایبەتمەندی {0} نەتوانرا زیاد بکرێت یان نوێ بکرێتەوە. تکایە لیستی هەڵەکان بپشکنە.",
     "definition_flags"                 => "توانای بینراویی تایبەتمەندی",
     "definition_group"                 => "گروپ",

--- a/app/Language/ckb/Attributes.php
+++ b/app/Language/ckb/Attributes.php
@@ -5,7 +5,7 @@ return [
     "confirm_delete"                   => "ئایا دڵنیای کە دەتەوێت تایبەتمەندییە هەڵبژێردراوەکە(کان) بسڕیتەوە؟",
     "confirm_restore"                  => "ئایا دڵنیای کە دەتەوێت تایبەتمەندییە هەڵبژێردراوەکە(کان) بگەڕێنیتەوە؟",
     "definition_cannot_be_deleted"     => "نەتوانرا تایبەتمەندی هەڵبژێردراو بسڕدرێتەوە",
-    "definition_invalid_group" => "The selected group does not exist or is invalid.",
+    "definition_invalid_group" => "",
     "definition_error_adding_updating" => "تایبەتمەندی {0} نەتوانرا زیاد بکرێت یان نوێ بکرێتەوە. تکایە لیستی هەڵەکان بپشکنە.",
     "definition_flags"                 => "توانای بینراویی تایبەتمەندی",
     "definition_group"                 => "گروپ",

--- a/app/Language/cs/Attributes.php
+++ b/app/Language/cs/Attributes.php
@@ -5,6 +5,7 @@ return [
     "confirm_delete"                   => "",
     "confirm_restore"                  => "",
     "definition_cannot_be_deleted"     => "",
+    "definition_invalid_group" => "The selected group does not exist or is invalid.",
     "definition_error_adding_updating" => "",
     "definition_flags"                 => "",
     "definition_group"                 => "",

--- a/app/Language/cs/Attributes.php
+++ b/app/Language/cs/Attributes.php
@@ -5,7 +5,7 @@ return [
     "confirm_delete"                   => "",
     "confirm_restore"                  => "",
     "definition_cannot_be_deleted"     => "",
-    "definition_invalid_group" => "The selected group does not exist or is invalid.",
+    "definition_invalid_group" => "",
     "definition_error_adding_updating" => "",
     "definition_flags"                 => "",
     "definition_group"                 => "",

--- a/app/Language/da/Attributes.php
+++ b/app/Language/da/Attributes.php
@@ -5,6 +5,7 @@ return [
     "confirm_delete"                   => "Er du sikker på, at du vil slette de valgte egenskaber?",
     "confirm_restore"                  => "Er du sikker på, at du vil gendanne de valgte egenskaber?",
     "definition_cannot_be_deleted"     => "De valgte egenskaber kunne ikke slettes",
+    "definition_invalid_group" => "The selected group does not exist or is invalid.",
     "definition_error_adding_updating" => "Egenskab {0} Kunne ikke tilføjes eller opdateres. Tjek venligst fejlprotokollen.",
     "definition_flags"                 => "Egenskabens Synlighed",
     "definition_group"                 => "Gruppe",

--- a/app/Language/da/Attributes.php
+++ b/app/Language/da/Attributes.php
@@ -5,7 +5,7 @@ return [
     "confirm_delete"                   => "Er du sikker på, at du vil slette de valgte egenskaber?",
     "confirm_restore"                  => "Er du sikker på, at du vil gendanne de valgte egenskaber?",
     "definition_cannot_be_deleted"     => "De valgte egenskaber kunne ikke slettes",
-    "definition_invalid_group" => "The selected group does not exist or is invalid.",
+    "definition_invalid_group" => "Den valgte gruppe findes ikke eller er ugyldig.",
     "definition_error_adding_updating" => "Egenskab {0} Kunne ikke tilføjes eller opdateres. Tjek venligst fejlprotokollen.",
     "definition_flags"                 => "Egenskabens Synlighed",
     "definition_group"                 => "Gruppe",

--- a/app/Language/de-CH/Attributes.php
+++ b/app/Language/de-CH/Attributes.php
@@ -5,6 +5,7 @@ return [
     "confirm_delete"                   => "",
     "confirm_restore"                  => "",
     "definition_cannot_be_deleted"     => "",
+    "definition_invalid_group" => "The selected group does not exist or is invalid.",
     "definition_error_adding_updating" => "",
     "definition_flags"                 => "",
     "definition_group"                 => "",

--- a/app/Language/de-CH/Attributes.php
+++ b/app/Language/de-CH/Attributes.php
@@ -5,7 +5,7 @@ return [
     "confirm_delete"                   => "",
     "confirm_restore"                  => "",
     "definition_cannot_be_deleted"     => "",
-    "definition_invalid_group" => "The selected group does not exist or is invalid.",
+    "definition_invalid_group" => "Die ausgewählte Gruppe existiert nicht oder ist ungültig.",
     "definition_error_adding_updating" => "",
     "definition_flags"                 => "",
     "definition_group"                 => "",

--- a/app/Language/de-DE/Attributes.php
+++ b/app/Language/de-DE/Attributes.php
@@ -5,6 +5,7 @@ return [
     "confirm_delete"                   => "Sind Sie sicher, dass Sie die ausgewählten Attribute löschen möchten?",
     "confirm_restore"                  => "Sind Sie sicher, dass Sie die ausgewählten Attribute wiederherstellen möchten?",
     "definition_cannot_be_deleted"     => "Ausgewählte Attribute konnten nicht gelöscht werden",
+    "definition_invalid_group" => "The selected group does not exist or is invalid.",
     "definition_error_adding_updating" => "Das Attribut {0} konnte nicht hinzugefügt oder aktualisiert werden. Bitte überprüfen Sie den Error-Log.",
     "definition_flags"                 => "Attribut Sichtbarkeit",
     "definition_group"                 => "Gruppe",

--- a/app/Language/de-DE/Attributes.php
+++ b/app/Language/de-DE/Attributes.php
@@ -5,7 +5,7 @@ return [
     "confirm_delete"                   => "Sind Sie sicher, dass Sie die ausgewählten Attribute löschen möchten?",
     "confirm_restore"                  => "Sind Sie sicher, dass Sie die ausgewählten Attribute wiederherstellen möchten?",
     "definition_cannot_be_deleted"     => "Ausgewählte Attribute konnten nicht gelöscht werden",
-    "definition_invalid_group" => "The selected group does not exist or is invalid.",
+    "definition_invalid_group" => "Die ausgewählte Gruppe existiert nicht oder ist ungültig.",
     "definition_error_adding_updating" => "Das Attribut {0} konnte nicht hinzugefügt oder aktualisiert werden. Bitte überprüfen Sie den Error-Log.",
     "definition_flags"                 => "Attribut Sichtbarkeit",
     "definition_group"                 => "Gruppe",

--- a/app/Language/el/Attributes.php
+++ b/app/Language/el/Attributes.php
@@ -5,6 +5,7 @@ return [
     "confirm_delete"                   => "Είστε βέβαιοι ότι θέλετε να διαγράψετε τα επιλεγμένα χαρακτηριστικά;",
     "confirm_restore"                  => "Είστε βέβαιοι ότι θέλετε να επαναφέρετε τα επιλεγμένα χαρακτηριστικά;",
     "definition_cannot_be_deleted"     => "Δεν ήταν δυνατή η διαγραφή των επιλεγμένων χαρακτηριστικών",
+    "definition_invalid_group" => "The selected group does not exist or is invalid.",
     "definition_error_adding_updating" => "Το χαρακτηριστικό {0} δεν ήταν δυνατό να προστεθεί ή να ενημερωθεί. Ελέγξτε το αρχείο καταγραφής σφαλμάτων.",
     "definition_flags"                 => "Ορατότητα χαρακτηριστικών",
     "definition_group"                 => "Ομάδα",

--- a/app/Language/el/Attributes.php
+++ b/app/Language/el/Attributes.php
@@ -5,7 +5,7 @@ return [
     "confirm_delete"                   => "Είστε βέβαιοι ότι θέλετε να διαγράψετε τα επιλεγμένα χαρακτηριστικά;",
     "confirm_restore"                  => "Είστε βέβαιοι ότι θέλετε να επαναφέρετε τα επιλεγμένα χαρακτηριστικά;",
     "definition_cannot_be_deleted"     => "Δεν ήταν δυνατή η διαγραφή των επιλεγμένων χαρακτηριστικών",
-    "definition_invalid_group" => "The selected group does not exist or is invalid.",
+    "definition_invalid_group" => "Η επιλεγμένη ομάδα δεν υπάρχει ή δεν είναι έγκυρη.",
     "definition_error_adding_updating" => "Το χαρακτηριστικό {0} δεν ήταν δυνατό να προστεθεί ή να ενημερωθεί. Ελέγξτε το αρχείο καταγραφής σφαλμάτων.",
     "definition_flags"                 => "Ορατότητα χαρακτηριστικών",
     "definition_group"                 => "Ομάδα",

--- a/app/Language/en-GB/Attributes.php
+++ b/app/Language/en-GB/Attributes.php
@@ -6,6 +6,7 @@ return [
     "confirm_restore"                  => "Are you sure you want to restore the selected attribute(s)?",
     "definition_cannot_be_deleted"     => "Could not delete selected attribute(s)",
     "definition_error_adding_updating" => "Attribute {0} could not be added or updated. Please check the error log.",
+    "definition_invalid_group" => "The selected group does not exist or is invalid.",
     "definition_flags"                 => "Attribute Visibility",
     "definition_group"                 => "Group",
     "definition_id"                    => "Id",

--- a/app/Language/en/Attributes.php
+++ b/app/Language/en/Attributes.php
@@ -6,6 +6,7 @@ return [
     "confirm_restore"                  => "Are you sure you want to restore the selected attribute(s)?",
     "definition_cannot_be_deleted"     => "Could not delete selected attribute(s)",
     "definition_error_adding_updating" => "Attribute {0} could not be added or updated. Please check the error log.",
+    "definition_invalid_group" => "The selected group does not exist or is invalid.",
     "definition_flags"                 => "Attribute Visibility",
     "definition_group"                 => "Group",
     "definition_id"                    => "Id",

--- a/app/Language/es-ES/Attributes.php
+++ b/app/Language/es-ES/Attributes.php
@@ -5,7 +5,7 @@ return [
     "confirm_delete"                   => "¿Está seguro de que desea borrar los atributos seleccionados?",
     "confirm_restore"                  => "¿Está seguro de que desea restaurar los atributos seleccionados?",
     "definition_cannot_be_deleted"     => "No se han podido borrar los atributos seleccionados",
-    "definition_invalid_group" => "The selected group does not exist or is invalid.",
+    "definition_invalid_group" => "El grupo seleccionado no existe o no es válido.",
     "definition_error_adding_updating" => "El atributo {0} no pudo ser agregado o actulizado. Por favor compruebe el registro de errores.",
     "definition_flags"                 => "Visibilidad del atributo",
     "definition_group"                 => "Grupo",

--- a/app/Language/es-ES/Attributes.php
+++ b/app/Language/es-ES/Attributes.php
@@ -5,6 +5,7 @@ return [
     "confirm_delete"                   => "¿Está seguro de que desea borrar los atributos seleccionados?",
     "confirm_restore"                  => "¿Está seguro de que desea restaurar los atributos seleccionados?",
     "definition_cannot_be_deleted"     => "No se han podido borrar los atributos seleccionados",
+    "definition_invalid_group" => "The selected group does not exist or is invalid.",
     "definition_error_adding_updating" => "El atributo {0} no pudo ser agregado o actulizado. Por favor compruebe el registro de errores.",
     "definition_flags"                 => "Visibilidad del atributo",
     "definition_group"                 => "Grupo",

--- a/app/Language/es-MX/Attributes.php
+++ b/app/Language/es-MX/Attributes.php
@@ -5,7 +5,7 @@ return [
     "confirm_delete"                   => "¿Está seguro de eliminar el/los atributo(s) seleccionado(s)?",
     "confirm_restore"                  => "¿Está seguro que quiere restaurar los atributos seleccionados?",
     "definition_cannot_be_deleted"     => "No ha sido posible eliminar el/los atributo(s) seleccionado(s)",
-    "definition_invalid_group" => "The selected group does not exist or is invalid.",
+    "definition_invalid_group" => "El grupo seleccionado no existe o no es válido.",
     "definition_error_adding_updating" => "El atributo {0} no pudo ser agregado o actualizado. Favor de revisar el registro de errorres.",
     "definition_flags"                 => "Visibilidad del atributo",
     "definition_group"                 => "Grupo",

--- a/app/Language/es-MX/Attributes.php
+++ b/app/Language/es-MX/Attributes.php
@@ -5,6 +5,7 @@ return [
     "confirm_delete"                   => "¿Está seguro de eliminar el/los atributo(s) seleccionado(s)?",
     "confirm_restore"                  => "¿Está seguro que quiere restaurar los atributos seleccionados?",
     "definition_cannot_be_deleted"     => "No ha sido posible eliminar el/los atributo(s) seleccionado(s)",
+    "definition_invalid_group" => "The selected group does not exist or is invalid.",
     "definition_error_adding_updating" => "El atributo {0} no pudo ser agregado o actualizado. Favor de revisar el registro de errorres.",
     "definition_flags"                 => "Visibilidad del atributo",
     "definition_group"                 => "Grupo",

--- a/app/Language/fa/Attributes.php
+++ b/app/Language/fa/Attributes.php
@@ -5,7 +5,7 @@ return [
     "confirm_delete"                   => "آیا مطمئن هستید که می خواهید ویژگی (های) انتخاب شده را حذف کنید؟",
     "confirm_restore"                  => "آیا مطمئن هستید که می خواهید ویژگی (های) انتخاب شده را بازیابی کنید؟",
     "definition_cannot_be_deleted"     => "نمی توان ویژگی (های) انتخابی را حذف کرد",
-    "definition_invalid_group" => "The selected group does not exist or is invalid.",
+    "definition_invalid_group" => "گروه انتخاب شده وجود ندارد یا نامعتبر است.",
     "definition_error_adding_updating" => "ویژگی{0} اضافه نشد یا به روز نمی شود. لطفا گزارش خطا را بررسی کنید.",
     "definition_flags"                 => "قابلیت مشاهده ویژگی",
     "definition_group"                 => "گروه",

--- a/app/Language/fa/Attributes.php
+++ b/app/Language/fa/Attributes.php
@@ -5,6 +5,7 @@ return [
     "confirm_delete"                   => "آیا مطمئن هستید که می خواهید ویژگی (های) انتخاب شده را حذف کنید؟",
     "confirm_restore"                  => "آیا مطمئن هستید که می خواهید ویژگی (های) انتخاب شده را بازیابی کنید؟",
     "definition_cannot_be_deleted"     => "نمی توان ویژگی (های) انتخابی را حذف کرد",
+    "definition_invalid_group" => "The selected group does not exist or is invalid.",
     "definition_error_adding_updating" => "ویژگی{0} اضافه نشد یا به روز نمی شود. لطفا گزارش خطا را بررسی کنید.",
     "definition_flags"                 => "قابلیت مشاهده ویژگی",
     "definition_group"                 => "گروه",

--- a/app/Language/fr/Attributes.php
+++ b/app/Language/fr/Attributes.php
@@ -5,7 +5,7 @@ return [
     "confirm_delete"                   => "Êtes-vous certain de vouloir supprimer le(s) attribut(s) sélectionné(s) ?",
     "confirm_restore"                  => "Êtes-vous certain de vouloir restaurer le(s) attribut(s) sélectionné(s) ?",
     "definition_cannot_be_deleted"     => "Le(s) attribut(s) sélectionné(s) n'ont pas pu être supprimé(s)",
-    "definition_invalid_group" => "The selected group does not exist or is invalid.",
+    "definition_invalid_group" => "Le groupe sélectionné n'existe pas ou est invalide.",
     "definition_error_adding_updating" => "L'attribut {0} n'a pas pu être ajouté ou mis à jour. Veuillez vérifier le journal d'erreurs.",
     "definition_flags"                 => "Visibilité de l'attribut",
     "definition_group"                 => "Groupe",

--- a/app/Language/fr/Attributes.php
+++ b/app/Language/fr/Attributes.php
@@ -5,6 +5,7 @@ return [
     "confirm_delete"                   => "Êtes-vous certain de vouloir supprimer le(s) attribut(s) sélectionné(s) ?",
     "confirm_restore"                  => "Êtes-vous certain de vouloir restaurer le(s) attribut(s) sélectionné(s) ?",
     "definition_cannot_be_deleted"     => "Le(s) attribut(s) sélectionné(s) n'ont pas pu être supprimé(s)",
+    "definition_invalid_group" => "The selected group does not exist or is invalid.",
     "definition_error_adding_updating" => "L'attribut {0} n'a pas pu être ajouté ou mis à jour. Veuillez vérifier le journal d'erreurs.",
     "definition_flags"                 => "Visibilité de l'attribut",
     "definition_group"                 => "Groupe",

--- a/app/Language/he/Attributes.php
+++ b/app/Language/he/Attributes.php
@@ -5,7 +5,7 @@ return [
     "confirm_delete"                   => "האם אתה בטוח שברצונך למחוק את המאפיינים שנבחרו?",
     "confirm_restore"                  => "האם אתה בטוח שברצונך לשחזר את המאפיינים שנבחרו?",
     "definition_cannot_be_deleted"     => "לא ניתן למחוק מאפיינים נבחר(ים)",
-    "definition_invalid_group" => "The selected group does not exist or is invalid.",
+    "definition_invalid_group" => "הקבוצה שנבחרה לא קיימת או אינה תקינה.",
     "definition_error_adding_updating" => "לא ניתן להוסיף או לעדכן את הערך {0}. בדוק את יומן השגיאות.",
     "definition_flags"                 => "מאפיין גלוי",
     "definition_group"                 => "קבוצה",

--- a/app/Language/he/Attributes.php
+++ b/app/Language/he/Attributes.php
@@ -5,6 +5,7 @@ return [
     "confirm_delete"                   => "האם אתה בטוח שברצונך למחוק את המאפיינים שנבחרו?",
     "confirm_restore"                  => "האם אתה בטוח שברצונך לשחזר את המאפיינים שנבחרו?",
     "definition_cannot_be_deleted"     => "לא ניתן למחוק מאפיינים נבחר(ים)",
+    "definition_invalid_group" => "The selected group does not exist or is invalid.",
     "definition_error_adding_updating" => "לא ניתן להוסיף או לעדכן את הערך {0}. בדוק את יומן השגיאות.",
     "definition_flags"                 => "מאפיין גלוי",
     "definition_group"                 => "קבוצה",

--- a/app/Language/hr-HR/Attributes.php
+++ b/app/Language/hr-HR/Attributes.php
@@ -5,6 +5,7 @@ return [
     "confirm_delete"                   => "",
     "confirm_restore"                  => "",
     "definition_cannot_be_deleted"     => "",
+    "definition_invalid_group" => "The selected group does not exist or is invalid.",
     "definition_error_adding_updating" => "",
     "definition_flags"                 => "",
     "definition_group"                 => "",

--- a/app/Language/hr-HR/Attributes.php
+++ b/app/Language/hr-HR/Attributes.php
@@ -5,7 +5,7 @@ return [
     "confirm_delete"                   => "",
     "confirm_restore"                  => "",
     "definition_cannot_be_deleted"     => "",
-    "definition_invalid_group" => "The selected group does not exist or is invalid.",
+    "definition_invalid_group" => "",
     "definition_error_adding_updating" => "",
     "definition_flags"                 => "",
     "definition_group"                 => "",

--- a/app/Language/hu/Attributes.php
+++ b/app/Language/hu/Attributes.php
@@ -5,6 +5,7 @@ return [
     "confirm_delete"                   => "Biztosan törli szeretné a kijelölt tulajdonságokat?",
     "confirm_restore"                  => "Biztosan visszaállítja a kijelölt tulajdonságokat?",
     "definition_cannot_be_deleted"     => "Nem sikerült törölni a kijelölt tulajdonságokat",
+    "definition_invalid_group" => "The selected group does not exist or is invalid.",
     "definition_error_adding_updating" => "{0} attribútum nem adható hozzá és nem frissíthető. Kérjük, ellenőrizze a hibanaplót.",
     "definition_flags"                 => "Tulajdonság láthatósága",
     "definition_group"                 => "Csoport",

--- a/app/Language/hu/Attributes.php
+++ b/app/Language/hu/Attributes.php
@@ -5,7 +5,7 @@ return [
     "confirm_delete"                   => "Biztosan törli szeretné a kijelölt tulajdonságokat?",
     "confirm_restore"                  => "Biztosan visszaállítja a kijelölt tulajdonságokat?",
     "definition_cannot_be_deleted"     => "Nem sikerült törölni a kijelölt tulajdonságokat",
-    "definition_invalid_group" => "The selected group does not exist or is invalid.",
+    "definition_invalid_group" => "A kiválasztott csoport nem létezik vagy érvénytelen.",
     "definition_error_adding_updating" => "{0} attribútum nem adható hozzá és nem frissíthető. Kérjük, ellenőrizze a hibanaplót.",
     "definition_flags"                 => "Tulajdonság láthatósága",
     "definition_group"                 => "Csoport",

--- a/app/Language/hy/Attributes.php
+++ b/app/Language/hy/Attributes.php
@@ -5,7 +5,7 @@ return [
     "confirm_delete"                   => "Are you sure you want to delete the selected attribute(s)?",
     "confirm_restore"                  => "Are you sure you want to restore the selected attribute(s)?",
     "definition_cannot_be_deleted"     => "Could not delete selected attribute(s)",
-    "definition_invalid_group" => "The selected group does not exist or is invalid.",
+    "definition_invalid_group" => "",
     "definition_error_adding_updating" => "Attribute {0} could not be added or updated. Please check the error log.",
     "definition_flags"                 => "Attribute Visibility",
     "definition_group"                 => "Group",

--- a/app/Language/hy/Attributes.php
+++ b/app/Language/hy/Attributes.php
@@ -5,6 +5,7 @@ return [
     "confirm_delete"                   => "Are you sure you want to delete the selected attribute(s)?",
     "confirm_restore"                  => "Are you sure you want to restore the selected attribute(s)?",
     "definition_cannot_be_deleted"     => "Could not delete selected attribute(s)",
+    "definition_invalid_group" => "The selected group does not exist or is invalid.",
     "definition_error_adding_updating" => "Attribute {0} could not be added or updated. Please check the error log.",
     "definition_flags"                 => "Attribute Visibility",
     "definition_group"                 => "Group",

--- a/app/Language/id/Attributes.php
+++ b/app/Language/id/Attributes.php
@@ -5,6 +5,7 @@ return [
     "confirm_delete"                   => "Apakah Anda yakin ingin menghapus atribut tersebut?",
     "confirm_restore"                  => "Apakah Anda yakin ingin mengembalikan atribut tersebut?",
     "definition_cannot_be_deleted"     => "Tidak bisa menghapus atribut terpilih",
+    "definition_invalid_group" => "The selected group does not exist or is invalid.",
     "definition_error_adding_updating" => "Atribut {0} tidak dapat ditambah atau diperbaharui. Silahkan periksa log kesalahan.",
     "definition_flags"                 => "Visibilitas Atribut",
     "definition_group"                 => "Grup",

--- a/app/Language/id/Attributes.php
+++ b/app/Language/id/Attributes.php
@@ -5,7 +5,7 @@ return [
     "confirm_delete"                   => "Apakah Anda yakin ingin menghapus atribut tersebut?",
     "confirm_restore"                  => "Apakah Anda yakin ingin mengembalikan atribut tersebut?",
     "definition_cannot_be_deleted"     => "Tidak bisa menghapus atribut terpilih",
-    "definition_invalid_group" => "The selected group does not exist or is invalid.",
+    "definition_invalid_group" => "Grup yang dipilih tidak ada atau tidak valid.",
     "definition_error_adding_updating" => "Atribut {0} tidak dapat ditambah atau diperbaharui. Silahkan periksa log kesalahan.",
     "definition_flags"                 => "Visibilitas Atribut",
     "definition_group"                 => "Grup",

--- a/app/Language/it/Attributes.php
+++ b/app/Language/it/Attributes.php
@@ -5,6 +5,7 @@ return [
     "confirm_delete"                   => "Sei sicuro di voler eliminare gli attributi selezionati?",
     "confirm_restore"                  => "Sei sicuro di voler ripristinare l'attributo selezionato?",
     "definition_cannot_be_deleted"     => "Non riesco a cancellare l'attributo selezionato",
+    "definition_invalid_group" => "The selected group does not exist or is invalid.",
     "definition_error_adding_updating" => "Impossibile aggiungere o aggiornare l'attributo {0}. Si prega di controllare il registro degli errori.",
     "definition_flags"                 => "Visibilità attributo",
     "definition_group"                 => "Gruppo",

--- a/app/Language/it/Attributes.php
+++ b/app/Language/it/Attributes.php
@@ -5,7 +5,7 @@ return [
     "confirm_delete"                   => "Sei sicuro di voler eliminare gli attributi selezionati?",
     "confirm_restore"                  => "Sei sicuro di voler ripristinare l'attributo selezionato?",
     "definition_cannot_be_deleted"     => "Non riesco a cancellare l'attributo selezionato",
-    "definition_invalid_group" => "The selected group does not exist or is invalid.",
+    "definition_invalid_group" => "Il gruppo selezionato non esiste o non è valido.",
     "definition_error_adding_updating" => "Impossibile aggiungere o aggiornare l'attributo {0}. Si prega di controllare il registro degli errori.",
     "definition_flags"                 => "Visibilità attributo",
     "definition_group"                 => "Gruppo",

--- a/app/Language/km/Attributes.php
+++ b/app/Language/km/Attributes.php
@@ -5,7 +5,7 @@ return [
     "confirm_delete"                   => "តើអ្នកពិតជាចង់លុប ព៌តមានបន្ថែម ដែលបានជ្រើសរើស?",
     "confirm_restore"                  => "តើអ្នកពិតជាដាក់ឡើងវិញនៅ ព៌តមានបន្ថែម ដែលបានជ្រើសរើស?",
     "definition_cannot_be_deleted"     => "មិនអាចលុបព៌តមានបន្ថែមដែលបានជ្រើសរើស",
-    "definition_invalid_group" => "The selected group does not exist or is invalid.",
+    "definition_invalid_group" => "",
     "definition_error_adding_updating" => "ព៌តមានបន្ថែម {0} មិនអាចថែម រឺកែប្រែបានឡើយ។​ សូមចូលទៅឆែករបាយការណ៍កំហុស។",
     "definition_flags"                 => "ដាក់បង្ហាញព៌តមានបន្ថែម",
     "definition_group"                 => "ក្រុម",

--- a/app/Language/km/Attributes.php
+++ b/app/Language/km/Attributes.php
@@ -5,6 +5,7 @@ return [
     "confirm_delete"                   => "តើអ្នកពិតជាចង់លុប ព៌តមានបន្ថែម ដែលបានជ្រើសរើស?",
     "confirm_restore"                  => "តើអ្នកពិតជាដាក់ឡើងវិញនៅ ព៌តមានបន្ថែម ដែលបានជ្រើសរើស?",
     "definition_cannot_be_deleted"     => "មិនអាចលុបព៌តមានបន្ថែមដែលបានជ្រើសរើស",
+    "definition_invalid_group" => "The selected group does not exist or is invalid.",
     "definition_error_adding_updating" => "ព៌តមានបន្ថែម {0} មិនអាចថែម រឺកែប្រែបានឡើយ។​ សូមចូលទៅឆែករបាយការណ៍កំហុស។",
     "definition_flags"                 => "ដាក់បង្ហាញព៌តមានបន្ថែម",
     "definition_group"                 => "ក្រុម",

--- a/app/Language/lo/Attributes.php
+++ b/app/Language/lo/Attributes.php
@@ -5,6 +5,7 @@ return [
     "confirm_delete"                   => "ແນ່ໃຈຫຼືບໍທີ່ຈະລືບລາຍການທີ່ເລືອກ",
     "confirm_restore"                  => "ແນ່ໃຈຫຼືບໍທີ່ຈະຄືນຄ່າແອັດທິບິ້ວດັ່ງກ່າວ?",
     "definition_cannot_be_deleted"     => "ບໍສາມາດລືບລາຍການທີ່ເລືອກໄດ້",
+    "definition_invalid_group" => "The selected group does not exist or is invalid.",
     "definition_error_adding_updating" => "ລາຍການ {0} ບໍສາມາດເພີ່ມ ຫຼື ແກ້ໄຂ. ກະລຸນາກວດສອບຢູ່ log ຂໍ້ຜິດຜາດ",
     "definition_flags"                 => "ຄູນສົມບັດການເບິ່ງເຫັນ",
     "definition_group"                 => "ກຸ່ມ",

--- a/app/Language/lo/Attributes.php
+++ b/app/Language/lo/Attributes.php
@@ -5,7 +5,7 @@ return [
     "confirm_delete"                   => "ແນ່ໃຈຫຼືບໍທີ່ຈະລືບລາຍການທີ່ເລືອກ",
     "confirm_restore"                  => "ແນ່ໃຈຫຼືບໍທີ່ຈະຄືນຄ່າແອັດທິບິ້ວດັ່ງກ່າວ?",
     "definition_cannot_be_deleted"     => "ບໍສາມາດລືບລາຍການທີ່ເລືອກໄດ້",
-    "definition_invalid_group" => "The selected group does not exist or is invalid.",
+    "definition_invalid_group" => "",
     "definition_error_adding_updating" => "ລາຍການ {0} ບໍສາມາດເພີ່ມ ຫຼື ແກ້ໄຂ. ກະລຸນາກວດສອບຢູ່ log ຂໍ້ຜິດຜາດ",
     "definition_flags"                 => "ຄູນສົມບັດການເບິ່ງເຫັນ",
     "definition_group"                 => "ກຸ່ມ",

--- a/app/Language/ml/Attributes.php
+++ b/app/Language/ml/Attributes.php
@@ -5,7 +5,7 @@ return [
     "confirm_delete"                   => "Are you sure you want to delete the selected attribute(s)?",
     "confirm_restore"                  => "",
     "definition_cannot_be_deleted"     => "Could not delete selected attribute(s)",
-    "definition_invalid_group" => "The selected group does not exist or is invalid.",
+    "definition_invalid_group" => "",
     "definition_error_adding_updating" => "",
     "definition_flags"                 => "Attribute Visibility",
     "definition_group"                 => "Group",

--- a/app/Language/ml/Attributes.php
+++ b/app/Language/ml/Attributes.php
@@ -5,6 +5,7 @@ return [
     "confirm_delete"                   => "Are you sure you want to delete the selected attribute(s)?",
     "confirm_restore"                  => "",
     "definition_cannot_be_deleted"     => "Could not delete selected attribute(s)",
+    "definition_invalid_group" => "The selected group does not exist or is invalid.",
     "definition_error_adding_updating" => "",
     "definition_flags"                 => "Attribute Visibility",
     "definition_group"                 => "Group",

--- a/app/Language/nb/Attributes.php
+++ b/app/Language/nb/Attributes.php
@@ -5,7 +5,7 @@ return [
     "confirm_delete"                   => "Are you sure you want to delete the selected attribute(s)?",
     "confirm_restore"                  => "Are you sure you want to restore the selected attribute(s)?",
     "definition_cannot_be_deleted"     => "Could not delete selected attribute(s)",
-    "definition_invalid_group" => "The selected group does not exist or is invalid.",
+    "definition_invalid_group" => "",
     "definition_error_adding_updating" => "Attribute {0} could not be added or updated. Please check the error log.",
     "definition_flags"                 => "Attribute Visibility",
     "definition_group"                 => "Group",

--- a/app/Language/nb/Attributes.php
+++ b/app/Language/nb/Attributes.php
@@ -5,6 +5,7 @@ return [
     "confirm_delete"                   => "Are you sure you want to delete the selected attribute(s)?",
     "confirm_restore"                  => "Are you sure you want to restore the selected attribute(s)?",
     "definition_cannot_be_deleted"     => "Could not delete selected attribute(s)",
+    "definition_invalid_group" => "The selected group does not exist or is invalid.",
     "definition_error_adding_updating" => "Attribute {0} could not be added or updated. Please check the error log.",
     "definition_flags"                 => "Attribute Visibility",
     "definition_group"                 => "Group",

--- a/app/Language/nl-BE/Attributes.php
+++ b/app/Language/nl-BE/Attributes.php
@@ -5,7 +5,7 @@ return [
     "confirm_delete"                   => "Bent u zeker dat u de geselecteerde attributen wil verwijderen?",
     "confirm_restore"                  => "Bent u zeker dat u de geselecteerde attributen wil herstellen?",
     "definition_cannot_be_deleted"     => "De geselecteerde attributen konden niet verwijderd worden",
-    "definition_invalid_group" => "The selected group does not exist or is invalid.",
+    "definition_invalid_group" => "De geselecteerde groep bestaat niet of is ongeldig.",
     "definition_error_adding_updating" => "Attribuut {0} kon niet toegevoegd of gewijzigd worden. Kijk de error logs na.",
     "definition_flags"                 => "Zichtbaarheid",
     "definition_group"                 => "Groep",

--- a/app/Language/nl-BE/Attributes.php
+++ b/app/Language/nl-BE/Attributes.php
@@ -5,6 +5,7 @@ return [
     "confirm_delete"                   => "Bent u zeker dat u de geselecteerde attributen wil verwijderen?",
     "confirm_restore"                  => "Bent u zeker dat u de geselecteerde attributen wil herstellen?",
     "definition_cannot_be_deleted"     => "De geselecteerde attributen konden niet verwijderd worden",
+    "definition_invalid_group" => "The selected group does not exist or is invalid.",
     "definition_error_adding_updating" => "Attribuut {0} kon niet toegevoegd of gewijzigd worden. Kijk de error logs na.",
     "definition_flags"                 => "Zichtbaarheid",
     "definition_group"                 => "Groep",

--- a/app/Language/nl-NL/Attributes.php
+++ b/app/Language/nl-NL/Attributes.php
@@ -5,7 +5,7 @@ return [
     "confirm_delete"                   => "Weet u zeker dat u de geselecteerde kenmerken wilt verwijderen?",
     "confirm_restore"                  => "Weet u zeker dat u de geselecteerde kenmerken wilt herstellen?",
     "definition_cannot_be_deleted"     => "Kan geselecteerde kenmerk(en) niet verwijderen",
-    "definition_invalid_group" => "The selected group does not exist or is invalid.",
+    "definition_invalid_group" => "De geselecteerde groep bestaat niet of is ongeldig.",
     "definition_error_adding_updating" => "Kenmerk {0} kan niet worden toegevoegd of bijgewerkt. Bekijk het foutenlogboek.",
     "definition_flags"                 => "Kenmerk zichtbaarheid",
     "definition_group"                 => "Groep",

--- a/app/Language/nl-NL/Attributes.php
+++ b/app/Language/nl-NL/Attributes.php
@@ -5,6 +5,7 @@ return [
     "confirm_delete"                   => "Weet u zeker dat u de geselecteerde kenmerken wilt verwijderen?",
     "confirm_restore"                  => "Weet u zeker dat u de geselecteerde kenmerken wilt herstellen?",
     "definition_cannot_be_deleted"     => "Kan geselecteerde kenmerk(en) niet verwijderen",
+    "definition_invalid_group" => "The selected group does not exist or is invalid.",
     "definition_error_adding_updating" => "Kenmerk {0} kan niet worden toegevoegd of bijgewerkt. Bekijk het foutenlogboek.",
     "definition_flags"                 => "Kenmerk zichtbaarheid",
     "definition_group"                 => "Groep",

--- a/app/Language/pl/Attributes.php
+++ b/app/Language/pl/Attributes.php
@@ -5,7 +5,7 @@ return [
     "confirm_delete"                   => "Czy jesteś pewny, że chcesz usunąć wybrane atrybuty?",
     "confirm_restore"                  => "Czy jesteś pewien, że chcesz przywrócić zaznaczone atrybuty?",
     "definition_cannot_be_deleted"     => "Nie można usunąć wybranych atrybutów",
-    "definition_invalid_group" => "The selected group does not exist or is invalid.",
+    "definition_invalid_group" => "Wybrana grupa nie istnieje lub jest nieprawidłowa.",
     "definition_error_adding_updating" => "Atrybut 51 nie może zostać dodany lub zaktualizowany. Sprawdź dziennik błędów.",
     "definition_flags"                 => "Widoczność atrybutu",
     "definition_group"                 => "Grupa",

--- a/app/Language/pl/Attributes.php
+++ b/app/Language/pl/Attributes.php
@@ -5,6 +5,7 @@ return [
     "confirm_delete"                   => "Czy jesteś pewny, że chcesz usunąć wybrane atrybuty?",
     "confirm_restore"                  => "Czy jesteś pewien, że chcesz przywrócić zaznaczone atrybuty?",
     "definition_cannot_be_deleted"     => "Nie można usunąć wybranych atrybutów",
+    "definition_invalid_group" => "The selected group does not exist or is invalid.",
     "definition_error_adding_updating" => "Atrybut 51 nie może zostać dodany lub zaktualizowany. Sprawdź dziennik błędów.",
     "definition_flags"                 => "Widoczność atrybutu",
     "definition_group"                 => "Grupa",

--- a/app/Language/pt-BR/Attributes.php
+++ b/app/Language/pt-BR/Attributes.php
@@ -5,7 +5,7 @@ return [
     "confirm_delete"                   => "Tem certeza de que deseja excluir os atributos selecionados?",
     "confirm_restore"                  => "Tem certeza de que deseja restaurar o(s) atributo(s) selecionado(s)?",
     "definition_cannot_be_deleted"     => "Não foi possível excluir atributo selecionado (s)",
-    "definition_invalid_group" => "The selected group does not exist or is invalid.",
+    "definition_invalid_group" => "O grupo selecionado não existe ou é inválido.",
     "definition_error_adding_updating" => "Atributo {0} não pode ser adicionado ou atualizado. Por favor verifique o log de erros.",
     "definition_flags"                 => "Visibilidade de atributo",
     "definition_group"                 => "Grupo",

--- a/app/Language/pt-BR/Attributes.php
+++ b/app/Language/pt-BR/Attributes.php
@@ -5,6 +5,7 @@ return [
     "confirm_delete"                   => "Tem certeza de que deseja excluir os atributos selecionados?",
     "confirm_restore"                  => "Tem certeza de que deseja restaurar o(s) atributo(s) selecionado(s)?",
     "definition_cannot_be_deleted"     => "Não foi possível excluir atributo selecionado (s)",
+    "definition_invalid_group" => "The selected group does not exist or is invalid.",
     "definition_error_adding_updating" => "Atributo {0} não pode ser adicionado ou atualizado. Por favor verifique o log de erros.",
     "definition_flags"                 => "Visibilidade de atributo",
     "definition_group"                 => "Grupo",

--- a/app/Language/ro/Attributes.php
+++ b/app/Language/ro/Attributes.php
@@ -5,6 +5,7 @@ return [
     "confirm_delete"                   => "Sigur doriti stergerea atributului/atributelor selectat(e)?",
     "confirm_restore"                  => "",
     "definition_cannot_be_deleted"     => "Nu se poate sterge atributul/atributele selectat(e)",
+    "definition_invalid_group" => "The selected group does not exist or is invalid.",
     "definition_error_adding_updating" => "",
     "definition_flags"                 => "Vizibilitate atribut",
     "definition_group"                 => "Grup",

--- a/app/Language/ro/Attributes.php
+++ b/app/Language/ro/Attributes.php
@@ -5,7 +5,7 @@ return [
     "confirm_delete"                   => "Sigur doriti stergerea atributului/atributelor selectat(e)?",
     "confirm_restore"                  => "",
     "definition_cannot_be_deleted"     => "Nu se poate sterge atributul/atributele selectat(e)",
-    "definition_invalid_group" => "The selected group does not exist or is invalid.",
+    "definition_invalid_group" => "Grupul selectat nu există sau este invalid.",
     "definition_error_adding_updating" => "",
     "definition_flags"                 => "Vizibilitate atribut",
     "definition_group"                 => "Grup",

--- a/app/Language/ru/Attributes.php
+++ b/app/Language/ru/Attributes.php
@@ -5,7 +5,7 @@ return [
     "confirm_delete"                   => "Вы уверены, что хотите удалить выбранные атрибут(ы)?",
     "confirm_restore"                  => "Вы уверены, что хотите восстановить выбранные атрибут(ы)?",
     "definition_cannot_be_deleted"     => "Не удалось удалить выбранные атрибут(ы)",
-    "definition_invalid_group" => "The selected group does not exist or is invalid.",
+    "definition_invalid_group" => "Выбранная группа не существует или недействительна.",
     "definition_error_adding_updating" => "Атрибут {0} не может быть добавлен или обновлен. Пожалуйста, проверьте журнал ошибок.",
     "definition_flags"                 => "Видимость атрибута",
     "definition_group"                 => "Группа",

--- a/app/Language/ru/Attributes.php
+++ b/app/Language/ru/Attributes.php
@@ -5,6 +5,7 @@ return [
     "confirm_delete"                   => "Вы уверены, что хотите удалить выбранные атрибут(ы)?",
     "confirm_restore"                  => "Вы уверены, что хотите восстановить выбранные атрибут(ы)?",
     "definition_cannot_be_deleted"     => "Не удалось удалить выбранные атрибут(ы)",
+    "definition_invalid_group" => "The selected group does not exist or is invalid.",
     "definition_error_adding_updating" => "Атрибут {0} не может быть добавлен или обновлен. Пожалуйста, проверьте журнал ошибок.",
     "definition_flags"                 => "Видимость атрибута",
     "definition_group"                 => "Группа",

--- a/app/Language/sv/Attributes.php
+++ b/app/Language/sv/Attributes.php
@@ -5,6 +5,7 @@ return [
     "confirm_delete"                   => "Är du säker på att du vill ta bort de valda attributen?",
     "confirm_restore"                  => "Är du säker på att du vill återställa de valda attributen?",
     "definition_cannot_be_deleted"     => "Det gick inte att ta bort valda attribut",
+    "definition_invalid_group" => "The selected group does not exist or is invalid.",
     "definition_error_adding_updating" => "Attribut{0} kunde inte läggas till eller uppdateras. Kontrollera felloggen.",
     "definition_flags"                 => "Attribut synlighet",
     "definition_group"                 => "Grupp",

--- a/app/Language/sv/Attributes.php
+++ b/app/Language/sv/Attributes.php
@@ -5,7 +5,7 @@ return [
     "confirm_delete"                   => "Är du säker på att du vill ta bort de valda attributen?",
     "confirm_restore"                  => "Är du säker på att du vill återställa de valda attributen?",
     "definition_cannot_be_deleted"     => "Det gick inte att ta bort valda attribut",
-    "definition_invalid_group" => "The selected group does not exist or is invalid.",
+    "definition_invalid_group" => "Den valda gruppen finns inte eller är ogiltig.",
     "definition_error_adding_updating" => "Attribut{0} kunde inte läggas till eller uppdateras. Kontrollera felloggen.",
     "definition_flags"                 => "Attribut synlighet",
     "definition_group"                 => "Grupp",

--- a/app/Language/sw-KE/Attributes.php
+++ b/app/Language/sw-KE/Attributes.php
@@ -5,7 +5,7 @@ return [
     "confirm_delete"                   => "Una uhakika unataka kufuta sifa iliyochaguliwa/zilizochaguliwa?",
     "confirm_restore"                  => "Una uhakika unataka kurejesha sifa iliyochaguliwa/zilizochaguliwa?",
     "definition_cannot_be_deleted"     => "Haiwezekani kufuta sifa iliyochaguliwa/zilizochaguliwa",
-    "definition_invalid_group" => "The selected group does not exist or is invalid.",
+    "definition_invalid_group" => "Kikundi ulichochagua hakipo au hakitoshi.",
     "definition_error_adding_updating" => "Sifa {0} haiwezekani kuongezwa au kusasishwa. Tafadhali angalia logi ya makosa.",
     "definition_flags"                 => "Uonekano wa Sifa",
     "definition_group"                 => "Kundi",

--- a/app/Language/sw-KE/Attributes.php
+++ b/app/Language/sw-KE/Attributes.php
@@ -5,6 +5,7 @@ return [
     "confirm_delete"                   => "Una uhakika unataka kufuta sifa iliyochaguliwa/zilizochaguliwa?",
     "confirm_restore"                  => "Una uhakika unataka kurejesha sifa iliyochaguliwa/zilizochaguliwa?",
     "definition_cannot_be_deleted"     => "Haiwezekani kufuta sifa iliyochaguliwa/zilizochaguliwa",
+    "definition_invalid_group" => "The selected group does not exist or is invalid.",
     "definition_error_adding_updating" => "Sifa {0} haiwezekani kuongezwa au kusasishwa. Tafadhali angalia logi ya makosa.",
     "definition_flags"                 => "Uonekano wa Sifa",
     "definition_group"                 => "Kundi",

--- a/app/Language/sw-TZ/Attributes.php
+++ b/app/Language/sw-TZ/Attributes.php
@@ -5,7 +5,7 @@ return [
     "confirm_delete"                   => "Una uhakika unataka kufuta sifa iliyochaguliwa/zilizochaguliwa?",
     "confirm_restore"                  => "Una uhakika unataka kurejesha sifa iliyochaguliwa/zilizochaguliwa?",
     "definition_cannot_be_deleted"     => "Haiwezekani kufuta sifa iliyochaguliwa/zilizochaguliwa",
-    "definition_invalid_group" => "The selected group does not exist or is invalid.",
+    "definition_invalid_group" => "Kikundi ulichochagua hakipo au hakitoshi.",
     "definition_error_adding_updating" => "Sifa {0} haiwezekani kuongezwa au kusasishwa. Tafadhali angalia logi ya makosa.",
     "definition_flags"                 => "Uonekano wa Sifa",
     "definition_group"                 => "Kundi",

--- a/app/Language/sw-TZ/Attributes.php
+++ b/app/Language/sw-TZ/Attributes.php
@@ -5,6 +5,7 @@ return [
     "confirm_delete"                   => "Una uhakika unataka kufuta sifa iliyochaguliwa/zilizochaguliwa?",
     "confirm_restore"                  => "Una uhakika unataka kurejesha sifa iliyochaguliwa/zilizochaguliwa?",
     "definition_cannot_be_deleted"     => "Haiwezekani kufuta sifa iliyochaguliwa/zilizochaguliwa",
+    "definition_invalid_group" => "The selected group does not exist or is invalid.",
     "definition_error_adding_updating" => "Sifa {0} haiwezekani kuongezwa au kusasishwa. Tafadhali angalia logi ya makosa.",
     "definition_flags"                 => "Uonekano wa Sifa",
     "definition_group"                 => "Kundi",

--- a/app/Language/ta/Attributes.php
+++ b/app/Language/ta/Attributes.php
@@ -5,6 +5,7 @@ return [
     "confirm_delete"                   => "தேர்ந்தெடுக்கப்பட்ட பண்புக்கூறு (களை) நீக்க விரும்புகிறீர்களா?",
     "confirm_restore"                  => "தேர்ந்தெடுக்கப்பட்ட பண்புக்கூறுகளை (களை) மீட்டெடுக்க விரும்புகிறீர்களா?",
     "definition_cannot_be_deleted"     => "Could not delete selected attribute(s)",
+    "definition_invalid_group" => "The selected group does not exist or is invalid.",
     "definition_error_adding_updating" => "Attribute {0} could not be added or updated. Please check the error log.",
     "definition_flags"                 => "Attribute Visibility",
     "definition_group"                 => "Group",

--- a/app/Language/ta/Attributes.php
+++ b/app/Language/ta/Attributes.php
@@ -5,7 +5,7 @@ return [
     "confirm_delete"                   => "தேர்ந்தெடுக்கப்பட்ட பண்புக்கூறு (களை) நீக்க விரும்புகிறீர்களா?",
     "confirm_restore"                  => "தேர்ந்தெடுக்கப்பட்ட பண்புக்கூறுகளை (களை) மீட்டெடுக்க விரும்புகிறீர்களா?",
     "definition_cannot_be_deleted"     => "Could not delete selected attribute(s)",
-    "definition_invalid_group" => "The selected group does not exist or is invalid.",
+    "definition_invalid_group" => "",
     "definition_error_adding_updating" => "Attribute {0} could not be added or updated. Please check the error log.",
     "definition_flags"                 => "Attribute Visibility",
     "definition_group"                 => "Group",

--- a/app/Language/th/Attributes.php
+++ b/app/Language/th/Attributes.php
@@ -5,7 +5,7 @@ return [
     "confirm_delete"                   => "ต้องการลบคุณลักษณะที่เลือกหรือไม่ ?",
     "confirm_restore"                  => "ต้องการคืนค่าคุณลักษณะที่เลือกหรือไม่ ?",
     "definition_cannot_be_deleted"     => "ไม่สามารถลบคุณลักษณะที่เลือก",
-    "definition_invalid_group" => "The selected group does not exist or is invalid.",
+    "definition_invalid_group" => "กลุ่มที่เลือกไม่มีอยู่หรือไม่ถูกต้อง",
     "definition_error_adding_updating" => "ไม่สามารถเพิ่มหรือแก้ไขคุณลักษณะ {0}, โปรดตรวจสอบความผิดพลาดในบันทึก",
     "definition_flags"                 => "การมองเห็นคุณลักษณะ",
     "definition_group"                 => "กลุ่ม",

--- a/app/Language/th/Attributes.php
+++ b/app/Language/th/Attributes.php
@@ -5,6 +5,7 @@ return [
     "confirm_delete"                   => "ต้องการลบคุณลักษณะที่เลือกหรือไม่ ?",
     "confirm_restore"                  => "ต้องการคืนค่าคุณลักษณะที่เลือกหรือไม่ ?",
     "definition_cannot_be_deleted"     => "ไม่สามารถลบคุณลักษณะที่เลือก",
+    "definition_invalid_group" => "The selected group does not exist or is invalid.",
     "definition_error_adding_updating" => "ไม่สามารถเพิ่มหรือแก้ไขคุณลักษณะ {0}, โปรดตรวจสอบความผิดพลาดในบันทึก",
     "definition_flags"                 => "การมองเห็นคุณลักษณะ",
     "definition_group"                 => "กลุ่ม",

--- a/app/Language/tl/Attributes.php
+++ b/app/Language/tl/Attributes.php
@@ -5,6 +5,7 @@ return [
     "confirm_delete"                   => "Are you sure you want to restore the selected attribute(s)?",
     "confirm_restore"                  => "Are you sure you want to delete the selected attribute(s)?",
     "definition_cannot_be_deleted"     => "Could not delete selected attribute(s)",
+    "definition_invalid_group" => "The selected group does not exist or is invalid.",
     "definition_error_adding_updating" => "Attribute {0} could not be added or updated. Please check the error log.",
     "definition_flags"                 => "Attribute Visibility",
     "definition_group"                 => "Group",

--- a/app/Language/tl/Attributes.php
+++ b/app/Language/tl/Attributes.php
@@ -5,7 +5,7 @@ return [
     "confirm_delete"                   => "Are you sure you want to restore the selected attribute(s)?",
     "confirm_restore"                  => "Are you sure you want to delete the selected attribute(s)?",
     "definition_cannot_be_deleted"     => "Could not delete selected attribute(s)",
-    "definition_invalid_group" => "The selected group does not exist or is invalid.",
+    "definition_invalid_group" => "",
     "definition_error_adding_updating" => "Attribute {0} could not be added or updated. Please check the error log.",
     "definition_flags"                 => "Attribute Visibility",
     "definition_group"                 => "Group",

--- a/app/Language/tr/Attributes.php
+++ b/app/Language/tr/Attributes.php
@@ -5,6 +5,7 @@ return [
     "confirm_delete"                   => "Seçili niteliği ya da nitelikleri silmek istediğinize emin misiniz?",
     "confirm_restore"                  => "Seçili nitelik ya da nitelikleri kurtarmak istediğinize emin misiniz?",
     "definition_cannot_be_deleted"     => "Seçili nitelik ya da nitelikler silinemedi",
+    "definition_invalid_group" => "The selected group does not exist or is invalid.",
     "definition_error_adding_updating" => "Nitelik {0} eklenemedi ya da güncellenemedi. Lütfen hata kaydını gözden geçirin.",
     "definition_flags"                 => "Nitelik Görünebilirliği",
     "definition_group"                 => "Küme",

--- a/app/Language/tr/Attributes.php
+++ b/app/Language/tr/Attributes.php
@@ -5,7 +5,7 @@ return [
     "confirm_delete"                   => "Seçili niteliği ya da nitelikleri silmek istediğinize emin misiniz?",
     "confirm_restore"                  => "Seçili nitelik ya da nitelikleri kurtarmak istediğinize emin misiniz?",
     "definition_cannot_be_deleted"     => "Seçili nitelik ya da nitelikler silinemedi",
-    "definition_invalid_group" => "The selected group does not exist or is invalid.",
+    "definition_invalid_group" => "Seçilen grup mevcut değil veya geçersiz.",
     "definition_error_adding_updating" => "Nitelik {0} eklenemedi ya da güncellenemedi. Lütfen hata kaydını gözden geçirin.",
     "definition_flags"                 => "Nitelik Görünebilirliği",
     "definition_group"                 => "Küme",

--- a/app/Language/uk/Attributes.php
+++ b/app/Language/uk/Attributes.php
@@ -5,7 +5,7 @@ return [
     "confirm_delete"                   => "Ви впевнені, що хочете видалити вибрані атрибут(и)?",
     "confirm_restore"                  => "Ви впевнені, що хочете відновити вибрані атрибут(и)?",
     "definition_cannot_be_deleted"     => "Не вдалося видалити вибрані атрибут(и)",
-    "definition_invalid_group" => "The selected group does not exist or is invalid.",
+    "definition_invalid_group" => "Вибрана група не існує або недійсна.",
     "definition_error_adding_updating" => "Атрибут {0} не може бути доданий або оновлений. Будь ласка, перевірте журнал помилок.",
     "definition_flags"                 => "Видимість атрибуту",
     "definition_group"                 => "Група",

--- a/app/Language/uk/Attributes.php
+++ b/app/Language/uk/Attributes.php
@@ -5,6 +5,7 @@ return [
     "confirm_delete"                   => "Ви впевнені, що хочете видалити вибрані атрибут(и)?",
     "confirm_restore"                  => "Ви впевнені, що хочете відновити вибрані атрибут(и)?",
     "definition_cannot_be_deleted"     => "Не вдалося видалити вибрані атрибут(и)",
+    "definition_invalid_group" => "The selected group does not exist or is invalid.",
     "definition_error_adding_updating" => "Атрибут {0} не може бути доданий або оновлений. Будь ласка, перевірте журнал помилок.",
     "definition_flags"                 => "Видимість атрибуту",
     "definition_group"                 => "Група",

--- a/app/Language/ur/Attributes.php
+++ b/app/Language/ur/Attributes.php
@@ -5,7 +5,7 @@ return [
     "confirm_delete"                   => "کیا آپ منتخب شدہ کو حذف کرنا چاہتے ہیں ؟",
     "confirm_restore"                  => "کیا آپ منتخب شدہ کو بحال کرنا چاہتے ہیں ؟",
     "definition_cannot_be_deleted"     => "منتخب شدہ کو حذف نہیں کیا جا سکتا",
-    "definition_invalid_group" => "The selected group does not exist or is invalid.",
+    "definition_invalid_group" => "",
     "definition_error_adding_updating" => "Attribute {0} could not be added or updated. Please check the error log.",
     "definition_flags"                 => "Attribute Visibility",
     "definition_group"                 => "Group",

--- a/app/Language/ur/Attributes.php
+++ b/app/Language/ur/Attributes.php
@@ -5,6 +5,7 @@ return [
     "confirm_delete"                   => "کیا آپ منتخب شدہ کو حذف کرنا چاہتے ہیں ؟",
     "confirm_restore"                  => "کیا آپ منتخب شدہ کو بحال کرنا چاہتے ہیں ؟",
     "definition_cannot_be_deleted"     => "منتخب شدہ کو حذف نہیں کیا جا سکتا",
+    "definition_invalid_group" => "The selected group does not exist or is invalid.",
     "definition_error_adding_updating" => "Attribute {0} could not be added or updated. Please check the error log.",
     "definition_flags"                 => "Attribute Visibility",
     "definition_group"                 => "Group",

--- a/app/Language/vi/Attributes.php
+++ b/app/Language/vi/Attributes.php
@@ -5,6 +5,7 @@ return [
     "confirm_delete"                   => "Bạn có chắc chắn muốn xóa (các) thuộc tính đã chọn không?",
     "confirm_restore"                  => "Bạn có chắc chắn muốn khôi phục (các) thuộc tính đã chọn không?",
     "definition_cannot_be_deleted"     => "Không thể xóa (các) thuộc tính được chọn",
+    "definition_invalid_group" => "The selected group does not exist or is invalid.",
     "definition_error_adding_updating" => "Thuộc tính {0} không thể thêm hoặc cập nhật. Vui lòng kiểm tra nhật ký lỗi.",
     "definition_flags"                 => "Hiển thị thuộc tính",
     "definition_group"                 => "Nhóm",

--- a/app/Language/vi/Attributes.php
+++ b/app/Language/vi/Attributes.php
@@ -5,7 +5,7 @@ return [
     "confirm_delete"                   => "Bạn có chắc chắn muốn xóa (các) thuộc tính đã chọn không?",
     "confirm_restore"                  => "Bạn có chắc chắn muốn khôi phục (các) thuộc tính đã chọn không?",
     "definition_cannot_be_deleted"     => "Không thể xóa (các) thuộc tính được chọn",
-    "definition_invalid_group" => "The selected group does not exist or is invalid.",
+    "definition_invalid_group" => "Nhóm đã chọn không tồn tại hoặc không hợp lệ.",
     "definition_error_adding_updating" => "Thuộc tính {0} không thể thêm hoặc cập nhật. Vui lòng kiểm tra nhật ký lỗi.",
     "definition_flags"                 => "Hiển thị thuộc tính",
     "definition_group"                 => "Nhóm",

--- a/app/Language/zh-Hans/Attributes.php
+++ b/app/Language/zh-Hans/Attributes.php
@@ -5,6 +5,7 @@ return [
     "confirm_delete"                   => "确定要删除所选属性吗",
     "confirm_restore"                  => "您确定要还原所选属性吗？",
     "definition_cannot_be_deleted"     => "不能删除该特征属性",
+    "definition_invalid_group" => "The selected group does not exist or is invalid.",
     "definition_error_adding_updating" => "无法添加或更新属性{0}。 请检查错误日志。",
     "definition_flags"                 => "属性可见性",
     "definition_group"                 => "组",

--- a/app/Language/zh-Hans/Attributes.php
+++ b/app/Language/zh-Hans/Attributes.php
@@ -5,7 +5,7 @@ return [
     "confirm_delete"                   => "确定要删除所选属性吗",
     "confirm_restore"                  => "您确定要还原所选属性吗？",
     "definition_cannot_be_deleted"     => "不能删除该特征属性",
-    "definition_invalid_group" => "The selected group does not exist or is invalid.",
+    "definition_invalid_group" => "所选组不存在或无效。",
     "definition_error_adding_updating" => "无法添加或更新属性{0}。 请检查错误日志。",
     "definition_flags"                 => "属性可见性",
     "definition_group"                 => "组",

--- a/app/Language/zh-Hant/Attributes.php
+++ b/app/Language/zh-Hant/Attributes.php
@@ -5,7 +5,7 @@ return [
     "confirm_delete"                   => "您確定要刪除此屬性?",
     "confirm_restore"                  => "您確定要還原所選屬性嗎？",
     "definition_cannot_be_deleted"     => "無法刪除所選屬性",
-    "definition_invalid_group" => "The selected group does not exist or is invalid.",
+    "definition_invalid_group" => "所選擇的群組不存在或無效。",
     "definition_error_adding_updating" => "無法添加或更新屬性 {0}。 請檢查錯誤日誌。",
     "definition_flags"                 => "屬性可見性",
     "definition_group"                 => "群組",

--- a/app/Language/zh-Hant/Attributes.php
+++ b/app/Language/zh-Hant/Attributes.php
@@ -5,6 +5,7 @@ return [
     "confirm_delete"                   => "您確定要刪除此屬性?",
     "confirm_restore"                  => "您確定要還原所選屬性嗎？",
     "definition_cannot_be_deleted"     => "無法刪除所選屬性",
+    "definition_invalid_group" => "The selected group does not exist or is invalid.",
     "definition_error_adding_updating" => "無法添加或更新屬性 {0}。 請檢查錯誤日誌。",
     "definition_flags"                 => "屬性可見性",
     "definition_group"                 => "群組",

--- a/app/Views/attributes/form.php
+++ b/app/Views/attributes/form.php
@@ -23,7 +23,7 @@
                     'name'  => 'definition_name',
                     'id'    => 'definition_name',
                     'class' => 'form-control input-sm',
-                    'value' => $definition_info->definition_name
+                    'value' => esc($definition_info->definition_name)
                 ]) ?>
             </div>
         </div>

--- a/app/Views/attributes/form.php
+++ b/app/Views/attributes/form.php
@@ -69,7 +69,7 @@
                 <div class="input-group">
                     <?= form_input([
                         'name'  => 'definition_unit',
-                        'value' => $definition_info->definition_unit,
+                        'value' => esc($definition_info->definition_unit),
                         'class' => 'form-control input-sm',
                         'id'    => 'definition_unit'
                     ]) ?>

--- a/app/Views/attributes/item.php
+++ b/app/Views/attributes/item.php
@@ -23,7 +23,7 @@
 <?php foreach ($definition_values as $definition_id => $definition_value) { ?>
 
     <div class="form-group form-group-sm">
-        <?= form_label($definition_value['definition_name'], $definition_value['definition_name'], ['class' => 'control-label col-xs-3']) ?>
+        <?= form_label(esc($definition_value['definition_name']), esc($definition_value['definition_name']), ['class' => 'control-label col-xs-3']) ?>
         <div class="col-xs-8">
             <div class="input-group">
                 <?php

--- a/app/Views/attributes/item.php
+++ b/app/Views/attributes/item.php
@@ -55,7 +55,7 @@
                         $value = (empty($attribute_value) || empty($attribute_value->attribute_value)) ? $definition_value['selected_value'] : $attribute_value->attribute_value;
                         echo form_input([
                             'name'               => "attribute_links[$definition_id]",
-                            'value'              => $value,
+                            'value'              => esc($value),
                             'class'              => 'form-control valid_chars',
                             'data-definition-id' => $definition_id
                         ]);


### PR DESCRIPTION
## Summary
Fixes stored XSS vulnerability in Attribute Definitions (GHSA-rvfg-ww4r-rwqf).

## Security Impact
- Authenticated users with attribute management permission can inject XSS payloads in definition names
- Payloads execute when viewing/editing attributes in admin panel
- Can steal session cookies, perform CSRF attacks, or compromise admin operations

## Root Cause
1. Input: `Attributes.php` postSaveDefinition() accepts `definition_name` without sanitization
2. Output: Views echo `definition_name` without proper escaping

## Fix Applied
- **Input sanitization**: Added `FILTER_SANITIZE_FULL_SPECIAL_CHARS` to `definition_name` and `definition_unit` in POST handlers
- **Output escaping**: Added `esc()` wrapper when displaying `definition_name` in views
- **Defense-in-depth**: `htmlspecialchars()` on attribute values saved to database

## Files Changed
- `app/Controllers/Attributes.php` - Sanitize inputs on save
- `app/Views/attributes/form.php` - Escape output on display
- `app/Views/attributes/item.php` - Escape output on display

## Testing
- XSS payloads like `<script>alert(1)</script>` are now sanitized on input
- Any existing malicious definitions are escaped on output
- Does not break legitimate attribute names with special characters

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Attribute saving now validates referenced groups and returns a localized error when an invalid group is submitted.
  * Attribute forms and lists escape displayed values to prevent unsafe rendering.

* **Localization**
  * Added a new localized message key ("definition_invalid_group") across many languages to surface the invalid-group error.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->