### PR TITLE
Bugfix: Sale search in register not handling trailing space properly

### DIFF
--- a/app/Controllers/Sales.php
+++ b/app/Controllers/Sales.php
@@ -161,7 +161,7 @@ class Sales extends Secure_Controller
             'only_bank_transfer'=> false,
             'only_wallet'       => false,
             'only_invoices'     => $this->config['invoice_enable'] && $this->request->getGet('only_invoices', FILTER_SANITIZE_NUMBER_INT),
-            'is_valid_receipt'  => $this->sale->is_valid_receipt($search)
+            'is_valid_receipt'  => $this->sale->isValidReceipt($search)
         ];
 
         // Check if any filter is set in the multiselect dropdown
@@ -198,7 +198,7 @@ class Sales extends Secure_Controller
             ? $this->request->getGet('term')
             : null;
 
-        if ($this->sale_lib->get_mode() == 'return' && $this->sale->is_valid_receipt($receipt)) {
+        if ($this->sale_lib->get_mode() == 'return' && $this->sale->isValidReceipt($receipt)) {
             // If a valid receipt or invoice was found the search term will be replaced with a receipt number (POS #)
             $suggestions[] = $receipt;
         }
@@ -525,7 +525,7 @@ class Sales extends Secure_Controller
         $quantity = ($mode == 'return') ? -$quantity : $quantity;
         $item_location = $this->sale_lib->get_sale_location();
 
-        if ($mode == 'return' && $this->sale->is_valid_receipt($item_id_or_number_or_item_kit_or_receipt)) {
+        if ($mode == 'return' && $this->sale->isValidReceipt($item_id_or_number_or_item_kit_or_receipt)) {
             $this->sale_lib->return_entire_sale($item_id_or_number_or_item_kit_or_receipt);
         } elseif ($this->item_kit->is_valid_item_kit($item_id_or_number_or_item_kit_or_receipt)) {
             // Add kit item to order if one is assigned

--- a/app/Models/Sale.php
+++ b/app/Models/Sale.php
@@ -416,7 +416,7 @@ class Sale extends Model
             // POS #
             $pieces = explode(' ', trim($receiptSaleId));
 
-            if (count($pieces) == 2 && preg_match('/(POS)/i', $pieces[0]) && ctype_digit($pieces[1])) {
+            if (count($pieces) == 2 && strtoupper($pieces[0]) === 'POS' && ctype_digit($pieces[1])) {
                 return $this->exists((int)$pieces[1]);
             } elseif ($config['invoice_enable']) {
                 $saleInfo = $this->get_sale_by_invoice_number($receiptSaleId);

--- a/app/Models/Sale.php
+++ b/app/Models/Sale.php
@@ -327,7 +327,7 @@ class Sale extends Model
     {
         $suggestions = [];
 
-        if (!$this->is_valid_receipt($search)) {
+        if (!$this->isValidReceipt($search)) {
             $builder = $this->db->table('sales');
             $builder->distinct()->select('first_name, last_name');
             $builder->join('people', 'people.person_id = sales.customer_id');
@@ -408,21 +408,21 @@ class Sale extends Model
     /**
      * Checks if valid receipt
      */
-    public function is_valid_receipt(string|null &$receipt_sale_id): bool    // TODO: like the others, maybe this should be an array rather than a delimited string... either that or the parameter name needs to be changed. $receipt_sale_id implies that it's an int.
+    public function isValidReceipt(string|null &$receiptSaleId): bool    // TODO: like the others, maybe this should be an array rather than a delimited string... either that or the parameter name needs to be changed. $receipt_sale_id implies that it's an int.
     {
         $config = config(OSPOS::class)->settings;
 
-        if (!empty($receipt_sale_id)) {
+        if (!empty($receiptSaleId)) {
             // POS #
-            $pieces = explode(' ', $receipt_sale_id);
+            $pieces = explode(' ', trim($receiptSaleId));
 
-            if (count($pieces) == 2 && preg_match('/(POS)/i', $pieces[0])) {
-                return $this->exists($pieces[1]);
+            if (count($pieces) == 2 && preg_match('/(POS)/i', $pieces[0]) && ctype_digit($pieces[1])) {
+                return $this->exists((int)$pieces[1]);
             } elseif ($config['invoice_enable']) {
-                $sale_info = $this->get_sale_by_invoice_number($receipt_sale_id);
+                $saleInfo = $this->get_sale_by_invoice_number($receiptSaleId);
 
-                if ($sale_info->getNumRows() > 0) {
-                    $receipt_sale_id = 'POS ' . $sale_info->getRow()->sale_id;
+                if ($saleInfo->getNumRows() > 0) {
+                    $receiptSaleId = 'POS ' . $saleInfo->getRow()->sale_id;
 
                     return true;
                 }


### PR DESCRIPTION
Searching for `POS ` produces

```
CRITICAL - 2026-05-21 23:57:03 --> TypeError: App\Models\Sale::exists(): Argument #1 ($sale_id) must be of type int, string given, called in C:\Users\objec\PhpstormProjects\opensourcepos\app\Models\Sale.php on line 420
[Method: GET, Route: sales/itemSearch]
in APPPATH\Models\Sale.php on line 438.
 1 APPPATH\Models\Sale.php(420): App\Models\Sale->exists('')
 2 APPPATH\Controllers\Sales.php(202): App\Models\Sale->is_valid_receipt('POS ')
 3 SYSTEMPATH\CodeIgniter.php(951): App\Controllers\Sales->getItemSearch()
 4 SYSTEMPATH\CodeIgniter.php(497): CodeIgniter\CodeIgniter->runController(Object(App\Controllers\Sales))
 5 SYSTEMPATH\CodeIgniter.php(340): CodeIgniter\CodeIgniter->handleRequest(null, Object(Config\Cache), false)
 6 SYSTEMPATH\Boot.php(417): CodeIgniter\CodeIgniter->run()
 7 SYSTEMPATH\Boot.php(68): CodeIgniter\Boot::runCodeIgniter(Object(CodeIgniter\CodeIgniter))
 8 FCPATH\index.php(59): CodeIgniter\Boot::bootWeb(Object(Config\Paths))
```

This is because `Sale::exists()` was being passed ` ` which is a string and it's expecting an integer. These changes guard against trailing whitespace and non-numerics being passed to `Sale::exists()`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Stricter receipt validation that more accurately parses POS-prefixed receipts, improving reliability of receipt lookups in searches and return operations.
  * Receipt inputs are now normalized when found via invoice lookup, reducing mismatches and improving consistency when adding items in return mode.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/opensourcepos/opensourcepos/pull/4557?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->