### PR TITLE
fix: Catch mysqli_sql_exception in DB fallback handlers for fresh Docker installs

### DIFF
--- a/app/Config/OSPOS.php
+++ b/app/Config/OSPOS.php
@@ -5,7 +5,6 @@ namespace Config;
 use App\Models\Appconfig;
 use CodeIgniter\Cache\CacheInterface;
 use CodeIgniter\Config\BaseConfig;
-use CodeIgniter\Database\Exceptions\DatabaseException;
 
 /**
  * This class holds the configuration options stored from the database so that on launch those settings can be cached
@@ -41,9 +40,11 @@ class OSPOS extends BaseConfig
                     $this->settings[$app_config->key] = $app_config->value;
                 }
                 $this->cache->save('settings', encode_array($this->settings));
-            } catch (DatabaseException $e) {
+            } catch (\Throwable $e) {
                 // Database table doesn't exist yet (migrations haven't run)
-                // Return empty settings to allow migration page to display
+                // or database connection failed. Return empty settings to
+                // allow migration page to display. Catches mysqli_sql_exception
+                // which is not a subclass of DatabaseException.
                 $this->settings = [
                     'language' => 'english',
                     'language_code' => 'en',

--- a/app/Config/OSPOS.php
+++ b/app/Config/OSPOS.php
@@ -40,7 +40,7 @@ class OSPOS extends BaseConfig
                     $this->settings[$app_config->key] = $app_config->value;
                 }
                 $this->cache->save('settings', encode_array($this->settings));
-            } catch (\Throwable $e) {
+            } catch (\Exception $e) {
                 // Database table doesn't exist yet (migrations haven't run)
                 // or database connection failed. Return empty settings to
                 // allow migration page to display. Catches mysqli_sql_exception

--- a/app/Config/Session.php
+++ b/app/Config/Session.php
@@ -138,11 +138,11 @@ class Session extends BaseConfig
                     $this->driver = FileHandler::class;
                     $this->savePath = WRITEPATH . 'session';
                 }
-            } catch (\Throwable $e) {
+            } catch (\Exception $e) {
                 // Database not available yet (e.g. fresh install before migrations).
                 // Fall back to file-based sessions so the login/migration page
                 // can still be served. Catches mysqli_sql_exception which is
-                // not a subclass of DatabaseException.
+                // not a subclass of DatabaseException but is a RuntimeException.
                 $this->driver = FileHandler::class;
                 $this->savePath = WRITEPATH . 'session';
             }

--- a/app/Config/Session.php
+++ b/app/Config/Session.php
@@ -3,7 +3,6 @@
 namespace Config;
 
 use CodeIgniter\Config\BaseConfig;
-use CodeIgniter\Database\Exceptions\DatabaseException;
 use CodeIgniter\Session\Handlers\BaseHandler;
 use CodeIgniter\Session\Handlers\DatabaseHandler;
 use CodeIgniter\Session\Handlers\FileHandler;
@@ -139,7 +138,11 @@ class Session extends BaseConfig
                     $this->driver = FileHandler::class;
                     $this->savePath = WRITEPATH . 'session';
                 }
-            } catch (DatabaseException $e) {
+            } catch (\Throwable $e) {
+                // Database not available yet (e.g. fresh install before migrations).
+                // Fall back to file-based sessions so the login/migration page
+                // can still be served. Catches mysqli_sql_exception which is
+                // not a subclass of DatabaseException.
                 $this->driver = FileHandler::class;
                 $this->savePath = WRITEPATH . 'session';
             }

--- a/app/Libraries/MY_Migration.php
+++ b/app/Libraries/MY_Migration.php
@@ -2,7 +2,6 @@
 
 namespace App\Libraries;
 
-use CodeIgniter\Database\Exceptions\DatabaseException;
 use CodeIgniter\Database\MigrationRunner;
 use Config\Database;
 use stdClass;
@@ -44,7 +43,9 @@ class MY_Migration extends MigrationRunner
                 $result = $builder->get()->getRow();
                 return $result ? $result->version : 0;
             }
-        } catch (DatabaseException $e) {
+        } catch (\Throwable $e) {
+            // Database not available yet (e.g. fresh install before schema).
+            // Catches mysqli_sql_exception which is not a DatabaseException.
             return 0;
         }
 
@@ -76,8 +77,9 @@ class MY_Migration extends MigrationRunner
                 $result = $builder->get()->getRow();
                 return $result ? $result->version : false;
             }
-        } catch (DatabaseException $e) {
-            // Database doesn't exist yet or connection failed
+        } catch (\Throwable $e) {
+            // Database not available yet (e.g. fresh install before schema).
+            // Catches mysqli_sql_exception which is not a DatabaseException.
         }
 
         return false;

--- a/app/Libraries/MY_Migration.php
+++ b/app/Libraries/MY_Migration.php
@@ -43,7 +43,7 @@ class MY_Migration extends MigrationRunner
                 $result = $builder->get()->getRow();
                 return $result ? $result->version : 0;
             }
-        } catch (\Throwable $e) {
+        } catch (\Exception $e) {
             // Database not available yet (e.g. fresh install before schema).
             // Catches mysqli_sql_exception which is not a DatabaseException.
             return 0;
@@ -77,7 +77,7 @@ class MY_Migration extends MigrationRunner
                 $result = $builder->get()->getRow();
                 return $result ? $result->version : false;
             }
-        } catch (\Throwable $e) {
+        } catch (\Exception $e) {
             // Database not available yet (e.g. fresh install before schema).
             // Catches mysqli_sql_exception which is not a DatabaseException.
         }

--- a/app/Models/Item.php
+++ b/app/Models/Item.php
@@ -391,7 +391,6 @@ class Item extends Model
     public function get_item_id(string $item_number, bool $ignore_deleted = false, bool $deleted = false): bool|int
     {
         $builder = $this->db->table('items');
-        $builder->join('suppliers', 'suppliers.person_id = items.supplier_id', 'left');
         $builder->groupStart();
         $builder->where('item_number', $item_number);
         $builder->orWhere('item_id', $item_number);


### PR DESCRIPTION
## Summary

- Fixes HTTP 500 error on fresh Docker installs by catching `mysqli_sql_exception` (not just `DatabaseException`) in three database fallback handlers
- Removes unused `suppliers` LEFT JOIN in `Item::get_item_id()` per review feedback
- Narrows catch blocks from `\Throwable` to `\Exception` per review feedback
- Allows the login/migration page to render on first access so the initial schema migration can run

## Problem

On a fresh `docker compose up`, the database starts **completely empty** (no tables). The first HTTP request triggers this chain:

1. **CSRF filter** → calls `service('security')` → calls `service('session')`
2. **Session** → tries `DatabaseHandler::read()` on `ospos_sessions` table
3. **CRASH**: MySQLi throws `mysqli_sql_exception: Table 'ospos.ospos_sessions' doesn't exist`
4. **Result**: HTTP 500 — the login/migration page is never reached

The existing fallback code from PR #4467 catches `DatabaseException`, but MySQLi throws `mysqli_sql_exception` which extends `RuntimeException`, **not** `DatabaseException`. So the catch block never fires and the exception goes unhandled.

## Changes

### 1. Session.php — Catch `\Exception` instead of `DatabaseException`

When sessions can't use the database (no tables), fall back to `FileHandler` so the app can still serve the login/migration page.

### 2. OSPOS.php — Catch `\Exception` instead of `DatabaseException`

When `app_config` table doesn't exist, fall back to empty default settings.

### 3. MY_Migration.php — Catch `\Exception` in two places

When checking current schema version on an empty database, return `0`/`false` gracefully instead of crashing.

### 4. Item.php — Remove unused `suppliers` LEFT JOIN

The `get_item_id()` method LEFT JOINs `suppliers` but selects nothing from it and the WHERE clause doesn't reference it. This is pure overhead on a hot lookup path (called via `sale_lib->get_item_id()`). Per CodeRabbit review on PR #4520.

## Why `\Exception` instead of `\Throwable`

Per review feedback from CodeRabbit: `mysqli_sql_exception` extends `RuntimeException → Exception`, so `\Exception` is sufficient. Using `\Throwable` would unnecessarily mask programming errors like `TypeError` and `ValueError` that should surface during debugging.

## Testing

Reproduced the error with a fresh `docker compose up`:
```
ERROR - mysqli_sql_exception: Table 'ospos.ospos_sessions' doesn't exist
CRITICAL - Call to a member function getRow() on bool
```

Verified that the Session fallback to `FileHandler` correctly triggers with the `\Exception` catch, allowing the login page to render (HTTP 200).

Note: The current `jekkos/opensourcepos:master` Docker image doesn't include the PR #4467 Session fallback at all (127 lines vs 150), so it needs to be rebuilt. This fix will take effect once the image is updated.

## Related

- PR #4467 introduced the `DatabaseException` catch but didn't account for `mysqli_sql_exception`
- Issue #4524
- PR #4520 (items performance — also includes the `suppliers` JOIN removal)