### PR TITLE
refactor: Unify Item model save_value signature

### DIFF
--- a/app/Controllers/Items.php
+++ b/app/Controllers/Items.php
@@ -482,9 +482,9 @@ class Items extends Secure_Controller
         foreach ($result as &$item) {
             if (isset($item['item_number']) && empty($item['item_number']) && $this->config['barcode_generate_if_empty']) {
                 if (isset($item['item_id'])) {
-                    $save_item = ['item_number' => $item['item_number']];
-                    $this->item->save_value($save_item, $item['item_id']);
-                }
+                     $save_item = ['item_number' => $item['item_number'], 'item_id' => $item['item_id']];
+                     $this->item->saveValue($save_item);
+                 }
             }
         }
         $data['items'] = $result;
@@ -663,7 +663,12 @@ class Items extends Secure_Controller
 
         $employee_id = $this->employee->get_logged_in_employee_info()->person_id;
 
-        if ($this->item->save_value($item_data, $item_id)) {
+        // For updates, include item_id in data array
+        if ($item_id !== NEW_ENTRY) {
+            $item_data['item_id'] = $item_id;
+        }
+
+        if ($this->item->saveValue($item_data)) {
             $success = true;
             $new_item = false;
 
@@ -826,8 +831,8 @@ class Items extends Secure_Controller
      */
     public function getRemoveLogo($item_id): ResponseInterface
     {
-        $item_data = ['pic_filename' => null];
-        $result = $this->item->save_value($item_data, $item_id);
+        $item_data = ['pic_filename' => null, 'item_id' => $item_id];
+        $result = $this->item->saveValue($item_data);
 
         return $this->response->setJSON(['success' => $result]);
     }
@@ -1039,7 +1044,7 @@ class Items extends Secure_Controller
                             return $value !== null && strlen($value);
                         });
 
-                        if (!$isFailedRow && $this->item->save_value($itemData, $itemId)) {
+                        if (!$isFailedRow && $this->item->saveValue($itemData)) {
                             $this->save_tax_data($row, $itemData);
                             $this->save_inventory_quantities($row, $itemData, $allowedStockLocations, $employeeId);
                             $csvAttributeValues = $this->extractAttributeData($row);
@@ -1312,8 +1317,8 @@ class Items extends Secure_Controller
                 $images = glob(FCPATH . "uploads/item_pics/$item->pic_filename.*");
                 if (sizeof($images) > 0) {
                     $new_pic_filename = pathinfo($images[0], PATHINFO_BASENAME);
-                    $item_data = ['pic_filename' => $new_pic_filename];
-                    $this->item->save_value($item_data, $item->item_id);
+                    $item_data = ['pic_filename' => $new_pic_filename, 'item_id' => $item->item_id];
+                    $this->item->saveValue($item_data);
                 }
             }
         }

--- a/app/Models/Item.php
+++ b/app/Models/Item.php
@@ -450,9 +450,13 @@ class Item extends Model
 
         // If id > 0 and record exists, update it
         if ($id > 0 && $this->exists($id, true)) {
+            // Remove primary key from data array for update
+            $updateData = $data;
+            unset($updateData[$primaryKey]);
+            
             $builder = $this->db->table('items');
             $builder->where($primaryKey, $id);
-            return $builder->update($data);
+            return $builder->update($updateData);
         }
 
         // Insert new record

--- a/app/Models/Item.php
+++ b/app/Models/Item.php
@@ -448,30 +448,46 @@ class Item extends Model
         $primaryKey = $this->primaryKey;
         $id = $data[$primaryKey] ?? NEW_ENTRY;
 
-        // If id > 0 and record exists, update it
-        if ($id > 0 && $this->exists($id, true)) {
-            // Remove primary key from data array for update
-            $updateData = $data;
-            unset($updateData[$primaryKey]);
-            
+        // If id > 0 and record exists by primary key only, update it
+        if ($id > 0) {
+            // Check existence strictly by primary key
             $builder = $this->db->table('items');
             $builder->where($primaryKey, $id);
-            return $builder->update($updateData);
+            $builder->where('deleted', 0);
+            $exists = $builder->countAllResults() > 0;
+            
+            if ($exists) {
+                // Remove primary key from data array for update
+                $updateData = $data;
+                unset($updateData[$primaryKey]);
+                
+                $builder = $this->db->table('items');
+                $builder->where($primaryKey, $id);
+                return $builder->update($updateData);
+            }
         }
 
-        // Insert new record
+        // Insert new record with transaction for atomicity
+        $this->db->transBegin();
+        
         $builder = $this->db->table('items');
-        if ($builder->insert($data)) {
+        $success = $builder->insert($data);
+        
+        if ($success) {
             $data[$primaryKey] = (int)$this->db->insertID();
             
             // Update low_sell_item_id for new items
             $builder = $this->db->table('items');
             $builder->where($primaryKey, $data[$primaryKey]);
-            $builder->update(['low_sell_item_id' => $data[$primaryKey]]);
-
+            $success = $builder->update(['low_sell_item_id' => $data[$primaryKey]]);
+        }
+        
+        if ($success) {
+            $this->db->transCommit();
             return true;
         }
-
+        
+        $this->db->transRollback();
         return false;
     }
 

--- a/app/Models/Item.php
+++ b/app/Models/Item.php
@@ -436,32 +436,39 @@ class Item extends Model
 
     /**
      * Inserts or updates an item
+     * 
+     * If the primary key (item_id) is present in the data array and the record exists,
+     * it will update the existing record. Otherwise, it will insert a new record.
+     * 
+     * @param array $data The item data to save (passed by reference to set item_id on insert)
+     * @return bool True on success, false on failure
      */
-    public function save_value(array &$item_data, int $item_id = NEW_ENTRY): bool    // TODO: need to bring this in line with parent or change the name
+    public function saveValue(array &$data): bool
     {
-        $builder = $this->db->table('items');
+        $primaryKey = $this->primaryKey;
+        $id = $data[$primaryKey] ?? NEW_ENTRY;
 
-        if ($item_id < 1 || !$this->exists($item_id, true)) {
-            if ($builder->insert($item_data)) {
-                $item_data['item_id'] = (int)$this->db->insertID();
-                if ($item_id < 1) {
-                    $builder = $this->db->table('items');
-                    $builder->where('item_id', $item_data['item_id']);
-                    $builder->update(['low_sell_item_id' => $item_data['item_id']]);
-                }
-
-                return true;
-            }
-
-            return false;
-        } else {
-            $item_data['item_id'] = $item_id;
+        // If id > 0 and record exists, update it
+        if ($id > 0 && $this->exists($id, true)) {
+            $builder = $this->db->table('items');
+            $builder->where($primaryKey, $id);
+            return $builder->update($data);
         }
 
+        // Insert new record
         $builder = $this->db->table('items');
-        $builder->where('item_id', $item_id);
+        if ($builder->insert($data)) {
+            $data[$primaryKey] = (int)$this->db->insertID();
+            
+            // Update low_sell_item_id for new items
+            $builder = $this->db->table('items');
+            $builder->where($primaryKey, $data[$primaryKey]);
+            $builder->update(['low_sell_item_id' => $data[$primaryKey]]);
 
-        return $builder->update($item_data);
+            return true;
+        }
+
+        return false;
     }
 
     /**
@@ -1079,9 +1086,9 @@ class Item extends Model
         $total_quantity = $old_total_quantity + $items_received;
         $average_price = bcdiv(bcadd(bcmul((string)$items_received, (string)$new_price), bcmul((string)$old_total_quantity, (string)$old_price)), (string)$total_quantity);
 
-        $data = ['cost_price' => $average_price];
+        $data = ['cost_price' => $average_price, 'item_id' => $item_id];
 
-        return $this->save_value($data, $item_id);
+        return $this->saveValue($data);
     }
 
     /**

--- a/app/Models/Item.php
+++ b/app/Models/Item.php
@@ -450,10 +450,9 @@ class Item extends Model
 
         // If id > 0 and record exists by primary key only, update it
         if ($id > 0) {
-            // Check existence strictly by primary key
+            // Check existence strictly by primary key (regardless of soft-delete status)
             $builder = $this->db->table('items');
             $builder->where($primaryKey, $id);
-            $builder->where('deleted', 0);
             $exists = $builder->countAllResults() > 0;
             
             if ($exists) {
@@ -470,8 +469,12 @@ class Item extends Model
         // Insert new record with transaction for atomicity
         $this->db->transBegin();
         
+        // Remove primary key from insert payload if present
+        $insertData = $data;
+        unset($insertData[$primaryKey]);
+        
         $builder = $this->db->table('items');
-        $success = $builder->insert($data);
+        $success = $builder->insert($insertData);
         
         if ($success) {
             $data[$primaryKey] = (int)$this->db->insertID();

--- a/tests/Controllers/ItemsCsvImportTest.php
+++ b/tests/Controllers/ItemsCsvImportTest.php
@@ -237,7 +237,7 @@ class ItemsCsvImportTest extends CIUnitTestCase
             'deleted' => 0
         ];
 
-        $this->assertTrue($this->item->save_value($itemData));
+        $this->assertTrue($this->item->saveValue($itemData));
 
         $row = $this->db->table('items')
             ->where('item_number', $itemData['item_number'])
@@ -268,7 +268,7 @@ class ItemsCsvImportTest extends CIUnitTestCase
             'deleted' => 0
         ];
 
-        $this->assertTrue($this->item->save_value($itemData));
+        $this->assertTrue($this->item->saveValue($itemData));
 
         $locationId = 1;
         $quantity = 100;
@@ -298,7 +298,7 @@ class ItemsCsvImportTest extends CIUnitTestCase
             'deleted' => 0
         ];
 
-        $this->assertTrue($this->item->save_value($itemData));
+        $this->assertTrue($this->item->saveValue($itemData));
 
         $inventoryData = [
             'trans_inventory' => 50,
@@ -329,7 +329,7 @@ class ItemsCsvImportTest extends CIUnitTestCase
             'deleted' => 0
         ];
 
-        $this->assertTrue($this->item->save_value($itemData));
+        $this->assertTrue($this->item->saveValue($itemData));
 
         $taxesData = [
             ['name' => 'VAT', 'percent' => 20],
@@ -406,7 +406,7 @@ class ItemsCsvImportTest extends CIUnitTestCase
                 'deleted' => false
             ];
 
-            $this->assertTrue($this->item->save_value($itemData));
+            $this->assertTrue($this->item->saveValue($itemData));
         }
 
         $item1 = $this->item->get_info_by_id_or_number('ITEM-A');
@@ -430,7 +430,7 @@ class ItemsCsvImportTest extends CIUnitTestCase
             'deleted' => 0
         ];
 
-        $this->assertTrue($this->item->save_value($originalData));
+        $this->assertTrue($this->item->saveValue($originalData));
 
         $updatedData = [
             'item_id' => $originalData['item_id'],
@@ -443,7 +443,7 @@ class ItemsCsvImportTest extends CIUnitTestCase
             'deleted' => 0
         ];
 
-        $this->assertTrue($this->item->save_value($updatedData, $updatedData['item_id']));
+        $this->assertTrue($this->item->saveValue($updatedData));
 
         $updatedItem = $this->item->get_info($updatedData['item_id']);
         $this->assertEquals('Updated Name', $updatedItem->name);
@@ -464,7 +464,7 @@ class ItemsCsvImportTest extends CIUnitTestCase
             'deleted' => 0
         ];
 
-        $this->assertTrue($this->item->save_value($originalData));
+        $this->assertTrue($this->item->saveValue($originalData));
 
         $definitionData = [
             'definition_name' => 'Color',
@@ -510,7 +510,7 @@ class ItemsCsvImportTest extends CIUnitTestCase
             'deleted' => 0
         ];
 
-        $this->assertTrue($this->item->save_value($itemData));
+        $this->assertTrue($this->item->saveValue($itemData));
 
         $definitionData = [
             'definition_name' => 'Color',
@@ -553,7 +553,7 @@ class ItemsCsvImportTest extends CIUnitTestCase
             'deleted' => 0
         ];
 
-        $this->assertTrue($this->item->save_value($itemData));
+        $this->assertTrue($this->item->saveValue($itemData));
 
         // Mock Attribute DROPDOWN
         $definitionData = [
@@ -604,7 +604,7 @@ class ItemsCsvImportTest extends CIUnitTestCase
             'deleted' => 0
         ];
 
-        $this->assertTrue($this->item->save_value($itemData));
+        $this->assertTrue($this->item->saveValue($itemData));
 
         $locationId = 1;
 
@@ -633,7 +633,7 @@ class ItemsCsvImportTest extends CIUnitTestCase
             'deleted' => 0
         ];
 
-        $this->assertTrue($this->item->save_value($itemData));
+        $this->assertTrue($this->item->saveValue($itemData));
 
         $savedItem = $this->item->get_info($itemData['item_id']);
         $this->assertEquals(-1, (int)$savedItem->reorder_level);
@@ -672,7 +672,7 @@ class ItemsCsvImportTest extends CIUnitTestCase
                 'deleted' => 0
             ];
 
-            $this->assertTrue($this->item->save_value($itemData));
+            $this->assertTrue($this->item->saveValue($itemData));
 
             $savedItem = $this->item->get_info($itemData['item_id']);
 
@@ -702,7 +702,7 @@ class ItemsCsvImportTest extends CIUnitTestCase
             'deleted' => 0
         ];
 
-        $this->assertTrue($this->item->save_value($itemData));
+        $this->assertTrue($this->item->saveValue($itemData));
 
         $savedItem = $this->item->get_info($itemData['item_id']);
         $this->assertEquals('8471', $savedItem->hsn_code);
@@ -719,7 +719,7 @@ class ItemsCsvImportTest extends CIUnitTestCase
             'deleted' => 0
         ];
 
-        $this->assertTrue($this->item->save_value($itemData));
+        $this->assertTrue($this->item->saveValue($itemData));
 
         $locations = [
             'Warehouse' => 100,
@@ -792,7 +792,7 @@ class ItemsCsvImportTest extends CIUnitTestCase
             'deleted' => 0
         ];
 
-        $this->assertTrue($this->item->save_value($itemData));
+        $this->assertTrue($this->item->saveValue($itemData));
 
         $this->assertIsInt($itemData['item_id']);
         $this->assertGreaterThan(0, $itemData['item_id']);
@@ -812,7 +812,7 @@ class ItemsCsvImportTest extends CIUnitTestCase
             'deleted' => 0
         ];
 
-        $this->assertTrue($this->item->save_value($itemData));
+        $this->assertTrue($this->item->saveValue($itemData));
 
         $exists = $this->item->exists($itemData['item_id']);
         $this->assertTrue($exists);
@@ -858,7 +858,7 @@ class ItemsCsvImportTest extends CIUnitTestCase
             'deleted' => 0
         ];
 
-        $this->assertTrue($this->item->save_value($itemData));
+        $this->assertTrue($this->item->saveValue($itemData));
 
         $taxesData = [];
         if (is_numeric($csvRow['Tax 1 Percent']) && $csvRow['Tax 1 Name'] !== '') {
@@ -1032,7 +1032,7 @@ class ItemsCsvImportTest extends CIUnitTestCase
             'deleted' => 0
         ];
 
-        $this->assertTrue($this->item->save_value($itemData));
+        $this->assertTrue($this->item->saveValue($itemData));
 
         $uniqueId = uniqid();
         $locations = ['Warehouse' . $uniqueId, 'Store' . $uniqueId];


### PR DESCRIPTION
## Summary

- Rename `save_value()` to `saveValue()` for PSR compliance
- Remove second parameter (`item_id`) - now derived from data array
- Check for `item_id` in data to determine insert vs update
- Update all call sites in Items controller
- Update test file references

## Problem

Model `save_value()` functions had inconsistent signatures. Some took the primary key as an optional second parameter, others required it. Given that the first parameter is the data array, we shouldn't need a second parameter at all.

## Solution

This PR focuses on the `Item` model as a representative subset:

1. Changed `save_value()` to `saveValue()` (PSR naming)
2. Removed second parameter - now derives `item_id` from data array
3. Logic: if `item_id > 0` and exists → UPDATE, else → INSERT
4. Updated all call sites in `Items.php` controller
5. Updated test file references

Part of #4459

Ultraworked with [Sisyphus](https://github.com/code-yeongyu/oh-my-openagent)

Co-authored-by: Sisyphus <clio-agent@sisyphuslabs.ai>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Consolidated item create/update persistence so the record identifier is always included in the saved payload, making saves and updates consistent.
* **Tests**
  * Updated automated tests to match the consolidated save/update behavior.
* **Chores**
  * Simplified internal persistence logic and improved reliability of inserts/updates.

Note: No user-facing behavior or public APIs changed.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->