### PR TITLE
Bugfixes to get Migration working on MySQL and MariaDB

### DIFF
--- a/app/Config/OSPOS.php
+++ b/app/Config/OSPOS.php
@@ -41,12 +41,7 @@ class OSPOS extends BaseConfig
             $db = Database::connect();
 
             if (!$db->tableExists('app_config')) {
-                $this->settings = [
-                    'language'      => 'english',
-                    'language_code' => 'en',
-                    'company'       => 'Home',
-                    'barcode_type'  => 'Code39'
-                ];
+                $this->settings = $this->getDefaultSettings();
                 return;
             }
 
@@ -56,13 +51,18 @@ class OSPOS extends BaseConfig
             }
             $this->cache->save('settings', encode_array($this->settings));
         } catch (\Exception $e) {
-            $this->settings = [
-                'language'      => 'english',
-                'language_code' => 'en',
-                'company'       => 'Home',
-                'barcode_type'  => 'Code39'
-            ];
+            $this->settings = $this->getDefaultSettings();
         }
+    }
+
+    private function getDefaultSettings(): array
+    {
+        return [
+            'language'      => 'english',
+            'language_code' => 'en',
+            'company'       => 'Home',
+            'barcode_type'  => 'Code39'
+        ];
     }
 
     /**

--- a/app/Config/OSPOS.php
+++ b/app/Config/OSPOS.php
@@ -14,7 +14,7 @@ use Config\Database;
  */
 class OSPOS extends BaseConfig
 {
-    public array $settings;
+    public array $settings = [];
     public string $commit_sha1 = 'dev';    // TODO: Travis scripts need to be updated to replace this with the commit hash on build
     private CacheInterface $cache;
 

--- a/app/Config/OSPOS.php
+++ b/app/Config/OSPOS.php
@@ -37,26 +37,25 @@ class OSPOS extends BaseConfig
             return;
         }
 
-        $db = Database::connect();
-
-        if (!$db->tableExists('app_config')) {
-            $this->settings = [
-                'language'      => 'english',
-                'language_code' => 'en',
-                'company'       => 'Home',
-                'barcode_type'  => 'Code39'
-            ];
-            return;
-        }
-
         try {
+            $db = Database::connect();
+
+            if (!$db->tableExists('app_config')) {
+                $this->settings = [
+                    'language'      => 'english',
+                    'language_code' => 'en',
+                    'company'       => 'Home',
+                    'barcode_type'  => 'Code39'
+                ];
+                return;
+            }
+
             $appconfig = model(Appconfig::class);
             foreach ($appconfig->get_all()->getResult() as $app_config) {
                 $this->settings[$app_config->key] = $app_config->value;
             }
             $this->cache->save('settings', encode_array($this->settings));
         } catch (\Exception $e) {
-            // Database connection failed (table-missing case handled above).
             $this->settings = [
                 'language'      => 'english',
                 'language_code' => 'en',

--- a/app/Config/OSPOS.php
+++ b/app/Config/OSPOS.php
@@ -5,6 +5,7 @@ namespace Config;
 use App\Models\Appconfig;
 use CodeIgniter\Cache\CacheInterface;
 use CodeIgniter\Config\BaseConfig;
+use Config\Database;
 
 /**
  * This class holds the configuration options stored from the database so that on launch those settings can be cached
@@ -33,25 +34,35 @@ class OSPOS extends BaseConfig
 
         if ($cache) {
             $this->settings = decode_array($cache);
-        } else {
-            try {
-                $appconfig = model(Appconfig::class);
-                foreach ($appconfig->get_all()->getResult() as $app_config) {
-                    $this->settings[$app_config->key] = $app_config->value;
-                }
-                $this->cache->save('settings', encode_array($this->settings));
-            } catch (\Exception $e) {
-                // Database table doesn't exist yet (migrations haven't run)
-                // or database connection failed. Return empty settings to
-                // allow migration page to display. Catches mysqli_sql_exception
-                // which is not a subclass of DatabaseException.
-                $this->settings = [
-                    'language' => 'english',
-                    'language_code' => 'en',
-                    'company' => 'Home',
-                    'barcode_type' => 'Code39'
-                ];
+            return;
+        }
+
+        $db = Database::connect();
+
+        if (!$db->tableExists('app_config')) {
+            $this->settings = [
+                'language'      => 'english',
+                'language_code' => 'en',
+                'company'       => 'Home',
+                'barcode_type'  => 'Code39'
+            ];
+            return;
+        }
+
+        try {
+            $appconfig = model(Appconfig::class);
+            foreach ($appconfig->get_all()->getResult() as $app_config) {
+                $this->settings[$app_config->key] = $app_config->value;
             }
+            $this->cache->save('settings', encode_array($this->settings));
+        } catch (\Exception $e) {
+            // Database connection failed (table-missing case handled above).
+            $this->settings = [
+                'language'      => 'english',
+                'language_code' => 'en',
+                'company'       => 'Home',
+                'barcode_type'  => 'Code39'
+            ];
         }
     }
 

--- a/app/Controllers/Login.php
+++ b/app/Controllers/Login.php
@@ -49,6 +49,13 @@ class Login extends BaseController
                 return view('login', $data);
             }
 
+            if (!$data['is_latest'] || $data['is_new_install']) {
+                set_time_limit(3600);
+
+                $migration->setNamespace('App')->latest();
+                return redirect()->to('login');
+            }
+
             $rules = ['username' => 'required|login_check[data]'];
             $messages = [
                 'username' => [
@@ -62,13 +69,6 @@ class Login extends BaseController
 
                 return view('login', $data);
             }
-
-            if (!$data['is_latest']) {
-                set_time_limit(3600);
-
-                $migration->setNamespace('App')->latest();
-                return redirect()->to('login');
-            }
         }
 
         return redirect()->to('home');
@@ -79,18 +79,18 @@ class Login extends BaseController
         try {
             $migration = new MY_Migration(config('Migrations'));
             $migration->migrate_to_ci4();
-            
+
             set_time_limit(3600);
             $migration->setNamespace('App')->latest();
-            
+
             return $this->response->setJSON([
                 'success' => true,
                 'message' => 'Migration completed successfully'
             ]);
-            
+
         } catch (\Exception $e) {
             log_message('error', 'Migration failed: ' . $e->getMessage());
-            
+
             return $this->response->setJSON([
                 'success' => false,
                 'message' => 'Migration failed: ' . $e->getMessage()

--- a/app/Database/Migrations/20170501150000_upgrade_to_3_1_1.php
+++ b/app/Database/Migrations/20170501150000_upgrade_to_3_1_1.php
@@ -2,6 +2,7 @@
 
 namespace App\Database\Migrations;
 
+use CodeIgniter\Database\Exceptions\DatabaseException;
 use CodeIgniter\Database\Migration;
 
 class Migration_Upgrade_To_3_1_1 extends Migration
@@ -41,7 +42,9 @@ class Migration_Upgrade_To_3_1_1 extends Migration
             }
         }
 
-        execute_script(APPPATH . 'Database/Migrations/sqlscripts/3.0.2_to_3.1.1.sql');
+        if (!execute_script(APPPATH . 'Database/Migrations/sqlscripts/3.0.2_to_3.1.1.sql')) {
+            throw new DatabaseException('Migration script 3.0.2_to_3.1.1.sql failed. Check logs for details.');
+        }
 
         $droppedTables = ['sales_suspended', 'sales_suspended_items', 'sales_suspended_items_taxes', 'sales_suspended_payments'];
         $toRecreate = array_filter($constraints, fn($c) => !in_array($c['tableName'], $droppedTables, true));

--- a/app/Database/Migrations/20170501150000_upgrade_to_3_1_1.php
+++ b/app/Database/Migrations/20170501150000_upgrade_to_3_1_1.php
@@ -17,7 +17,35 @@ class Migration_Upgrade_To_3_1_1 extends Migration
     public function up(): void
     {
         helper('migration');
+
+        // MariaDB blocks CONVERT TO CHARACTER SET on tables with FK constraints.
+        // Drop all FKs across affected tables before running the SQL script, recreate after.
+        $fkColumns = [
+            ['modules',         'module_id'],
+            ['stock_locations', 'location_id'],
+            ['permissions',     'permission_id'],
+            ['people',          'person_id'],
+            ['suppliers',       'supplier_id'],
+            ['items',           'item_id'],
+            ['item_kits',       'item_kit_id'],
+            ['sales',           'sale_id'],
+            ['receivings',      'receiving_id'],
+            ['employees',       'employee_id'],
+            ['customers',       'person_id'],
+        ];
+
+        $constraints = [];
+        foreach ($fkColumns as [$table, $column]) {
+            foreach (dropAllForeignKeyConstraints($table, $column) as $c) {
+                $constraints[$c['constraintName']] = $c;
+            }
+        }
+
         execute_script(APPPATH . 'Database/Migrations/sqlscripts/3.0.2_to_3.1.1.sql');
+
+        $droppedTables = ['sales_suspended', 'sales_suspended_items', 'sales_suspended_items_taxes', 'sales_suspended_payments'];
+        $toRecreate = array_filter($constraints, fn($c) => !in_array($c['tableName'], $droppedTables, true));
+        recreateForeignKeyConstraints(array_values($toRecreate));
     }
 
     /**

--- a/app/Database/Migrations/sqlscripts/3.0.2_to_3.1.1.sql
+++ b/app/Database/Migrations/sqlscripts/3.0.2_to_3.1.1.sql
@@ -327,19 +327,6 @@ INSERT INTO `ospos_sales_items` (sale_id, item_id, description, serialnumber, li
 INSERT INTO `ospos_sales_payments` (sale_id, payment_type, payment_amount) SELECT sale_id, payment_type, payment_amount FROM `ospos_sales_suspended_payments`;
 INSERT INTO `ospos_sales_items_taxes` (sale_id, item_id, line, name, percent) SELECT sale_id, item_id, line, name, percent FROM `ospos_sales_suspended_items_taxes`;
 
-ALTER TABLE `ospos_sales_suspended_payments` DROP FOREIGN KEY IF EXISTS `ospos_sales_suspended_payments_ibfk_1`;
-
-ALTER TABLE `ospos_sales_suspended_items_taxes` DROP FOREIGN KEY IF EXISTS `ospos_sales_suspended_items_taxes_ibfk_1`;
-ALTER TABLE `ospos_sales_suspended_items_taxes` DROP FOREIGN KEY IF EXISTS `ospos_sales_suspended_items_taxes_ibfk_2`;
-
-ALTER TABLE `ospos_sales_suspended_items` DROP FOREIGN KEY IF EXISTS `ospos_sales_suspended_items_ibfk_1`;
-ALTER TABLE `ospos_sales_suspended_items` DROP FOREIGN KEY IF EXISTS `ospos_sales_suspended_items_ibfk_2`;
-ALTER TABLE `ospos_sales_suspended_items` DROP FOREIGN KEY IF EXISTS `ospos_sales_suspended_items_ibfk_3`;
-
-ALTER TABLE `ospos_sales_suspended` DROP FOREIGN KEY IF EXISTS `ospos_sales_suspended_ibfk_1`;
-ALTER TABLE `ospos_sales_suspended` DROP FOREIGN KEY IF EXISTS `ospos_sales_suspended_ibfk_2`;
-ALTER TABLE `ospos_sales_suspended` DROP FOREIGN KEY IF EXISTS `ospos_sales_suspended_ibfk_3`;
-
 DROP TABLE `ospos_sales_suspended_payments`, `ospos_sales_suspended_items_taxes`, `ospos_sales_suspended_items`, `ospos_sales_suspended`;
 
 --

--- a/app/Database/Migrations/sqlscripts/3.0.2_to_3.1.1.sql
+++ b/app/Database/Migrations/sqlscripts/3.0.2_to_3.1.1.sql
@@ -327,18 +327,18 @@ INSERT INTO `ospos_sales_items` (sale_id, item_id, description, serialnumber, li
 INSERT INTO `ospos_sales_payments` (sale_id, payment_type, payment_amount) SELECT sale_id, payment_type, payment_amount FROM `ospos_sales_suspended_payments`;
 INSERT INTO `ospos_sales_items_taxes` (sale_id, item_id, line, name, percent) SELECT sale_id, item_id, line, name, percent FROM `ospos_sales_suspended_items_taxes`;
 
-ALTER TABLE `ospos_sales_suspended_payments` DROP FOREIGN KEY `ospos_sales_suspended_payments_ibfk_1`;
+ALTER TABLE `ospos_sales_suspended_payments` DROP FOREIGN KEY IF EXISTS `ospos_sales_suspended_payments_ibfk_1`;
 
-ALTER TABLE `ospos_sales_suspended_items_taxes` DROP FOREIGN KEY `ospos_sales_suspended_items_taxes_ibfk_1`;
-ALTER TABLE `ospos_sales_suspended_items_taxes` DROP FOREIGN KEY `ospos_sales_suspended_items_taxes_ibfk_2`;
+ALTER TABLE `ospos_sales_suspended_items_taxes` DROP FOREIGN KEY IF EXISTS `ospos_sales_suspended_items_taxes_ibfk_1`;
+ALTER TABLE `ospos_sales_suspended_items_taxes` DROP FOREIGN KEY IF EXISTS `ospos_sales_suspended_items_taxes_ibfk_2`;
 
-ALTER TABLE `ospos_sales_suspended_items` DROP FOREIGN KEY `ospos_sales_suspended_items_ibfk_1`;
-ALTER TABLE `ospos_sales_suspended_items` DROP FOREIGN KEY `ospos_sales_suspended_items_ibfk_2`;
-ALTER TABLE `ospos_sales_suspended_items` DROP FOREIGN KEY `ospos_sales_suspended_items_ibfk_3`;
+ALTER TABLE `ospos_sales_suspended_items` DROP FOREIGN KEY IF EXISTS `ospos_sales_suspended_items_ibfk_1`;
+ALTER TABLE `ospos_sales_suspended_items` DROP FOREIGN KEY IF EXISTS `ospos_sales_suspended_items_ibfk_2`;
+ALTER TABLE `ospos_sales_suspended_items` DROP FOREIGN KEY IF EXISTS `ospos_sales_suspended_items_ibfk_3`;
 
-ALTER TABLE `ospos_sales_suspended` DROP FOREIGN KEY `ospos_sales_suspended_ibfk_1`;
-ALTER TABLE `ospos_sales_suspended` DROP FOREIGN KEY `ospos_sales_suspended_ibfk_2`;
-ALTER TABLE `ospos_sales_suspended` DROP FOREIGN KEY `ospos_sales_suspended_ibfk_3`;
+ALTER TABLE `ospos_sales_suspended` DROP FOREIGN KEY IF EXISTS `ospos_sales_suspended_ibfk_1`;
+ALTER TABLE `ospos_sales_suspended` DROP FOREIGN KEY IF EXISTS `ospos_sales_suspended_ibfk_2`;
+ALTER TABLE `ospos_sales_suspended` DROP FOREIGN KEY IF EXISTS `ospos_sales_suspended_ibfk_3`;
 
 DROP TABLE `ospos_sales_suspended_payments`, `ospos_sales_suspended_items_taxes`, `ospos_sales_suspended_items`, `ospos_sales_suspended`;
 

--- a/app/Database/Migrations/sqlscripts/3.1.1_to_3.2.0.sql
+++ b/app/Database/Migrations/sqlscripts/3.1.1_to_3.2.0.sql
@@ -140,7 +140,7 @@ CREATE TABLE IF NOT EXISTS `ospos_expense_categories` (
   `category_name` varchar(255) DEFAULT NULL,
   `category_description` varchar(255) NOT NULL,
   `deleted` int(1) NOT NULL DEFAULT '0'
-) ENGINE=InnoDB DEFAULT CHARSET=utf8;
+) ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_general_ci;
 
 
 -- Table structure for table `ospos_expenses`
@@ -154,7 +154,7 @@ CREATE TABLE IF NOT EXISTS `ospos_expenses` (
   `description` varchar(255) NOT NULL,
   `employee_id` int(10) NOT NULL,
   `deleted` int(1) NOT NULL DEFAULT '0'
-) ENGINE=InnoDB DEFAULT CHARSET=utf8;
+) ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_general_ci;
 
 
 -- Indexes for table `ospos_expense_categories`

--- a/app/Database/Migrations/sqlscripts/3.2.1_to_3.3.0.sql
+++ b/app/Database/Migrations/sqlscripts/3.2.1_to_3.3.0.sql
@@ -75,7 +75,7 @@ CREATE TABLE `ospos_cash_up` (
   `open_employee_id` int(10) NOT NULL,
   `close_employee_id` int(10) NOT NULL,
   `deleted` int(1) NOT NULL DEFAULT '0'
-) ENGINE=InnoDB DEFAULT CHARSET=utf8;
+) ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_general_ci;
 
 -- Indexes for table `ospos_cash_up`
 

--- a/app/Database/Migrations/sqlscripts/3.3.0_indiagst.sql
+++ b/app/Database/Migrations/sqlscripts/3.3.0_indiagst.sql
@@ -26,7 +26,7 @@ CREATE TABLE IF NOT EXISTS `ospos_tax_codes` (
     `state` varchar(255) NOT NULL DEFAULT '',
     `deleted` int(1) NOT NULL DEFAULT 0,
     PRIMARY KEY (`tax_code_id`)
-) ENGINE=InnoDB DEFAULT CHARSET=utf8;
+) ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_general_ci;
 
 ALTER TABLE `ospos_customers`
     ADD COLUMN `tax_id` varchar(32) NOT NULL DEFAULT '' AFTER `taxable`,
@@ -59,7 +59,7 @@ CREATE TABLE `ospos_sales_taxes` (
     `rounding_code` tinyint(2) NOT NULL DEFAULT 0,
     PRIMARY KEY (`sales_taxes_id`),
     KEY `print_sequence` (`sale_id`,`print_sequence`,`tax_group`)
-) ENGINE=InnoDB DEFAULT CHARSET=utf8;
+) ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_general_ci;
 
 CREATE TABLE IF NOT EXISTS `ospos_tax_jurisdictions` (
     `jurisdiction_id` int(11) NOT NULL AUTO_INCREMENT,
@@ -71,7 +71,7 @@ CREATE TABLE IF NOT EXISTS `ospos_tax_jurisdictions` (
     `cascade_sequence` tinyint(2) NOT NULL DEFAULT 0,
     `deleted` int(1) NOT NULL DEFAULT 0,
     PRIMARY KEY (`jurisdiction_id`)
-) ENGINE=InnoDB DEFAULT CHARSET=utf8 AUTO_INCREMENT=1;
+) ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_general_ci AUTO_INCREMENT=1;
 
 ALTER TABLE `ospos_suppliers`
     ADD COLUMN `tax_id` varchar(32) DEFAULT NULL AFTER `account_number`;
@@ -89,7 +89,7 @@ CREATE TABLE IF NOT EXISTS `ospos_tax_rates` (
     `tax_rate` decimal(15,4) NOT NULL DEFAULT 0.0000,
     `tax_rounding_code` tinyint(2) NOT NULL DEFAULT 0,
     PRIMARY KEY (`tax_rate_id`)
-) ENGINE=InnoDB DEFAULT CHARSET=utf8;
+) ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_general_ci;
 
 -- Add support for sales tax report
 

--- a/app/Database/Migrations/sqlscripts/3.3.0_paymenttracking.sql
+++ b/app/Database/Migrations/sqlscripts/3.3.0_paymenttracking.sql
@@ -12,7 +12,7 @@ CREATE TABLE `ospos_sales_payments` (
   `reference_code` varchar(40) NOT NULL DEFAULT '',
   PRIMARY KEY (`payment_id`),
   KEY `payment_sale` (`sale_id`, `payment_type`)
-) ENGINE=InnoDB DEFAULT CHARSET=utf8;
+) ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_general_ci;
 
 INSERT INTO ospos_sales_payments (sale_id, payment_type, payment_amount, payment_user)
 SELECT payments.sale_id, payments.payment_type, payments.payment_amount, sales.employee_id

--- a/app/Helpers/migration_helper.php
+++ b/app/Helpers/migration_helper.php
@@ -172,6 +172,7 @@ function dropAllForeignKeyConstraints(string $table, string $column): array {
             WHERE kcu.TABLE_SCHEMA = DATABASE()
                 AND ((kcu.REFERENCED_TABLE_NAME = '" . $db->getPrefix() . "$table' AND kcu.REFERENCED_COLUMN_NAME = '$column')
                 OR (kcu.TABLE_NAME = '" . $db->getPrefix() . "$table' AND kcu.COLUMN_NAME = '$column'))
+                AND rc.CONSTRAINT_NAME IS NOT NULL
         ");
 
     $deletedConstraints = [];


### PR DESCRIPTION
This PR fixes issues in two different categories:
1 Bugs affecting both MySQL and MariaDB migrations.
- A bug causing ospos_appconfig to be queried when it doesn't  exist. Added a bypass.
- username validation in Login view was causing an error when no tables existed because no username was listed. Added a bypass.

2 Bugs not affecting MySQL but affecting MariaDB.  MariaDB is inherently pickier about some things and checks were not accounting for these in the migrations. Checks and dropping of foreign keys were added before making changes.  These migrations are normally frozen, but this is a breaking change, so we have no choice but to fix them in situ.

It's possible that older versions of MariaDB were not this picky, so the breaking changes are coming with 11.8.3, but that's unclear to me.

MariaDB 11.8 changed the default implicit character set to uca1400, so when some of our migrations specify utf8 without the collation MariaDB implies uca1400 and that breaks things.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Expense tracking with categories and full management
  * India GST support with jurisdiction/rate/tax updates
  * Work-order number tracking on sales and enhanced payment tracking
  * Per-employee language selection and office/home menu grouping
  * New app settings for search suggestions, duplicate-barcode allowance, and default quote comment

* **Bug Fixes**
  * Improved migration robustness and foreign-key handling
  * Ensured migration check occurs before login when needed

* **Chores**
  * Improved configuration caching with safe defaults on failure

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/opensourcepos/opensourcepos/pull/4551?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->