### PR TITLE
[Fix]: Add missing return statements to Sales Controller functions

### DIFF
--- a/app/Controllers/Sales.php
+++ b/app/Controllers/Sales.php
@@ -796,7 +796,7 @@ class Sales extends Secure_Controller
 
             if ($sale_id == NEW_ENTRY && $this->sale->check_invoice_number_exists($invoice_number)) {
                 $data['error'] = lang('Sales.invoice_number_duplicate', [$invoice_number]);
-                $this->_reload($data);
+                return $this->_reload($data);
             } else {
                 $data['invoice_number'] = $invoice_number;
                 $data['sale_status'] = COMPLETED;
@@ -840,7 +840,7 @@ class Sales extends Secure_Controller
 
             if ($sale_id == NEW_ENTRY && $this->sale->check_work_order_number_exists($work_order_number)) {
                 $data['error'] = lang('Sales.work_order_number_duplicate');
-                $this->_reload($data);
+                return $this->_reload($data);
             } else {
                 $data['work_order_number'] = $work_order_number;
                 $data['sale_status'] = SUSPENDED;
@@ -868,7 +868,7 @@ class Sales extends Secure_Controller
 
             if ($sale_id == NEW_ENTRY && $this->sale->check_quote_number_exists($quote_number)) {
                 $data['error'] = lang('Sales.quote_number_duplicate');
-                $this->_reload($data);
+                return $this->_reload($data);
             } else {
                 $data['quote_number'] = $quote_number;
                 $data['sale_status'] = SUSPENDED;
@@ -1697,6 +1697,7 @@ class Sales extends Secure_Controller
             $cart[$x]['item_number'] = $item_number;
         }
         $this->sale_lib->set_cart($cart);
+        return $this->response->setJSON(['success' => true]);
     }
 
     /**
@@ -1720,6 +1721,7 @@ class Sales extends Secure_Controller
         }
 
         $this->sale_lib->set_cart($cart);
+        return $this->response->setJSON(['success' => true]);
     }
 
     /**
@@ -1743,6 +1745,7 @@ class Sales extends Secure_Controller
         }
 
         $this->sale_lib->set_cart($cart);
+        return $this->response->setJSON(['success' => true]);
     }
 
     /**

--- a/app/Controllers/Sales.php
+++ b/app/Controllers/Sales.php
@@ -817,6 +817,7 @@ class Sales extends Secure_Controller
 
                 if ($data['sale_id_num'] == NEW_ENTRY) {
                     $data['error_message'] = lang('Sales.transaction_failed');
+                    return $this->_reload($data);
                 } else {
                     $data['barcode'] = $this->barcode_lib->generate_receipt_barcode($data['sale_id']);
                     $this->sale_lib->clear_all();
@@ -900,6 +901,7 @@ class Sales extends Secure_Controller
 
             if ($data['sale_id_num'] == NEW_ENTRY) {
                 $data['error_message'] = lang('Sales.transaction_failed');
+                return $this->_reload($data);
             } else {
                 $data['barcode'] = $this->barcode_lib->generate_receipt_barcode($data['sale_id']);
                 $this->sale_lib->clear_all();
@@ -1693,7 +1695,7 @@ class Sales extends Secure_Controller
         $this->item->update_item_number($item_id, $item_number);
         $cart = $this->sale_lib->get_cart();
         $x = $this->search_cart_for_item_id($item_id, $cart);
-        if ($x != null) {
+        if ($x !== null) {
             $cart[$x]['item_number'] = $item_number;
         }
         $this->sale_lib->set_cart($cart);
@@ -1716,7 +1718,7 @@ class Sales extends Secure_Controller
         $cart = $this->sale_lib->get_cart();
         $x = $this->search_cart_for_item_id($item_id, $cart);
 
-        if ($x != null) {
+        if ($x !== null) {
             $cart[$x]['name'] = $name;
         }
 
@@ -1740,7 +1742,7 @@ class Sales extends Secure_Controller
         $cart = $this->sale_lib->get_cart();
         $x = $this->search_cart_for_item_id($item_id, $cart);
 
-        if ($x != null) {
+        if ($x !== null) {
             $cart[$x]['description'] = $description;
         }
 


### PR DESCRIPTION
- Fix postComplete(): Add return keyword for error redirect paths (lines 799, 843, 871) when duplicate invoice/work_order/quote numbers
- Fix postChangeItemNumber(): Add return statement returning JSON response
- Fix postChangeItemName(): Add return statement returning JSON response
- Fix postChangeItemDescription(): Add return statement returning JSON response

All 4 functions declared return types but were missing return statements, causing potential runtime errors in certain code paths.

Resolves #4492

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed validation flow for duplicate invoice, work-order, and quote numbers so the process halts correctly and users receive the appropriate error notice.
  * Item-update endpoints now return explicit success responses after changing an item's number, name, or description for consistent, predictable feedback.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->