### PR TITLE
fix: Add missing $img_tag variable in Sales::getSendPdf()

### DIFF
--- a/app/Controllers/Sales.php
+++ b/app/Controllers/Sales.php
@@ -939,6 +939,14 @@ class Sales extends Secure_Controller
             $text = $this->token_lib->render($text, $tokens);
             $sale_data['mimetype'] = mime_content_type(FCPATH . 'uploads/' . $this->config['company_logo']);
 
+            // Build img_tag for email views that need it (receipt_email.php)
+            $sale_data['img_tag'] = '';
+            $logo_path = FCPATH . 'uploads/' . $this->config['company_logo'];
+            if (!empty($this->config['company_logo']) && file_exists($logo_path)) {
+                $logo_data = base64_encode(file_get_contents($logo_path));
+                $sale_data['img_tag'] = '<img id="image" src="data:image/png;base64,' . $logo_data . '" alt="company_logo">';
+            }
+
             // Generate email attachment: invoice in PDF format
             $view = Services::renderer();
             $html = $view->setData($sale_data)->render("sales/$type" . '_email', $sale_data);

--- a/app/Controllers/Sales.php
+++ b/app/Controllers/Sales.php
@@ -940,12 +940,7 @@ class Sales extends Secure_Controller
             $sale_data['mimetype'] = mime_content_type(FCPATH . 'uploads/' . $this->config['company_logo']);
 
             // Build img_tag for email views that need it (receipt_email.php)
-            $sale_data['img_tag'] = '';
-            $logo_path = FCPATH . 'uploads/' . $this->config['company_logo'];
-            if (!empty($this->config['company_logo']) && file_exists($logo_path)) {
-                $logo_data = base64_encode(file_get_contents($logo_path));
-                $sale_data['img_tag'] = '<img id="image" src="data:image/png;base64,' . $logo_data . '" alt="company_logo">';
-            }
+            $sale_data['img_tag'] = $this->_build_img_tag();
 
             // Generate email attachment: invoice in PDF format
             $view = Services::renderer();
@@ -982,13 +977,7 @@ class Sales extends Secure_Controller
 
         if (!empty($sale_data['customer_email'])) {
             $sale_data['barcode'] = $this->barcode_lib->generate_receipt_barcode($sale_data['sale_id']);
-            $sale_data['img_tag'] = '';
-
-            $logo_path = FCPATH . 'uploads/' . $this->config['company_logo'];
-            if (!empty($this->config['company_logo']) && file_exists($logo_path)) {
-                $logo_data = base64_encode(file_get_contents($logo_path));
-                $sale_data['img_tag'] = '<img id="image" src="data:image/png;base64,' . $logo_data . '" alt="company_logo">';
-            }
+            $sale_data['img_tag'] = $this->_build_img_tag();
 
             $to = $sale_data['customer_email'];
             $subject = lang('Sales.receipt');
@@ -1772,5 +1761,23 @@ class Sales extends Secure_Controller
         }
 
         return null;
+    }
+
+    /**
+     * Builds an img tag for the company logo to use in email templates.
+     *
+     * @return string HTML img tag with base64-encoded logo, or empty string if no logo
+     */
+    private function _build_img_tag(): string
+    {
+        $img_tag = '';
+        $logo_path = FCPATH . 'uploads/' . $this->config['company_logo'];
+
+        if (!empty($this->config['company_logo']) && file_exists($logo_path)) {
+            $logo_data = base64_encode(file_get_contents($logo_path));
+            $img_tag = '<img id="image" src="data:image/png;base64,' . $logo_data . '" alt="company_logo">';
+        }
+
+        return $img_tag;
     }
 }

--- a/app/Controllers/Sales.php
+++ b/app/Controllers/Sales.php
@@ -937,10 +937,10 @@ class Sales extends Secure_Controller
                 new Token_customer((array)$sale_data)
             ];
             $text = $this->token_lib->render($text, $tokens);
-            $sale_data['mimetype'] = mime_content_type(FCPATH . 'uploads/' . $this->config['company_logo']);
+            $sale_data['mimetype'] = $this->email_lib->getLogoMimeType();
 
             // Build img_tag for email views that need it (receipt_email.php)
-            $sale_data['img_tag'] = $this->_build_img_tag();
+            $sale_data['img_tag'] = $this->email_lib->buildLogoImgTag();
 
             // Generate email attachment: invoice in PDF format
             $view = Services::renderer();
@@ -977,7 +977,7 @@ class Sales extends Secure_Controller
 
         if (!empty($sale_data['customer_email'])) {
             $sale_data['barcode'] = $this->barcode_lib->generate_receipt_barcode($sale_data['sale_id']);
-            $sale_data['img_tag'] = $this->_build_img_tag();
+            $sale_data['img_tag'] = $this->email_lib->buildLogoImgTag();
 
             $to = $sale_data['customer_email'];
             $subject = lang('Sales.receipt');
@@ -1761,23 +1761,5 @@ class Sales extends Secure_Controller
         }
 
         return null;
-    }
-
-    /**
-     * Builds an img tag for the company logo to use in email templates.
-     *
-     * @return string HTML img tag with base64-encoded logo, or empty string if no logo
-     */
-    private function _build_img_tag(): string
-    {
-        $img_tag = '';
-        $logo_path = FCPATH . 'uploads/' . $this->config['company_logo'];
-
-        if (!empty($this->config['company_logo']) && file_exists($logo_path)) {
-            $logo_data = base64_encode(file_get_contents($logo_path));
-            $img_tag = '<img id="image" src="data:image/png;base64,' . $logo_data . '" alt="company_logo">';
-        }
-
-        return $img_tag;
     }
 }

--- a/app/Libraries/Email_lib.php
+++ b/app/Libraries/Email_lib.php
@@ -84,36 +84,38 @@ class Email_lib
     }
 
     /**
+     * Gets the mime type of the company logo file.
+     *
+     * @return string Mime type or empty string if logo doesn't exist
+     */
+    public function getLogoMimeType(): string
+    {
+        $logo_path = FCPATH . 'uploads/' . $this->config['company_logo'];
+
+        if (!empty($this->config['company_logo']) && file_exists($logo_path)) {
+            $mimeType = mime_content_type($logo_path);
+            return $mimeType !== false ? $mimeType : '';
+        }
+
+        return '';
+    }
+
+    /**
      * Builds an img tag for the company logo to use in email templates.
      *
      * @return string HTML img tag with base64-encoded logo, or empty string if no logo
      */
     public function buildLogoImgTag(): string
     {
-        $img_tag = '';
-        $logo_path = FCPATH . 'uploads/' . $this->config['company_logo'];
+        $mimeType = $this->getLogoMimeType();
 
-        if (!empty($this->config['company_logo']) && file_exists($logo_path)) {
-            $logo_data = base64_encode(file_get_contents($logo_path));
-            $img_tag = '<img id="image" src="data:image/png;base64,' . $logo_data . '" alt="company_logo">';
+        if ($mimeType === '') {
+            return '';
         }
 
-        return $img_tag;
-    }
-
-    /**
-     * Gets the mime type of the company logo file.
-     *
-     * @return string|false Mime type or false if logo doesn't exist
-     */
-    public function getLogoMimeType(): string|false
-    {
         $logo_path = FCPATH . 'uploads/' . $this->config['company_logo'];
+        $logo_data = base64_encode(file_get_contents($logo_path));
 
-        if (!empty($this->config['company_logo']) && file_exists($logo_path)) {
-            return mime_content_type($logo_path);
-        }
-
-        return false;
+        return '<img id="image" src="data:' . $mimeType . ';base64,' . $logo_data . '" alt="company_logo">';
     }
 }

--- a/app/Libraries/Email_lib.php
+++ b/app/Libraries/Email_lib.php
@@ -82,4 +82,38 @@ class Email_lib
 
         return $result;
     }
+
+    /**
+     * Builds an img tag for the company logo to use in email templates.
+     *
+     * @return string HTML img tag with base64-encoded logo, or empty string if no logo
+     */
+    public function buildLogoImgTag(): string
+    {
+        $img_tag = '';
+        $logo_path = FCPATH . 'uploads/' . $this->config['company_logo'];
+
+        if (!empty($this->config['company_logo']) && file_exists($logo_path)) {
+            $logo_data = base64_encode(file_get_contents($logo_path));
+            $img_tag = '<img id="image" src="data:image/png;base64,' . $logo_data . '" alt="company_logo">';
+        }
+
+        return $img_tag;
+    }
+
+    /**
+     * Gets the mime type of the company logo file.
+     *
+     * @return string|false Mime type or false if logo doesn't exist
+     */
+    public function getLogoMimeType(): string|false
+    {
+        $logo_path = FCPATH . 'uploads/' . $this->config['company_logo'];
+
+        if (!empty($this->config['company_logo']) && file_exists($logo_path)) {
+            return mime_content_type($logo_path);
+        }
+
+        return false;
+    }
 }


### PR DESCRIPTION
## Summary

Fixes a bug where sending a receipt email via `sales/sendPdf/{sale_id}/receipt` would fail with:
```
ErrorException: Undefined variable $img_tag
in APPPATH\Views\sales\receipt_email.php on line 22
```

## Root Cause

The `receipt_email.php` view expects an `$img_tag` variable containing the base64-encoded company logo:
```php
<div id="company_name">
    <?= $img_tag ?>
</div>
```

However, `Sales::getSendPdf()` method (which handles `sales/sendPdf/*/*` routes) did not set this variable before rendering receipt_email.php.

The `getSendReceipt()` method (which handles `sales/sendReceipt/*` route) correctly sets `$img_tag`, but this code was missing from `getSendPdf()`.

## Fix

Added the missing `$img_tag` initialization in `getSendPdf()` that mirrors the logic in `getSendReceipt()`:
- Initialize `$img_tag` to empty string
- If company logo exists, create the base64-encoded image tag

## Testing

1. Configure a company logo in OSPOS settings
2. Create a sale with a customer that has an email address
3. Use the "Send Receipt" functionality
4. Verify the email is sent successfully without error

## Related

Closes #4514

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Centralized company logo handling for emails and PDFs to improve consistency and maintainability.
  * PDF documents and receipt emails now embed the company logo more reliably, reducing missing or incorrect logo displays.
  * Email templates use standardized logo embedding, improving compatibility across mail clients.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->