### PR TITLE
fix: cast string returns to int in MY_Migration

### DIFF
--- a/app/Libraries/MY_Migration.php
+++ b/app/Libraries/MY_Migration.php
@@ -25,7 +25,7 @@ class MY_Migration extends MigrationRunner
     public function get_latest_migration(): int
     {
         $migrations = $this->findMigrations();
-        return basename(end($migrations)->version);
+        return (int) basename(end($migrations)->version);
     }
 
     /**
@@ -41,7 +41,7 @@ class MY_Migration extends MigrationRunner
                 $builder = $db->table('migrations');
                 $builder->select('version')->orderBy('version', 'DESC')->limit(1);
                 $result = $builder->get()->getRow();
-                return $result ? $result->version : 0;
+                return $result ? (int) $result->version : 0;
             }
         } catch (\Exception $e) {
             // Database not available yet (e.g. fresh install before schema).


### PR DESCRIPTION
## Summary

- Cast `basename()` return to `(int)` in `get_latest_migration()` — `basename()` always returns a string, but the method declares `int` return type
- Cast `$result->version` to `(int)` in `get_current_version()` — database column values are strings, but the method declares `int` return type

Fixes #4559

## Root Cause

PHP 8.0+ enforces strict return types. On older PHP versions, strings were silently coerced to int. On PHP 8.4 (as used in the Docker image), `basename()` returning `"20240101000000"` and `$result->version` returning a string from MariaDB both throw `TypeError` when the function declares `: int` as return type.

This affects **fresh installs** most severely because `get_latest_migration()` is called early in the migration setup flow.

## How to Test

- Fresh install on PHP 8.4 with MariaDB (the reported scenario)
- Verify login page loads without TypeError
- Verify migration runs successfully

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved migration version handling to ensure consistent data type processing, preventing potential issues with version comparison and migration execution.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/opensourcepos/opensourcepos/pull/4560?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->