### PR TITLE
fix: Add null/empty validation for $item_id in Receivings::postEditItem()

### DIFF
--- a/app/Controllers/Receivings.php
+++ b/app/Controllers/Receivings.php
@@ -198,6 +198,12 @@ class Receivings extends Secure_Controller
     {
         $data = [];
 
+        // Validate item_id to prevent null/empty values from reaching edit_item()
+        if ($item_id === null || $item_id === '') {
+            $data['error'] = lang('Receivings.error_editing_item');
+            return $this->_reload($data);
+        }
+
         $validation_rule = [
             'price'    => 'trim|required|decimal_locale',
             'quantity' => 'trim|required|decimal_locale',


### PR DESCRIPTION
## Summary

- Adds guard clause to `postEditItem()` method to reject null or empty `$item_id` values
- Returns meaningful error message via `_reload()` before any database operations
- Prevents silent failures in `Receiving_lib::edit_item()`

## Changes

- Added validation check at the start of `postEditItem()` in `app/Controllers/Receivings.php`
- Uses existing error message pattern `lang('Receivings.error_editing_item')`

## Related

Closes #4486