### PR TITLE
Fix PHPUnit environment variables not being set

### DIFF
--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -51,15 +51,15 @@
         <!-- Directory containing the front controller (index.php) -->
         <const name="PUBLICPATH" value="./public/"/>
         <!-- Database configuration for testing -->
-        <env name="database.tests.hostname" value="127.0.0.1"/>
-        <env name="database.tests.database" value="ospos"/>
-        <env name="database.tests.username" value="admin"/>
-        <env name="database.tests.password" value="pointofsale"/>
-        <env name="database.tests.DBDriver" value="MySQLi"/>
-        <env name="database.tests.DBPrefix" value="ospos_"/>
-        <env name="MYSQL_HOST_NAME" value="127.0.0.1"/>
-        <env name="MYSQL_USERNAME" value="admin"/>
-        <env name="MYSQL_PASSWORD" value="pointofsale"/>
-        <env name="MYSQL_DB_NAME" value="ospos"/>
+        <env name="database.tests.hostname" value="127.0.0.1" force="true"/>
+        <env name="database.tests.database" value="ospos" force="true"/>
+        <env name="database.tests.username" value="admin" force="true"/>
+        <env name="database.tests.password" value="pointofsale" force="true"/>
+        <env name="database.tests.DBDriver" value="MySQLi" force="true"/>
+        <env name="database.tests.DBPrefix" value="ospos_" force="true"/>
+        <env name="MYSQL_HOST_NAME" value="127.0.0.1" force="true"/>
+        <env name="MYSQL_USERNAME" value="admin" force="true"/>
+        <env name="MYSQL_PASSWORD" value="pointofsale" force="true"/>
+        <env name="MYSQL_DB_NAME" value="ospos" force="true"/>
     </php>
 </phpunit>


### PR DESCRIPTION
PHPUnit 10+/11+ requires force="true" attribute on <env> elements to properly set environment variables. Without this attribute, the database connection env vars were not being set during test bootstrap, causing tests to fail silently with empty junit.xml output.

This fix adds force="true" to all <env> elements in phpunit.xml.dist.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated test configuration settings to enforce environment variable precedence.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->