### PR TITLE
fix: Remove unused router service call in tax_helper

### DIFF
--- a/app/Helpers/tax_helper.php
+++ b/app/Helpers/tax_helper.php
@@ -143,8 +143,7 @@ function get_tax_rates_manage_table_headers(): string
  */
 function get_tax_rates_data_row($tax_rates_row): array
 {
-    $router = service('router');
-    $controller_name = strtolower($router->controllerName());
+    $controller_name = 'taxes';
 
     return [
         'tax_rate_id'        => $tax_rates_row->tax_rate_id,


### PR DESCRIPTION
## Summary

Fixes #4477 - Tax Rate form modal not opening

## Root Cause

**Kudos to @odiea for identifying the issue!** 🎉

The `get_tax_rates_data_row()` function was unnecessarily calling `service('router')` to get the controller name dynamically. This was inconsistent with all other similar functions in the same helper file.

Looking at the other functions:
- `get_tax_code_data_row()` - uses `$controller_name = 'tax_codes'` directly
- `get_tax_categories_data_row()` - uses `$controller_name = 'tax_categories'` directly  
- `get_tax_jurisdictions_data_row()` - uses `$controller_name = 'tax_jurisdictions'` directly

But `get_tax_rates_data_row()` was trying to be "clever" by using the router service, which failed in certain contexts (like AJAX requests from Bootstrap Table).

## Fix

Removed the router service call and simply hardcoded `$controller_name = 'taxes'` to match the pattern used by all other similar functions in this helper.

```php
function get_tax_rates_data_row($tax_rates_row): array
{
    $controller_name = 'taxes';  // Fixed: match pattern of other helper functions

    return [
        // ...
        'edit' => anchor(
            "$controller_name/view/$tax_rates_row->tax_rate_id",
            // ...
        )
    ];
}
```

## Testing

- Modal now opens correctly when clicking edit on a tax rate
- Edit link URL is properly constructed as `taxes/view/{id}`

## Changes

| File | Change |
|------|--------|
| `app/Helpers/tax_helper.php` | Removed `service('router')` call, hardcoded `'taxes'` as controller name |

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed URL generation for tax-related pages to consistently use the correct routing context.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->