### PR TITLE
fix(ci): include hidden files in Docker build context

### DIFF
--- a/.github/workflows/build-release.yml
+++ b/.github/workflows/build-release.yml
@@ -123,6 +123,7 @@ jobs:
             .
             !.git
             !node_modules
+          include-hidden-files: true
           retention-days: 1
 
   docker:


### PR DESCRIPTION
## Summary

Fixes #4541 (related to `.htaccess` missing in Docker container)

`actions/upload-artifact@v4` excludes hidden files (dotfiles) by default, causing `.htaccess` files to be missing from the Docker image. Without `.htaccess`, Apache doesn't apply rewrite rules, resulting in 404 errors on all routes except the front controller.

## Fix

Added `include-hidden-files: true` to the Docker build context artifact upload step.

## Test plan

- Build the Docker image via CI
- Verify `.htaccess` files exist at `/app/public/.htaccess` and `/app/.htaccess` in the container
- Verify Apache rewrite rules work (clean URLs, `/login/migrate` route, etc.)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved build context handling for Docker artifacts to ensure all necessary files are properly included during the build process.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/opensourcepos/opensourcepos/pull/4543)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->