### PR TITLE
Fix allowed hostnames with external reverse proxy

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -23,6 +23,23 @@ CI_ENVIRONMENT = production
 app.allowedHostnames = ''
 
 #--------------------------------------------------------------------
+# REVERSE PROXY CONFIGURATION
+#--------------------------------------------------------------------
+# Configure trusted proxy IPs for X-Forwarded-Host header support.
+#
+# For Docker/nginx or same-host deployments where proxy runs locally:
+#   app.proxyIPs = '*' 
+#
+# For specific proxy IPs (more secure):
+#   app.proxyIPs = '10.0.0.1,192.168.1.100'
+#
+# For CIDR ranges (load balancers):
+#   app.proxyIPs = '10.0.0.0/24'
+#
+# Leave empty to disable proxy header support (recommended for direct deployments)
+#app.proxyIPs = ''
+
+#--------------------------------------------------------------------
 # DATABASE
 #--------------------------------------------------------------------
 

--- a/.env.example
+++ b/.env.example
@@ -27,8 +27,12 @@ app.allowedHostnames = ''
 #--------------------------------------------------------------------
 # Configure trusted proxy IPs for X-Forwarded-Host header support.
 #
+# SECURITY: Even with proxyIPs configured, the hostname in X-Forwarded-Host
+# MUST still be in allowedHostnames whitelist. This prevents header spoofing.
+#
 # For Docker/nginx or same-host deployments where proxy runs locally:
 #   app.proxyIPs = '*' 
+#   (Requires firewall to block direct PHP-FPM access)
 #
 # For specific proxy IPs (more secure):
 #   app.proxyIPs = '10.0.0.1,192.168.1.100'

--- a/INSTALL.md
+++ b/INSTALL.md
@@ -23,9 +23,10 @@ app.allowedHostnames = 'yourdomain.com,www.yourdomain.com'
 
 ```bash
 app.allowedHostnames = 'localhost'
-```
 
 **If you see this error at startup:**
+
+
 
 ```text
 RuntimeException: Security: allowedHostnames is not configured.

--- a/INSTALL.md
+++ b/INSTALL.md
@@ -26,8 +26,6 @@ app.allowedHostnames = 'localhost'
 
 **If you see this error at startup:**
 
-
-
 ```text
 RuntimeException: Security: allowedHostnames is not configured.
 ```

--- a/app/Config/App.php
+++ b/app/Config/App.php
@@ -288,12 +288,14 @@ class App extends BaseConfig
     {
         parent::__construct();
         
-        // Support comma-separated .env configuration for allowedHostnames
-        // Workaround for CodeIgniter 4 limitation: arrays cannot be set from .env
+        // Solution for CodeIgniter 4 limitation: arrays cannot be set from .env
         // See: https://github.com/codeigniter4/CodeIgniter4/issues/7311
         $envAllowedHostnames = getenv('app.allowedHostnames');
-        if ($envAllowedHostnames !== false && !empty($envAllowedHostnames)) {
-            $this->allowedHostnames = array_map('trim', explode(',', $envAllowedHostnames));
+        if ($envAllowedHostnames !== false && trim($envAllowedHostnames) !== '') {
+            $this->allowedHostnames = array_values(array_filter(
+                array_map('trim', explode(',', $envAllowedHostnames)),
+                static fn (string $hostname): bool => $hostname !== ''
+            ));
         }
         
         }

--- a/app/Config/App.php
+++ b/app/Config/App.php
@@ -262,6 +262,10 @@ class App extends BaseConfig
      *         '192.168.5.0/24' => 'X-Real-IP',
      *     ]
      *
+     * For Docker/nginx or same-host deployments where the proxy runs locally,
+     * you can set this to ['*'] to trust all proxy sources for forwarded headers.
+     * In this case, only allow trusted networks via firewall/security groups.
+     *
      * @var array<string, string>
      */
     public array $proxyIPs = [];
@@ -290,6 +294,8 @@ class App extends BaseConfig
         
         // Solution for CodeIgniter 4 limitation: arrays cannot be set from .env
         // See: https://github.com/codeigniter4/CodeIgniter4/issues/7311
+        
+        // Parse allowedHostnames from .env (comma-separated)
         $envAllowedHostnames = getenv('app.allowedHostnames');
         if ($envAllowedHostnames !== false && trim($envAllowedHostnames) !== '') {
             $this->allowedHostnames = array_values(array_filter(
@@ -298,8 +304,21 @@ class App extends BaseConfig
             ));
         }
         
+        // Parse proxyIPs from .env (comma-separated, supports '*' for all)
+        $envProxyIPs = getenv('app.proxyIPs');
+        if ($envProxyIPs !== false && trim($envProxyIPs) !== '') {
+            $parsed = array_map('trim', explode(',', $envProxyIPs));
+            $this->proxyIPs = [];
+            foreach ($parsed as $ip) {
+                // Support wildcard '*' to trust all proxies
+                if ($ip === '*') {
+                    $this->proxyIPs['*'] = 'X-Forwarded-For';
+                } else {
+                    $this->proxyIPs[$ip] = 'X-Forwarded-For';
+                }
+            }
         }
-
+        
         $this->https_on = (isset($_SERVER['HTTPS']) && $_SERVER['HTTPS'] == 'on') || (isset($_ENV['FORCE_HTTPS']) && $_ENV['FORCE_HTTPS'] == 'true');
 
         $host = $this->getValidHost();
@@ -373,9 +392,14 @@ class App extends BaseConfig
      */
     private function getForwardedHost(): ?string
     {
-        // Only use forwarded headers if behind a trusted proxy
+        // Only use forwarded headers if proxyIPs is configured
         if (empty($this->proxyIPs)) {
             return null;
+        }
+
+        // Check if trusting all proxies (for Docker/same-host deployments)
+        if (isset($this->proxyIPs['*'])) {
+            return $_SERVER['HTTP_X_FORWARDED_HOST'] ?? null;
         }
 
         // Check if the request comes from a trusted proxy

--- a/app/Config/App.php
+++ b/app/Config/App.php
@@ -336,6 +336,10 @@ class App extends BaseConfig
      * Supports reverse proxies: Checks X-Forwarded-Host header when behind
      * a trusted proxy (configured via $proxyIPs).
      * 
+     * IMPORTANT: Both HTTP_HOST and X-Forwarded-Host are validated against
+     * the allowedHostnames whitelist. Even if an attacker injects a forged
+     * X-Forwarded-Host header, it must match an entry in allowedHostnames.
+     * 
      * In production: Fails fast if allowedHostnames is not configured.
      * In development: Allows localhost fallback with an error log.
      * 
@@ -344,7 +348,10 @@ class App extends BaseConfig
      */
     private function getValidHost(): string
     {
-        $httpHost = $this->getForwardedHost() ?? $_SERVER['HTTP_HOST'] ?? 'localhost';
+        // Get host from forwarded header or HTTP_HOST
+        // Both are validated against allowedHostnames whitelist below
+        $forwardedHost = $this->getForwardedHost();
+        $httpHost = $forwardedHost ?? $_SERVER['HTTP_HOST'] ?? 'localhost';
         
         // Determine environment
         // CodeIgniter's test bootstrap sets $_SERVER['CI_ENVIRONMENT'] = 'testing'
@@ -387,6 +394,15 @@ class App extends BaseConfig
      * 
      * When behind a reverse proxy (nginx, load balancer, etc.), the actual hostname
      * is sent in the X-Forwarded-Host header, while HTTP_HOST contains the proxy's hostname.
+     * 
+     * SECURITY WARNING: The returned hostname is still validated against allowedHostnames
+     * whitelist in getValidHost(). This prevents attacks even if an attacker:
+     * - Directly accesses PHP-FPM (bypassing nginx)
+     * - Forges X-Forwarded-Host with wildcard proxyIPs = '*'
+     * - Spoofs the header from an untrusted network
+     * 
+     * The defense is: allowedHostnames is the authoritative whitelist, regardless
+     * of which header the hostname comes from.
      * 
      * @return string|null The forwarded host if configured and behind trusted proxy, null otherwise
      */

--- a/app/Config/App.php
+++ b/app/Config/App.php
@@ -314,6 +314,9 @@ class App extends BaseConfig
      * Security: Prevents Host Header Injection attacks (GHSA-jchf-7hr6-h4f3)
      * by validating the HTTP_HOST against a whitelist of allowed hostnames.
      *
+     * Supports reverse proxies: Checks X-Forwarded-Host header when behind
+     * a trusted proxy (configured via $proxyIPs).
+     * 
      * In production: Fails fast if allowedHostnames is not configured.
      * In development: Allows localhost fallback with an error log.
      * 
@@ -322,7 +325,7 @@ class App extends BaseConfig
      */
     private function getValidHost(): string
     {
-        $httpHost = $_SERVER['HTTP_HOST'] ?? 'localhost';
+        $httpHost = $this->getForwardedHost() ?? $_SERVER['HTTP_HOST'] ?? 'localhost';
         
         // Determine environment
         // CodeIgniter's test bootstrap sets $_SERVER['CI_ENVIRONMENT'] = 'testing'
@@ -358,5 +361,79 @@ class App extends BaseConfig
         );
 
         return $this->allowedHostnames[0];
+    }
+
+    /**
+     * Get the forwarded host from X-Forwarded-Host header when behind a trusted proxy.
+     * 
+     * When behind a reverse proxy (nginx, load balancer, etc.), the actual hostname
+     * is sent in the X-Forwarded-Host header, while HTTP_HOST contains the proxy's hostname.
+     * 
+     * @return string|null The forwarded host if configured and behind trusted proxy, null otherwise
+     */
+    private function getForwardedHost(): ?string
+    {
+        // Only use forwarded headers if behind a trusted proxy
+        if (empty($this->proxyIPs)) {
+            return null;
+        }
+
+        // Check if the request comes from a trusted proxy
+        $clientIp = $_SERVER['REMOTE_ADDR'] ?? '';
+        if (!$this->isTrustedProxy($clientIp)) {
+            return null;
+        }
+
+        // Return the forwarded host if present
+        return $_SERVER['HTTP_X_FORWARDED_HOST'] ?? null;
+    }
+
+    /**
+     * Check if an IP address is a trusted proxy.
+     * 
+     * @param string $ip The IP address to check
+     * @return bool True if the IP is a trusted proxy
+     */
+    private function isTrustedProxy(string $ip): bool
+    {
+        foreach ($this->proxyIPs as $proxyIp => $header) {
+            if ($this->ipInRange($ip, $proxyIp)) {
+                return true;
+            }
+        }
+        
+        return false;
+    }
+
+    /**
+     * Check if an IP address is within a CIDR range.
+     * 
+     * @param string $ip The IP address to check
+     * @param string $range The CIDR range (e.g., '192.168.1.0/24' or '10.0.0.1')
+     * @return bool True if the IP is within the range
+     */
+    private function ipInRange(string $ip, string $range): bool
+    {
+        // If no subnet mask, check for exact match
+        if (strpos($range, '/') === false) {
+            return $ip === $range;
+        }
+
+        // Parse CIDR notation
+        list($subnet, $bits) = explode('/', $range);
+        
+        // Convert IP addresses to long format
+        $ipLong = ip2long($ip);
+        $subnetLong = ip2long($subnet);
+        
+        if ($ipLong === false || $subnetLong === false) {
+            return false;
+        }
+
+        // Calculate network mask
+        $mask = -1 << (32 - (int)$bits);
+        $network = $subnetLong & $mask;
+
+        return ($ipLong & $mask) === $network;
     }
 }

--- a/app/Config/App.php
+++ b/app/Config/App.php
@@ -57,9 +57,13 @@ class App extends BaseConfig
     /**
      * Allowed Hostnames in the Site URL other than the hostname in the baseURL.
      * If you want to accept multiple Hostnames, set this.
+     * If empty in production, the application will fail to start.
+     * In development, it will fall back to 'localhost' with a warning.
+     * Configure via .env file (comma-separated list):
+     *   app.allowedHostnames = 'example.com,www.example.com'
      *
      * E.g.,
-     * When your site URL ($baseURL) is 'http://example.com/', and your site
+     *   app.allowedHostnames = 'localhost'
      * also accepts 'http://media.example.com/' and 'http://accounts.example.com/':
      *     ['media.example.com', 'accounts.example.com']
      *
@@ -283,15 +287,15 @@ class App extends BaseConfig
     public function __construct()
     {
         parent::__construct();
-
-        // Solution for CodeIgniter 4 limitation: arrays cannot be set from .env
+        
+        // Support comma-separated .env configuration for allowedHostnames
+        // Workaround for CodeIgniter 4 limitation: arrays cannot be set from .env
         // See: https://github.com/codeigniter4/CodeIgniter4/issues/7311
         $envAllowedHostnames = getenv('app.allowedHostnames');
-        if ($envAllowedHostnames !== false && trim($envAllowedHostnames) !== '') {
-            $this->allowedHostnames = array_values(array_filter(
-                array_map('trim', explode(',', $envAllowedHostnames)),
-                static fn (string $hostname): bool => $hostname !== ''
-            ));
+        if ($envAllowedHostnames !== false && !empty($envAllowedHostnames)) {
+            $this->allowedHostnames = array_map('trim', explode(',', $envAllowedHostnames));
+        }
+        
         }
 
         $this->https_on = (isset($_SERVER['HTTPS']) && $_SERVER['HTTPS'] == 'on') || (isset($_ENV['FORCE_HTTPS']) && $_ENV['FORCE_HTTPS'] == 'true');
@@ -310,33 +314,33 @@ class App extends BaseConfig
      *
      * In production: Fails fast if allowedHostnames is not configured.
      * In development: Allows localhost fallback with an error log.
-     *
+     * 
      * @return string A validated hostname
      * @throws \RuntimeException If allowedHostnames is not configured in production
      */
     private function getValidHost(): string
     {
         $httpHost = $_SERVER['HTTP_HOST'] ?? 'localhost';
-
+        
         // Determine environment
         // CodeIgniter's test bootstrap sets $_SERVER['CI_ENVIRONMENT'] = 'testing'
         // Check $_SERVER first, then $_ENV, then fall back to 'production'
         $environment = $_SERVER['CI_ENVIRONMENT'] ?? $_ENV['CI_ENVIRONMENT'] ?? getenv('CI_ENVIRONMENT') ?: 'production';
 
         if (empty($this->allowedHostnames)) {
-            $errorMessage =
+            $errorMessage = 
                 'Security: allowedHostnames is not configured. ' .
                 'Host header injection protection is disabled. ' .
                 'Set app.allowedHostnames in your .env file. ' .
                 'Example: app.allowedHostnames = "example.com,www.example.com" ' .
                 'Received Host: ' . $httpHost;
-
+            
             // Production: Fail explicitly to prevent silent security vulnerabilities
             // Testing and development: Allow localhost fallback
             if ($environment === 'production') {
                 throw new \RuntimeException($errorMessage);
             }
-
+            
             log_message('error', $errorMessage . ' Using localhost fallback (development only).');
             return 'localhost';
         }

--- a/tests/Config/AppTest.php
+++ b/tests/Config/AppTest.php
@@ -369,4 +369,66 @@ class AppTest extends CIUnitTestCase
         // Should ignore X-Forwarded-Host when no proxy configured
         $this->assertEquals('example.com', $host);
     }
+
+    public function testGetValidHostUsesForwardedHostWithWildcardTrust(): void
+    {
+        $app = new class extends App {
+            public array $allowedHostnames = ['example.com'];
+            public array $proxyIPs = ['*' => 'X-Forwarded-For'];  // Trust all
+            
+            public function __construct() {}
+        };
+
+        $reflection = new \ReflectionClass($app);
+        $method = $reflection->getMethod('getValidHost');
+        $method->setAccessible(true);
+
+        // Any IP should be trusted with wildcard
+        $_SERVER['REMOTE_ADDR'] = '203.0.113.50';  // Random external IP
+        $_SERVER['HTTP_X_FORWARDED_HOST'] = 'example.com';
+        $_SERVER['HTTP_HOST'] = 'internal.local';
+
+        $host = $method->invoke($app);
+        $this->assertEquals('example.com', $host);
+    }
+
+    public function testEnvProxyIPsParsedAsCommaSeparated(): void
+    {
+        // Set proxy IPs as comma-separated string
+        putenv('app.proxyIPs=10.0.0.1,192.168.1.0/24');
+
+        $_SERVER['HTTP_HOST'] = 'internal.local';
+        $_SERVER['HTTP_X_FORWARDED_HOST'] = 'example.com';
+        $_SERVER['REMOTE_ADDR'] = '10.0.0.1';
+        $_SERVER['SCRIPT_NAME'] = '/index.php';
+        $_SERVER['HTTPS'] = null;
+
+        $app = new App();
+
+        // Should parse proxyIPs and use forwarded host from trusted proxy
+        $this->assertStringContainsString('example.com', $app->baseURL);
+
+        // Clean up
+        putenv('app.proxyIPs');
+    }
+
+    public function testEnvProxyIPsWildcard(): void
+    {
+        // Set wildcard proxy IPs
+        putenv('app.proxyIPs=*');
+
+        $_SERVER['HTTP_HOST'] = 'internal.local';
+        $_SERVER['HTTP_X_FORWARDED_HOST'] = 'example.com';
+        $_SERVER['REMOTE_ADDR'] = '203.0.113.50';  // Any IP
+        $_SERVER['SCRIPT_NAME'] = '/index.php';
+        $_SERVER['HTTPS'] = null;
+
+        $app = new App();
+
+        // Should trust any IP with wildcard
+        $this->assertStringContainsString('example.com', $app->baseURL);
+
+        // Clean up
+        putenv('app.proxyIPs');
+    }
 }

--- a/tests/Config/AppTest.php
+++ b/tests/Config/AppTest.php
@@ -431,4 +431,52 @@ class AppTest extends CIUnitTestCase
         // Clean up
         putenv('app.proxyIPs');
     }
+
+    public function testForwardedHostStillValidatesAgainstAllowedHostnames(): void
+    {
+        // Even with wildcard proxyIPs, forwarded host must be in allowedHostnames
+        $app = new class extends App {
+            public array $allowedHostnames = ['example.com'];  // Only example.com allowed
+            public array $proxyIPs = ['*' => 'X-Forwarded-For'];  // Trust all proxies
+            
+            public function __construct() {}
+        };
+
+        $reflection = new \ReflectionClass($app);
+        $method = $reflection->getMethod('getValidHost');
+        $method->setAccessible(true);
+
+        // Attacker tries to inject malicious forwarded host
+        $_SERVER['REMOTE_ADDR'] = '203.0.113.50';
+        $_SERVER['HTTP_X_FORWARDED_HOST'] = 'malicious.com';  // NOT in allowedHostnames
+        $_SERVER['HTTP_HOST'] = 'example.com';  // This IS in allowedHostnames
+
+        $host = $method->invoke($app);
+        // Should fall back to HTTP_HOST since forwarded host is not whitelisted
+        $this->assertEquals('example.com', $host);
+    }
+
+    public function testForwardedHostRejectedWhenNotInAllowedHostnames(): void
+    {
+        // Attacker forges X-Forwarded-Host with wildcard proxyIPs
+        $app = new class extends App {
+            public array $allowedHostnames = ['example.com'];
+            public array $proxyIPs = ['*' => 'X-Forwarded-For'];
+            
+            public function __construct() {}
+        };
+
+        $reflection = new \ReflectionClass($app);
+        $method = $reflection->getMethod('getValidHost');
+        $method->setAccessible(true);
+
+        // Attacker sends malicious forwarded host (not in whitelist)
+        $_SERVER['REMOTE_ADDR'] = '203.0.113.50';
+        $_SERVER['HTTP_HOST'] = 'internal.local';
+        $_SERVER['HTTP_X_FORWARDED_HOST'] = 'evil.com';  // NOT in allowedHostnames
+
+        $host = $method->invoke($app);
+        // Should use fallback (first allowed hostname), not the forged header
+        $this->assertEquals('example.com', $host);
+    }
 }

--- a/tests/Config/AppTest.php
+++ b/tests/Config/AppTest.php
@@ -281,4 +281,92 @@ class AppTest extends CIUnitTestCase
         putenv('app.allowedHostnames');
         putenv('CI_ENVIRONMENT');
     }
+
+    public function testGetValidHostUsesForwardedHostWhenBehindTrustedProxy(): void
+    {
+        $app = new class extends App {
+            public array $allowedHostnames = ['example.com', 'www.example.com'];
+            public array $proxyIPs = ['10.0.0.1' => 'X-Forwarded-For'];
+            
+            public function __construct() {}
+        };
+
+        $reflection = new \ReflectionClass($app);
+        $method = $reflection->getMethod('getValidHost');
+        $method->setAccessible(true);
+
+        // Request from trusted proxy with forwarded host
+        $_SERVER['REMOTE_ADDR'] = '10.0.0.1';
+        $_SERVER['HTTP_X_FORWARDED_HOST'] = 'www.example.com';
+        $_SERVER['HTTP_HOST'] = 'internal-proxy.local';
+
+        $host = $method->invoke($app);
+        $this->assertEquals('www.example.com', $host);
+    }
+
+    public function testGetValidHostIgnoresForwardedHostWhenNotBehindTrustedProxy(): void
+    {
+        $app = new class extends App {
+            public array $allowedHostnames = ['example.com'];
+            public array $proxyIPs = ['10.0.0.1' => 'X-Forwarded-For'];
+            
+            public function __construct() {}
+        };
+
+        $reflection = new \ReflectionClass($app);
+        $method = $reflection->getMethod('getValidHost');
+        $method->setAccessible(true);
+
+        // Request from untrusted IP
+        $_SERVER['REMOTE_ADDR'] = '192.168.1.100';
+        $_SERVER['HTTP_X_FORWARDED_HOST'] = 'malicious.com';
+        $_SERVER['HTTP_HOST'] = 'example.com';
+
+        $host = $method->invoke($app);
+        // Should use HTTP_HOST, not X-Forwarded-Host
+        $this->assertEquals('example.com', $host);
+    }
+
+    public function testGetValidHostUsesForwardedHostWithCidrProxyRange(): void
+    {
+        $app = new class extends App {
+            public array $allowedHostnames = ['example.com'];
+            public array $proxyIPs = ['10.0.0.0/24' => 'X-Forwarded-For'];
+            
+            public function __construct() {}
+        };
+
+        $reflection = new \ReflectionClass($app);
+        $method = $reflection->getMethod('getValidHost');
+        $method->setAccessible(true);
+
+        // Request from IP within trusted range
+        $_SERVER['REMOTE_ADDR'] = '10.0.0.50';  // Within 10.0.0.0/24
+        $_SERVER['HTTP_X_FORWARDED_HOST'] = 'example.com';
+        $_SERVER['HTTP_HOST'] = 'internal.local';
+
+        $host = $method->invoke($app);
+        $this->assertEquals('example.com', $host);
+    }
+
+    public function testGetValidHostNoProxyIPsUsesHttpHost(): void
+    {
+        $app = new class extends App {
+            public array $allowedHostnames = ['example.com'];
+            public array $proxyIPs = [];  // No proxy configured
+            
+            public function __construct() {}
+        };
+
+        $reflection = new \ReflectionClass($app);
+        $method = $reflection->getMethod('getValidHost');
+        $method->setAccessible(true);
+
+        $_SERVER['HTTP_HOST'] = 'example.com';
+        $_SERVER['HTTP_X_FORWARDED_HOST'] = 'malicious.com';
+
+        $host = $method->invoke($app);
+        // Should ignore X-Forwarded-Host when no proxy configured
+        $this->assertEquals('example.com', $host);
+    }
 }


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Clarified reverse-proxy guidance, documented proxy IP formats (wildcard, CIDR, comma-separated) and requirement to whitelist derived hostnames; fixed markdown formatting in install docs.
* **New Features**
  * Optional proxy configuration to trust X-Forwarded-Host from specified IPs/CIDR/wildcard; hostname validation still enforced against allowed hostnames.
* **Tests**
  * Added tests covering proxy trust rules, CIDR/wildcard behavior, env parsing, validation and fallback scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->