### PR TITLE
Add fallback for allowedHostnames environment variable

### DIFF
--- a/app/Config/App.php
+++ b/app/Config/App.php
@@ -286,18 +286,10 @@ class App extends BaseConfig
 
         // Solution for CodeIgniter 4 limitation: arrays cannot be set from .env
         // See: https://github.com/codeigniter4/CodeIgniter4/issues/7311
-        // Support both: app.allowedHostnames (from .env) and ALLOWED_HOSTNAMES (from environment/Docker)
-        $envAllowedHostnames = getenv('ALLOWED_HOSTNAMES');
-        if ($envAllowedHostnames === false || trim($envAllowedHostnames) === '') {
-            $envAllowedHostnames = $_ENV['ALLOWED_HOSTNAMES'] ?? $_SERVER['ALLOWED_HOSTNAMES'] ?? false;
-        }
-        if ($envAllowedHostnames === false || trim($envAllowedHostnames) === '') {
-            $envAllowedHostnames = getenv('app.allowedHostnames');
-        }
-        if ($envAllowedHostnames === false || trim($envAllowedHostnames) === '') {
-            $envAllowedHostnames = $_ENV['app.allowedHostnames'] ?? $_SERVER['app.allowedHostnames'] ?? false;
-        }
-        if ($envAllowedHostnames !== false && trim($envAllowedHostnames) !== '') {
+        $envAllowedHostnames = $this->getEnvString('ALLOWED_HOSTNAMES')
+            ?? $this->getEnvString('app.allowedHostnames');
+
+        if ($envAllowedHostnames !== null) {
             $this->allowedHostnames = array_values(array_filter(
                 array_map('trim', explode(',', $envAllowedHostnames)),
                 static fn (string $hostname): bool => $hostname !== ''
@@ -362,5 +354,21 @@ class App extends BaseConfig
         );
 
         return $this->allowedHostnames[0];
+    }
+
+    private function getEnvString(string $key): ?string
+    {
+        $value = env($key);
+
+        if (is_string($value) && trim($value) !== '') {
+            return $value;
+        }
+
+        $raw = $_ENV[$key] ?? $_SERVER[$key] ?? getenv($key);
+        if (is_string($raw) && trim($raw) !== '') {
+            return $raw;
+        }
+
+        return null;
     }
 }

--- a/app/Config/App.php
+++ b/app/Config/App.php
@@ -60,7 +60,7 @@ class App extends BaseConfig
      *
      * Or via environment variable (useful for Docker/Compose):
      *   ALLOWED_HOSTNAMES=example.com,www.example.com
-     * 
+     *
      *     ['media.example.com', 'accounts.example.com']
      *
      * @var list<string>
@@ -289,7 +289,13 @@ class App extends BaseConfig
         // Support both: app.allowedHostnames (from .env) and ALLOWED_HOSTNAMES (from environment/Docker)
         $envAllowedHostnames = getenv('ALLOWED_HOSTNAMES');
         if ($envAllowedHostnames === false || trim($envAllowedHostnames) === '') {
+            $envAllowedHostnames = $_ENV['ALLOWED_HOSTNAMES'] ?? $_SERVER['ALLOWED_HOSTNAMES'] ?? false;
+        }
+        if ($envAllowedHostnames === false || trim($envAllowedHostnames) === '') {
             $envAllowedHostnames = getenv('app.allowedHostnames');
+        }
+        if ($envAllowedHostnames === false || trim($envAllowedHostnames) === '') {
+            $envAllowedHostnames = $_ENV['app.allowedHostnames'] ?? $_SERVER['app.allowedHostnames'] ?? false;
         }
         if ($envAllowedHostnames !== false && trim($envAllowedHostnames) !== '') {
             $this->allowedHostnames = array_values(array_filter(

--- a/tests/Config/AppTest.php
+++ b/tests/Config/AppTest.php
@@ -391,4 +391,52 @@ class AppTest extends CIUnitTestCase
         // Clean up
         putenv('ALLOWED_HOSTNAMES');
     }
+
+    public function testEnvAllowedHostnamesLiteralFalse(): void
+    {
+        putenv('app.allowedHostnames=false');
+
+        $_SERVER['HTTP_HOST'] = 'false';
+        $_SERVER['SCRIPT_NAME'] = '/index.php';
+        $_SERVER['HTTPS'] = null;
+
+        $app = new App();
+
+        $this->assertEquals(['false'], $app->allowedHostnames);
+
+        putenv('app.allowedHostnames');
+    }
+
+    public function testEnvAllowedHostnamesLiteralNull(): void
+    {
+        putenv('app.allowedHostnames=null');
+
+        $_SERVER['HTTP_HOST'] = 'null';
+        $_SERVER['SCRIPT_NAME'] = '/index.php';
+        $_SERVER['HTTPS'] = null;
+
+        $app = new App();
+
+        $this->assertEquals(['null'], $app->allowedHostnames);
+
+        putenv('app.allowedHostnames');
+    }
+
+    public function testEnvAllowedHostnamesWhitespaceOnly(): void
+    {
+        putenv('app.allowedHostnames=   ');
+        putenv('CI_ENVIRONMENT=development');
+
+        $_SERVER['HTTP_HOST'] = 'example.com';
+        $_SERVER['SCRIPT_NAME'] = '/index.php';
+        $_SERVER['HTTPS'] = null;
+
+        $app = new App();
+
+        $this->assertEquals([], $app->allowedHostnames);
+        $this->assertStringContainsString('localhost', $app->baseURL);
+
+        putenv('app.allowedHostnames');
+        putenv('CI_ENVIRONMENT');
+    }
 }

--- a/tests/Config/AppTest.php
+++ b/tests/Config/AppTest.php
@@ -10,6 +10,10 @@ class AppTest extends CIUnitTestCase
     protected function setUp(): void
     {
         parent::setUp();
+        putenv('app.allowedHostnames');
+        putenv('ALLOWED_HOSTNAMES');
+        unset($_ENV['app.allowedHostnames'], $_ENV['ALLOWED_HOSTNAMES']);
+        unset($_SERVER['app.allowedHostnames'], $_SERVER['ALLOWED_HOSTNAMES']);
     }
 
     protected function tearDown(): void
@@ -20,13 +24,16 @@ class AppTest extends CIUnitTestCase
         putenv('app.allowedHostnames');
         putenv('ALLOWED_HOSTNAMES');
         unset($_SERVER['HTTP_HOST']);
+        unset($_ENV['app.allowedHostnames'], $_ENV['ALLOWED_HOSTNAMES']);
+        unset($_SERVER['app.allowedHostnames'], $_SERVER['ALLOWED_HOSTNAMES']);
+        $_SERVER['CI_ENVIRONMENT'] = 'testing';
     }
 
     public function testGetValidHostReturnsHostWhenValid(): void
     {
         $app = new class extends App {
             public array $allowedHostnames = ['example.com', 'www.example.com'];
-            
+
             public function __construct() {}
         };
 
@@ -47,7 +54,7 @@ class AppTest extends CIUnitTestCase
     {
         $app = new class extends App {
             public array $allowedHostnames = ['example.com', 'www.example.com'];
-            
+
             public function __construct() {}
         };
 
@@ -71,7 +78,7 @@ class AppTest extends CIUnitTestCase
 
         $app = new class extends App {
             public array $allowedHostnames = [];
-            
+
             public function __construct() {}
         };
 
@@ -93,12 +100,12 @@ class AppTest extends CIUnitTestCase
         $this->expectException(\RuntimeException::class);
         $this->expectExceptionMessage('allowedHostnames is not configured');
 
-        // Set production environment
+        $_SERVER['CI_ENVIRONMENT'] = 'production';
         putenv('CI_ENVIRONMENT=production');
 
         $app = new class extends App {
             public array $allowedHostnames = [];
-            
+
             public function __construct() {}
         };
 
@@ -114,7 +121,7 @@ class AppTest extends CIUnitTestCase
     {
         $app = new class extends App {
             public array $allowedHostnames = ['example.com'];
-            
+
             public function __construct() {}
         };
 


### PR DESCRIPTION
Bug: getenv('app.allowedHostnames') returns false intermittently even though .env has it set.

Key insight from DotEnv.php line 97:

if (getenv($name, true) === false) {
    putenv("{$name}={$value}");
}

Guard skips putenv if value already exists. But App.php line 292 uses getenv('app.allowedHostnames') without true flag. Different lookup path.

More importantly — App.php reads getenv() but never checks $_ENV or $_SERVER. DotEnv always sets those. So fix: make App.php check $_ENV/$_SERVER too.

Let me check one more thing to confirm the intermittency source.

Run Command
Confirm getenv misses $_ENV/$_SERVER values
Confirmed. When putenv is skipped (guard on line 97), getenv() returns false — even though $_ENV and $_SERVER have value.

Fix: App.php constructor should check $_ENV/$_SERVER as fallbacks, not rely solely on getenv().

Now writing plan.

Write File
i-got-this-error-drifting-riddle.md
CONTENT
# Fix: allowedHostnames intermittently not read from .env

## Context

Error log shows `allowedHostnames is not configured` even though `.env` has `app.allowedHostnames = 'localhost'`. Happens intermittently.

**Root cause:** CI4's DotEnv `setVariable()` has a guard (line 97) that skips `putenv()` if `getenv($name, true)` already returns a value. When `putenv` is skipped, `getenv()` (without `true`) returns `false` — it can't see values only in `$_ENV`/`$_SERVER`. But DotEnv always sets `$_ENV` and `$_SERVER`.

App.php constructor (line 290-292) only checks `getenv()`, never `$_ENV`/`$_SERVER`. So when the `putenv` guard triggers, `getenv('app.allowedHostnames')` returns `false` and allowedHostnames stays empty.

## Fix

**File:** `app/Config/App.php` (lines 290-293)

Change the env reading to also check `$_ENV` and `$_SERVER` as fallbacks, matching how CI4's own DotEnv stores values.

Replace:
```php
$envAllowedHostnames = getenv('ALLOWED_HOSTNAMES');
if ($envAllowedHostnames === false || trim($envAllowedHostnames) === '') {
    $envAllowedHostnames = getenv('app.allowedHostnames');
}
```

With:
```php
$envAllowedHostnames = getenv('ALLOWED_HOSTNAMES');
if ($envAllowedHostnames === false || trim($envAllowedHostnames) === '') {
    $envAllowedHostnames = $_ENV['ALLOWED_HOSTNAMES'] ?? $_SERVER['ALLOWED_HOSTNAMES'] ?? false;
}
if ($envAllowedHostnames === false || trim($envAllowedHostnames) === '') {
    $envAllowedHostnames = getenv('app.allowedHostnames');
}
if ($envAllowedHostnames === false || trim($envAllowedHostnames) === '') {
    $envAllowedHostnames = $_ENV['app.allowedHostnames'] ?? $_SERVER['app.allowedHostnames'] ?? false;
}
```

## Verification

1. Run existing tests: `vendor/bin/phpunit tests/Config/AppTest.php`
2. Verify error no longer appears in log on page load
Tool Search
QUERY
select:ExitPlanMode
MAX_RESULTS
1
Root cause confirmed: getenv() returns false when putenv was skipped by DotEnv's guard, even though $_ENV/$_SERVER have the value. Intermittent because it depends on whether a previous request in same PHP worker already called putenv for that key.

Fix: check $_ENV/$_SERVER as fallbacks in App.php constructor.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * More robust parsing and normalization of hostname environment values, including proper handling of empty, falsey, or whitespace-only inputs and multi-source environment lookups.
* **Tests**
  * Expanded test coverage for hostname/env parsing and production-environment behavior to prevent regressions.
* **Documentation**
  * Minor formatting updates to hostname configuration docs.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/opensourcepos/opensourcepos/pull/4565?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->