### PR TITLE
Fix stored XSS via stock location name (GHSA-vmm7-g33q-qqr2)

### DIFF
--- a/app/Views/receivings/receiving.php
+++ b/app/Views/receivings/receiving.php
@@ -137,7 +137,7 @@ if (isset($success)) {
                         <td><?= esc($item['item_number']) ?></td>
                         <td style="text-align: center;">
                             <?= esc($item['name'] . ' ' . implode(' ', [$item['attribute_values'], $item['attribute_dtvalues']])) ?><br>
-                            <?= '[' . to_quantity_decimals($item['in_stock']) . ' in ' . $item['stock_name'] . ']' ?>
+                            <?= '[' . to_quantity_decimals($item['in_stock']) . ' in ' . esc($item['stock_name']) . ']' ?>
                             <?= form_hidden('location', (string)$item['item_location']) ?>
                         </td>
 

--- a/app/Views/sales/register.php
+++ b/app/Views/sales/register.php
@@ -181,7 +181,7 @@ helper('url');
                                 <td style="align: center;">
                                     <?= esc($item['name']) . ' ' . implode(' ', [$item['attribute_values'], $item['attribute_dtvalues']]) ?>
                                     <br>
-                                    <?php if ($item['stock_type'] == '0'): echo '[' . to_quantity_decimals($item['in_stock']) . ' in ' . $item['stock_name'] . ']';
+                                    <?php if ($item['stock_type'] == '0'): echo '[' . to_quantity_decimals($item['in_stock']) . ' in ' . esc($item['stock_name']) . ']';
                                     endif; ?>
                                 </td>
                             <?php } ?>


### PR DESCRIPTION
## Summary
- Fix stored XSS vulnerability by escaping `stock_name` output in sales/register.php and receivings/receiving.php
- Addresses GHSA-vmm7-g33q-qqr2

## Impact
A **Medium** severity Stored Cross-Site Scripting (XSS) vulnerability exists in the stock location name display. Stock location names are stored without sanitization and rendered without output escaping in both the sales register and receivings register.

An administrator who sets a malicious stock location name can inject JavaScript that executes in the browser of every cashier using the POS system.

## Fix
Added `esc()` function to sanitize the `stock_name` output in:
- `app/Views/sales/register.php` (line 184)
- `app/Views/receivings/receiving.php` (line 140)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced data sanitization for product names displayed in Receiving and Sales interfaces to ensure proper and safe content rendering across the application.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->