### PR TITLE
Fix: Allow searching by Sale ID in Takings/Daily Sales view

### DIFF
--- a/app/Models/Sale.php
+++ b/app/Models/Sale.php
@@ -237,6 +237,9 @@ class Sale extends Model
                 $builder->orLike('customer_p.first_name', $search);    // Customer first name
                 $builder->orLike('CONCAT(customer_p.first_name, " ", customer_p.last_name)', $search);    // Customer first and last name
                 $builder->orLike('customer.company_name', $search);    // Customer company name
+                if (ctype_digit($search)) {
+                    $builder->orWhere('sales.sale_id', $search);    // Sale ID
+                }
                 $builder->groupEnd();
             }
         }
@@ -1477,6 +1480,9 @@ class Sale extends Model
                 $builder->orLike('CONCAT(customer_p.first_name, " ", customer_p.last_name)', $search);
                 // Customer company name
                 $builder->orLike('customer.company_name', $search);
+                if (ctype_digit($search)) {
+                    $builder->orWhere('sales.sale_id', $search);    // Sale ID
+                }
                 $builder->groupEnd();
             }
         }


### PR DESCRIPTION
## Summary

Fixes #4567 - Searching by Sale ID in the Takings/Daily Sales view now returns results.

## Problem

When a user searches for a Sale by ID (e.g., "123") in the Takings view, no results are returned. The search only works with customer names or the "POS 123" format.

## Root Cause

The `is_valid_receipt()` method only recognizes:
- "POS ####" format (e.g., "POS 123")
- Invoice numbers (when invoice feature is enabled)

Plain numeric Sale IDs like "123" return `false` from `is_valid_receipt()`, causing the search to fall through to the customer name search branch, which doesn't include `sale_id` in its WHERE clause.

## Fix

Added `sale_id` to the search conditions when the search term is purely numeric (`ctype_digit()` check). This allows users to search directly by Sale ID while maintaining backward compatibility with existing search patterns.

### Changes
- Modified `app/Models/Sale.php`:
  - Added sale_id search in `search()` method (line 230-245)
  - Added sale_id search in `add_filters_to_query()` method (line 1469-1488) - duplicate code noted with TODO

## Testing

Please verify:
1. Search for a Sale ID (e.g., "123") - should return the specific sale
2. Search for "POS 123" - should still work
3. Search for a customer name - should still work

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Search capability has been enhanced to recognize numeric input and match against sale identifiers across sales summaries, payment reports, and transaction records, enabling faster lookup of specific sales throughout the application.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->