### PR TITLE
fix(docker): correct permissions and fix migration barcode_type error

### DIFF
--- a/.github/workflows/build-release.yml
+++ b/.github/workflows/build-release.yml
@@ -123,6 +123,7 @@ jobs:
             .
             !.git
             !node_modules
+          include-hidden-files: true
           retention-days: 1
 
   docker:

--- a/Dockerfile
+++ b/Dockerfile
@@ -13,7 +13,8 @@ RUN echo "date.timezone = \"\${PHP_TIMEZONE}\"" > /usr/local/etc/php/conf.d/time
 
 WORKDIR /app
 COPY --chown=www-data:www-data . /app
-RUN chmod 770 /app/writable/uploads /app/writable/logs /app/writable/cache \
+RUN chmod 750 /app/writable/logs /app/writable/uploads /app/writable/cache /app/public/uploads /app/public/uploads/item_pics \
+    && chmod 640 /app/writable/uploads/importCustomers.csv \
     && ln -s /app/*[^public] /var/www \
     && rm -rf /var/www/html \
     && ln -nsf /app/public /var/www/html

--- a/app/Config/OSPOS.php
+++ b/app/Config/OSPOS.php
@@ -48,7 +48,8 @@ class OSPOS extends BaseConfig
                 $this->settings = [
                     'language' => 'english',
                     'language_code' => 'en',
-                    'company' => 'Home'
+                    'company' => 'Home',
+                    'barcode_type' => 'Code39'
                 ];
             }
         }


### PR DESCRIPTION
## Summary
- Fix Docker permissions for writable directories and public uploads
- Add `barcode_type` default to prevent "unknown key barcode_type" error during initial migration

## Details
### Permissions Fix
The Dockerfile now sets proper permissions (750) for:
- `/app/writable/logs`
- `/app/writable/uploads`
- `/app/writable/cache`
- `/app/public/uploads`
- `/app/public/uploads/item_pics`

And permissions (640) for:
- `/app/writable/uploads/importCustomers.csv`

### Migration Fix
During initial setup on fresh Docker containers, the database migration for converting barcode types fails with "unknown key barcode_type" because the `OSPOS` config class doesn't have a default value for `barcode_type` when the database is not yet initialized.

Added `'barcode_type' => 'Code39'` to the default settings fallback in `app/Config/OSPOS.php`.

## Testing
These fixes ensure:
1. Fresh Docker installations can complete initial migration without errors
2. Upload directories have correct permissions for the www-data user

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Enhanced Docker build artifact handling to include hidden files
  * Improved file permission security in containerized deployments
  * Added default barcode type configuration fallback

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/opensourcepos/opensourcepos/pull/4546)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->