### PR TITLE
fix: Capture CSV import failures in save_tax_data and save_inventory_quantities

### DIFF
--- a/app/Controllers/Items.php
+++ b/app/Controllers/Items.php
@@ -1055,14 +1055,20 @@ class Items extends Secure_Controller
                         });
 
                         if (!$isFailedRow && $this->item->save_value($itemData, $itemId)) {
-                            $this->save_tax_data($row, $itemData);
-                            $this->save_inventory_quantities($row, $itemData, $allowedStockLocations, $employeeId);
+                            if (!$this->save_tax_data($row, $itemData)) {
+                                $isFailedRow = true;
+                            }
+                            if (!$this->save_inventory_quantities($row, $itemData, $allowedStockLocations, $employeeId)) {
+                                $isFailedRow = true;
+                            }
                             $csvAttributeValues = $this->extractAttributeData($row);
-                            $isFailedRow = !$this->attribute->saveCSVRowAttributeData($csvAttributeValues, $itemData, $attributeData);
+                            if (!$this->attribute->saveCSVRowAttributeData($csvAttributeValues, $itemData, $attributeData)) {
+                                $isFailedRow = true;
+                            }
                             if ($isFailedRow) {
                                 $failedRow = $key + 2;
                                 $failCodes[] = $failedRow;
-                                log_message('error', "CSV Item import failed on line $failedRow while saving attributes.");
+                                log_message('error', "CSV Item import failed on line $failedRow while saving item.");
                                 continue;
                             }
 
@@ -1252,13 +1258,15 @@ class Items extends Secure_Controller
      * @param array $item_data
      * @param array $allowed_locations
      * @param int $employee_id
+     * @return bool Returns true on success, false on failure
      * @throws ReflectionException
      */
-    private function save_inventory_quantities(array $row, array $item_data, array $allowed_locations, int $employee_id): void
+    private function save_inventory_quantities(array $row, array $item_data, array $allowed_locations, int $employee_id): bool
     {
         // Quantities & Inventory Section
         $comment = lang('Items.inventory_CSV_import_quantity');
         $is_update = (bool)$row['Id'];
+        $success = true;
 
         foreach ($allowed_locations as $location_id => $location_name) {
             $item_quantity_data = ['item_id' => $item_data['item_id'], 'location_id' => $location_id];
@@ -1272,20 +1280,22 @@ class Items extends Secure_Controller
 
             if (!empty($row["location_$location_name"]) || $row["location_$location_name"] === '0') {
                 $item_quantity_data['quantity'] = $row["location_$location_name"];
-                $this->item_quantity->save_value($item_quantity_data, $item_data['item_id'], $location_id);
+                $success &= $this->item_quantity->save_value($item_quantity_data, $item_data['item_id'], $location_id);
 
                 $csv_data['trans_inventory'] = $row["location_$location_name"];
                 $this->inventory->insert($csv_data, false);
             } elseif ($is_update) {
-                return;
+                continue;
             } else {
                 $item_quantity_data['quantity'] = 0;
-                $this->item_quantity->save_value($item_quantity_data, $item_data['item_id'], $location_id);
+                $success &= $this->item_quantity->save_value($item_quantity_data, $item_data['item_id'], $location_id);
 
                 $csv_data['trans_inventory'] = 0;
                 $this->inventory->insert($csv_data, false);
             }
         }
+
+        return (bool)$success;
     }
 
     /**
@@ -1293,8 +1303,9 @@ class Items extends Secure_Controller
      *
      * @param array $row
      * @param array $item_data
+     * @return bool Returns true on success, false on failure
      */
-    private function save_tax_data(array $row, array $item_data): void
+    private function save_tax_data(array $row, array $item_data): bool
     {
         $items_taxes_data = [];
 
@@ -1307,8 +1318,10 @@ class Items extends Secure_Controller
         }
 
         if (isset($items_taxes_data)) {
-            $this->item_taxes->save_value($items_taxes_data, $item_data['item_id']);
+            return $this->item_taxes->save_value($items_taxes_data, $item_data['item_id']);
         }
+
+        return true;
     }
 
     /**

--- a/app/Controllers/Items.php
+++ b/app/Controllers/Items.php
@@ -1317,7 +1317,7 @@ class Items extends Secure_Controller
             $items_taxes_data[] = ['name' => $row['Tax 2 Name'], 'percent' => $row['Tax 2 Percent']];
         }
 
-        if (isset($items_taxes_data)) {
+        if (!empty($items_taxes_data)) {
             return $this->item_taxes->save_value($items_taxes_data, $item_data['item_id']);
         }
 

--- a/app/Controllers/Items.php
+++ b/app/Controllers/Items.php
@@ -1283,7 +1283,7 @@ class Items extends Secure_Controller
                 $success &= $this->item_quantity->save_value($item_quantity_data, $item_data['item_id'], $location_id);
 
                 $csv_data['trans_inventory'] = $row["location_$location_name"];
-                $this->inventory->insert($csv_data, false);
+                $success &= (bool)$this->inventory->insert($csv_data, false);
             } elseif ($is_update) {
                 continue;
             } else {
@@ -1291,7 +1291,7 @@ class Items extends Secure_Controller
                 $success &= $this->item_quantity->save_value($item_quantity_data, $item_data['item_id'], $location_id);
 
                 $csv_data['trans_inventory'] = 0;
-                $this->inventory->insert($csv_data, false);
+                $success &= (bool)$this->inventory->insert($csv_data, false);
             }
         }
 


### PR DESCRIPTION
## Summary

- Change `save_tax_data()` return type from `void` to `bool`
- Change `save_inventory_quantities()` return type from `void` to `bool` 
- Accumulate failure status with `&=` operator in `save_inventory_quantities()`
- Update `postImportCsvFile()` to capture return values and set `isFailedRow`
- Properly propagate failures to `failCodes` array

## Problem

In `postImportCsvFile()`, `save_tax_data()` and `save_inventory_quantities()` were called fire-and-forget. A write failure in either helper never propagated to the row's `failCodes` array, so the import could report a row as successfully imported even when tax or stock-quantity data was not persisted.

## Solution

1. Changed both helper functions to return `bool` indicating success/failure
2. Captured return values in `postImportCsvFile()` and set `isFailedRow = true` on failure
3. Changed `return;` to `continue;` in `save_inventory_quantities()` to allow loop completion
4. Updated log message to reflect all failure cases

Fixes #4475

Ultraworked with [Sisyphus](https://github.com/code-yeongyu/oh-my-openagent)

Co-authored-by: Sisyphus <clio-agent@sisyphuslabs.ai>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * CSV import now treats tax, inventory, and attribute save failures as definitive row failures, preventing partially imported rows from being marked complete.
  * Partial-import failure messaging clarified to report errors more accurately as occurring "while saving item."
  * Imports no longer abort when per-location quantity cells are empty; missing tax cells are handled gracefully so other row data continues to process.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/opensourcepos/opensourcepos/pull/4507?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->