### PR TITLE
fix: Propagate attribute definition failures in postSaveGeneral()

### DIFF
--- a/app/Controllers/Config.php
+++ b/app/Controllers/Config.php
@@ -398,6 +398,9 @@ class Config extends Secure_Controller
 
         $this->module->set_show_office_group($this->request->getPost('show_office_group') != null);
 
+        $this->db->transStart();
+
+        $attributeSuccess = true;
         if ($batchSaveData['category_dropdown']) {
             $definitionData['definition_name'] = 'ospos_category';
             $definitionData['definition_flags'] = 0;
@@ -405,12 +408,16 @@ class Config extends Secure_Controller
             $definitionData['definition_id'] = CATEGORY_DEFINITION_ID;
             $definitionData['deleted'] = 0;
 
-            $this->attribute->saveDefinition($definitionData, CATEGORY_DEFINITION_ID);
+            $attributeSuccess = $this->attribute->saveDefinition($definitionData, CATEGORY_DEFINITION_ID);
         } elseif ($batchSaveData['category_dropdown'] == NO_DEFINITION_ID) {
-            $this->attribute->deleteDefinition(CATEGORY_DEFINITION_ID);
+            $attributeSuccess = $this->attribute->deleteDefinition(CATEGORY_DEFINITION_ID);
         }
 
-        $success = $this->appconfig->batch_save($batchSaveData);
+        $success = $attributeSuccess && $this->appconfig->batch_save($batchSaveData);
+
+        $this->db->transComplete();
+
+        $success = $success && $this->db->transStatus();
 
         return $this->response->setJSON(['success' => $success, 'message' => lang('Config.saved_' . ($success ? '' : 'un') . 'successfully')]);
     }


### PR DESCRIPTION
## Summary

- Wrap attribute definition and appconfig save in single transaction
- Capture return values from `saveDefinition()` and `deleteDefinition()`
- Only call `batch_save()` if attribute operation succeeds
- Combine success status with `transStatus()` for atomic result
- Prevents `category_dropdown` config persistence when attribute fails

## Problem

In `Config::postSaveGeneral()`, `save_definition()`/`deleteDefinition()` and `appconfig->batch_save()` were called independently. This meant the endpoint could return success even when the attribute-definition change failed.

## Solution

1. Wrapped both operations in a transaction using `$this->db->transStart()` and `$this->db->transComplete()`
2. Captured the return value from `saveDefinition()`/`deleteDefinition()` 
3. Combined success status with `transStatus()` for final result

Fixes #4461

Ultraworked with [Sisyphus](https://github.com/code-yeongyu/oh-my-openagent)

Co-authored-by: Sisyphus <clio-agent@sisyphuslabs.ai>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Configuration save operations now include improved error handling and data consistency validation to prevent incomplete updates.
  * Attribute and category definitions are now properly tracked and verified during the save process.
  * Enhanced safeguards ensure save operations succeed completely or roll back to a consistent state.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->