### PR TITLE
Add Guards to Database Migration

### DIFF
--- a/app/Database/Migrations/20210422000000_database_optimizations.php
+++ b/app/Database/Migrations/20210422000000_database_optimizations.php
@@ -8,7 +8,6 @@ use App\Models\Attribute;
 use Config\Database;
 use Config\OSPOS;
 use DateTime;
-use RuntimeException;
 
 class Migration_database_optimizations extends Migration
 {
@@ -92,11 +91,16 @@ class Migration_database_optimizations extends Migration
                             $config = config(OSPOS::class)->settings;
                             $attributeDate = DateTime::createFromFormat('Y-m-d', (string) $attributeValue['attribute_date']);
 
-                            if ($attributeDate === false || empty($config['dateformat'])) {
-                                throw new RuntimeException('Invalid DATE attribute encountered during 20210422000000_database_optimizations migration.');
+                            if ($attributeDate === false) {
+                                log_message('warning', 'Migration 20210422000000: unparseable attribute_date "' . $attributeValue['attribute_date'] . '" for attribute_id ' . $attributeValue['attribute_id'] . ' — preserving raw value.');
+                                $value = (string) $attributeValue['attribute_date'];
+                            } else {
+                                $dateFormat = empty($config['dateformat']) ? 'Y-m-d' : $config['dateformat'];
+                                if (empty($config['dateformat'])) {
+                                    log_message('warning', 'Migration 20210422000000: dateformat config empty, falling back to Y-m-d for attribute_id ' . $attributeValue['attribute_id'] . '.');
+                                }
+                                $value = $attributeDate->format($dateFormat);
                             }
-+
-                            $value = $attributeDate->format($config['dateformat']);
                             break;
                         default:
                             $value = $attributeValue['attribute_value'];

--- a/app/Database/Migrations/20210422000000_database_optimizations.php
+++ b/app/Database/Migrations/20210422000000_database_optimizations.php
@@ -37,6 +37,10 @@ class Migration_database_optimizations extends Migration
         dropForeignKeyConstraints(['ospos_receivings_ibfk_2'], 'receivings');
         dropForeignKeyConstraints(['ospos_suppliers_ibfk_1'], 'suppliers');
 
+        createPrimaryKey('customers', 'person_id');
+        createPrimaryKey('employees', 'person_id');
+        createPrimaryKey('suppliers', 'person_id');
+
         $attribute = model(Attribute::class);
 
         $attribute->deleteOrphanedValues();

--- a/app/Database/Migrations/20210422000000_database_optimizations.php
+++ b/app/Database/Migrations/20210422000000_database_optimizations.php
@@ -41,8 +41,8 @@ class Migration_database_optimizations extends Migration
 
         $attribute->deleteOrphanedValues();
 
-        $this->migrate_duplicate_attribute_values(DECIMAL);
-        $this->migrate_duplicate_attribute_values(DATE);
+        $this->migrateDuplicateAttributeValues(DECIMAL);
+        $this->migrateDuplicateAttributeValues(DATE);
 
         // Select all attributes that have data in more than one column
         $builder = $this->db->table('attribute_values');
@@ -55,45 +55,45 @@ class Migration_database_optimizations extends Migration
         $builder->where('attribute_value IS NOT NULL');
         $builder->where('attribute_decimal IS NOT NULL');
         $builder->groupEnd();
-        $attribute_values = $builder->get();
+        $attributeValues = $builder->get();
 
         $this->db->transStart();
 
         // Clean up Attribute values table where there is an attribute value and an attribute_date/attribute_decimal
-        foreach ($attribute_values->getResultArray() as $attribute_value) {
+        foreach ($attributeValues->getResultArray() as $attributeValue) {
             $builder = $this->db->table('attribute_values');
-            $builder->delete(['attribute_id' => $attribute_value['attribute_id']]);
+            $builder->delete(['attribute_id' => $attributeValue['attribute_id']]);
 
             $builder = $this->db->table('attribute_links');
             $builder->select('links.definition_id, links.item_id, links.attribute_id, defs.definition_type');
             $builder->join('attribute_definitions defs', 'defs.definition_id = links.definition_id');
-            $builder->where('attribute_id', $attribute_value['attribute_id']);
-            $attribute_links = $builder->get();
+            $builder->where('attribute_id', $attributeValue['attribute_id']);
+            $attributeLinks = $builder->get();
 
-            if ($attribute_links) {
+            if ($attributeLinks) {
                 $builder = $this->db->table('attribute_links');
-                $attribute_links = $attribute_links->getResultArray() ?: [];
+                $attributeLinks = $attributeLinks->getResultArray() ?: [];
 
-                foreach ($attribute_links as $attribute_link) {
-                    $builder->where('attribute_id', $attribute_link['attribute_id']);
-                    $builder->where('item_id', $attribute_link['item_id']);
+                foreach ($attributeLinks as $attributeLink) {
+                    $builder->where('attribute_id', $attributeLink['attribute_id']);
+                    $builder->where('item_id', $attributeLink['item_id']);
                     $builder->delete();
 
-                    switch ($attribute_link['definition_type']) {
+                    switch ($attributeLink['definition_type']) {
                         case DECIMAL:
-                            $value = $attribute_value['attribute_decimal'];
+                            $value = $attributeValue['attribute_decimal'];
                             break;
                         case DATE:
                             $config = config(OSPOS::class)->settings;
-                            $attribute_date = DateTime::createFromFormat('Y-m-d', $attribute_value['attribute_date']);
-                            $value = $attribute_date->format($config['dateformat']);
+                            $attributeDate = DateTime::createFromFormat('Y-m-d', $attributeValue['attribute_date']);
+                            $value = $attributeDate->format($config['dateformat']);
                             break;
                         default:
-                            $value = $attribute_value['attribute_value'];
+                            $value = $attributeValue['attribute_value'];
                             break;
                     }
 
-                    $attribute->saveAttributeValue($value, $attribute_link['definition_id'], $attribute_link['item_id'], false, $attribute_link['definition_type']);
+                    $attribute->saveAttributeValue($value, $attributeLink['definition_id'], $attributeLink['item_id'], false, $attributeLink['definition_type']);
                 }
             }
         }
@@ -106,58 +106,58 @@ class Migration_database_optimizations extends Migration
     /**
      * Given the type of attribute, deletes any duplicates it finds in the attribute_values table and reassigns those
      */
-    private function migrate_duplicate_attribute_values($attribute_type): void
+    private function migrateDuplicateAttributeValues(string $attributeType): void
     {
         // Remove duplicate attribute values needed to make attribute_decimals and attribute_dates unique
         $this->db->transStart();
 
-        $column = 'attribute_' . strtolower($attribute_type);
+        $column = 'attribute_' . strtolower($attributeType);
 
         $builder = $this->db->table('attribute_values');
         $builder->select("$column");
         $builder->groupBy($column);
         $builder->having("COUNT($column) > 1");
-        $duplicated_values = $builder->get();
+        $duplicatedValues = $builder->get();
 
-        foreach ($duplicated_values->getResultArray() as $duplicated_value) {
-            $subquery_builder = $this->db->table('attribute_values');
-            $subquery_builder->select('attribute_id');
-            $subquery_builder->where($column, $duplicated_value[$column]);
-            $subquery = $subquery_builder->getCompiledSelect();
+        foreach ($duplicatedValues->getResultArray() as $duplicatedValue) {
+            $subqueryBuilder = $this->db->table('attribute_values');
+            $subqueryBuilder->select('attribute_id');
+            $subqueryBuilder->where($column, $duplicatedValue[$column]);
+            $subquery = $subqueryBuilder->getCompiledSelect();
 
             $builder = $this->db->table('attribute_values');
             $builder->select('attribute_id');
-            $builder->where($column, $duplicated_value[$column]);
+            $builder->where($column, $duplicatedValue[$column]);
             $builder->where("attribute_id IN ($subquery)", null, false);
-            $attribute_ids_to_fix = $builder->get();
+            $attributeIdsToFix = $builder->get();
 
-            $this->reassign_duplicate_attribute_values($attribute_ids_to_fix, $duplicated_value);
+            $this->reassignDuplicateAttributeValues($attributeIdsToFix, $duplicatedValue);
         }
 
         $this->db->transComplete();
     }
 
     /**
-     * Updates the attribute_id in all attribute_link rows with duplicated attribute_ids then deletes unneeded rows from attribute_values
+     * Updates the attribute_id in all attribute_link rows with duplicated attributeIds then deletes unneeded rows from attributeValues
      *
-     * @param ResultInterface $attribute_ids_to_fix All attribute_ids that need to parsed
-     * @param array $attribute_value The attribute value in question.
+     * @param ResultInterface $attributeIdsToFix All attributeIds that need to parsed
+     * @param array $attributeValue The attribute value in question.
      */
-    private function reassign_duplicate_attribute_values(ResultInterface $attribute_ids_to_fix, array $attribute_value): void
+    private function reassignDuplicateAttributeValues(ResultInterface $attributeIdsToFix, array $attributeValue): void
     {
-        $attribute_ids = $attribute_ids_to_fix->getResultArray();
-        $retain_attribute_id = $attribute_ids[0]['attribute_id'];
+        $attributeIds = $attributeIdsToFix->getResultArray();
+        $retainAttributeId = $attributeIds[0]['attribute_id'];
 
-        foreach ($attribute_ids as $attribute_id) {
+        foreach ($attributeIds as $attributeId) {
             // Update attribute_link with the attribute_id we are keeping
             $builder = $this->db->table('attribute_links');
-            $builder->where('attribute_id', $attribute_id['attribute_id']);
-            $builder->update(['attribute_id' => $retain_attribute_id]);
+            $builder->where('attribute_id', $attributeId['attribute_id']);
+            $builder->update(['attribute_id' => $retainAttributeId]);
 
             // Delete the row from attribute_values if it isn't our keeper
-            if ($attribute_id['attribute_id'] !== $retain_attribute_id) {
+            if ($attributeId['attribute_id'] !== $retainAttributeId) {
                 $builder = $this->db->table('attribute_values');
-                $builder->delete(['attribute_id' => $attribute_id['attribute_id']]);
+                $builder->delete(['attribute_id' => $attributeId['attribute_id']]);
             }
         }
     }

--- a/app/Database/Migrations/20210422000000_database_optimizations.php
+++ b/app/Database/Migrations/20210422000000_database_optimizations.php
@@ -8,6 +8,7 @@ use App\Models\Attribute;
 use Config\Database;
 use Config\OSPOS;
 use DateTime;
+use RuntimeException;
 
 class Migration_database_optimizations extends Migration
 {
@@ -89,7 +90,12 @@ class Migration_database_optimizations extends Migration
                             break;
                         case DATE:
                             $config = config(OSPOS::class)->settings;
-                            $attributeDate = DateTime::createFromFormat('Y-m-d', $attributeValue['attribute_date']);
+                            $attributeDate = DateTime::createFromFormat('Y-m-d', (string) $attributeValue['attribute_date']);
+
+                            if ($attributeDate === false || empty($config['dateformat'])) {
+                                throw new RuntimeException('Invalid DATE attribute encountered during 20210422000000_database_optimizations migration.');
+                            }
++
                             $value = $attributeDate->format($config['dateformat']);
                             break;
                         default:

--- a/app/Database/Migrations/20210422000000_database_optimizations.php
+++ b/app/Database/Migrations/20210422000000_database_optimizations.php
@@ -18,6 +18,25 @@ class Migration_database_optimizations extends Migration
     {
         log_message('info', 'Migrating database optimizations.');
 
+        helper('migration');
+
+        dropForeignKeyConstraints(['ospos_customers_ibfk_1'], 'customers');
+        dropForeignKeyConstraints(['ospos_customers_points_ibfk_1'], 'customers_points');
+        dropForeignKeyConstraints(['ospos_sales_ibfk_2'], 'sales');
+        dropForeignKeyConstraints(['ospos_sales_payments_ibfk_2'], 'sales_payments');
+        dropForeignKeyConstraints(['ospos_sales_ibfk_1'], 'sales');
+        dropForeignKeyConstraints(['ospos_receivings_ibfk_1'], 'receivings');
+        dropForeignKeyConstraints(['ospos_inventory_ibfk_2'], 'inventory');
+        dropForeignKeyConstraints(['ospos_grants_ibfk_2'], 'grants');
+        dropForeignKeyConstraints(['ospos_expenses_ibfk_2'], 'expenses');
+        dropForeignKeyConstraints(['ospos_employees_ibfk_1'], 'employees');
+        dropForeignKeyConstraints(['ospos_cash_up_ibfk_1'], 'cash_up');
+        dropForeignKeyConstraints(['ospos_cash_up_ibfk_2'], 'cash_up');
+        dropForeignKeyConstraints(['ospos_items_ibfk_1'], 'items');
+        dropForeignKeyConstraints(['ospos_expenses_ibfk_3'], 'expenses');
+        dropForeignKeyConstraints(['ospos_receivings_ibfk_2'], 'receivings');
+        dropForeignKeyConstraints(['ospos_suppliers_ibfk_1'], 'suppliers');
+
         $attribute = model(Attribute::class);
 
         $attribute->deleteOrphanedValues();
@@ -80,7 +99,6 @@ class Migration_database_optimizations extends Migration
         }
         $this->db->transComplete();
 
-        helper('migration');
         execute_script(APPPATH . 'Database/Migrations/sqlscripts/3.4.0_database_optimizations.sql');
         log_message('info', 'Finished migrating database optimizations.');
     }

--- a/app/Database/Migrations/20210422000000_database_optimizations.php
+++ b/app/Database/Migrations/20210422000000_database_optimizations.php
@@ -131,7 +131,7 @@ class Migration_database_optimizations extends Migration
             $builder->where("attribute_id IN ($subquery)", null, false);
             $attributeIdsToFix = $builder->get();
 
-            $this->reassignDuplicateAttributeValues($attributeIdsToFix, $duplicatedValue);
+            $this->reassignDuplicateAttributeValues($attributeIdsToFix);
         }
 
         $this->db->transComplete();
@@ -141,9 +141,8 @@ class Migration_database_optimizations extends Migration
      * Updates the attribute_id in all attribute_link rows with duplicated attributeIds then deletes unneeded rows from attributeValues
      *
      * @param ResultInterface $attributeIdsToFix All attributeIds that need to parsed
-     * @param array $attributeValue The attribute value in question.
      */
-    private function reassignDuplicateAttributeValues(ResultInterface $attributeIdsToFix, array $attributeValue): void
+    private function reassignDuplicateAttributeValues(ResultInterface $attributeIdsToFix): void
     {
         $attributeIds = $attributeIdsToFix->getResultArray();
         $retainAttributeId = $attributeIds[0]['attribute_id'];

--- a/app/Database/Migrations/20210422000000_database_optimizations.php
+++ b/app/Database/Migrations/20210422000000_database_optimizations.php
@@ -74,7 +74,7 @@ class Migration_database_optimizations extends Migration
                 $builder = $this->db->table('attribute_links');
                 $attribute_links = $attribute_links->getResultArray() ?: [];
 
-                foreach ($attribute_links->getResultArray() as $attribute_link) {
+                foreach ($attribute_links as $attribute_link) {
                     $builder->where('attribute_id', $attribute_link['attribute_id']);
                     $builder->where('item_id', $attribute_link['item_id']);
                     $builder->delete();

--- a/app/Database/Migrations/sqlscripts/3.4.0_database_optimizations.sql
+++ b/app/Database/Migrations/sqlscripts/3.4.0_database_optimizations.sql
@@ -11,10 +11,6 @@ ALTER TABLE `ospos_attribute_definitions` ADD INDEX(`definition_type`);
 ALTER TABLE `ospos_cash_up` MODIFY `deleted` tinyint(1) DEFAULT 0 NOT NULL;
 
 #ospos_customers table
-ALTER TABLE `ospos_customers` DROP FOREIGN KEY `ospos_customers_ibfk_1`;
-ALTER TABLE `ospos_customers_points` DROP FOREIGN KEY `ospos_customers_points_ibfk_1`;
-ALTER TABLE `ospos_sales` DROP FOREIGN KEY `ospos_sales_ibfk_2`;
-
 ALTER TABLE `ospos_customers` MODIFY `taxable` tinyint(1) DEFAULT 1 NOT NULL;
 ALTER TABLE `ospos_customers` MODIFY `deleted` tinyint(1) DEFAULT 0 NOT NULL;
 ALTER TABLE `ospos_customers` MODIFY `discount_type` tinyint(1) DEFAULT 0 NOT NULL;
@@ -31,16 +27,6 @@ ALTER TABLE `ospos_dinner_tables` MODIFY `deleted` tinyint(1) DEFAULT 0 NOT NULL
 ALTER TABLE `ospos_dinner_tables` ADD INDEX(`status`);
 
 #ospos_employees table
-ALTER TABLE `ospos_sales_payments` DROP FOREIGN KEY `ospos_sales_payments_ibfk_2`;
-ALTER TABLE `ospos_sales` DROP FOREIGN KEY `ospos_sales_ibfk_1`;
-ALTER TABLE `ospos_receivings` DROP FOREIGN KEY `ospos_receivings_ibfk_1`;
-ALTER TABLE `ospos_inventory` DROP FOREIGN KEY `ospos_inventory_ibfk_2`;
-ALTER TABLE `ospos_grants` DROP FOREIGN KEY `ospos_grants_ibfk_2`;
-ALTER TABLE `ospos_expenses` DROP FOREIGN KEY `ospos_expenses_ibfk_2`;
-ALTER TABLE `ospos_employees` DROP FOREIGN KEY `ospos_employees_ibfk_1`;
-ALTER TABLE `ospos_cash_up` DROP FOREIGN KEY `ospos_cash_up_ibfk_1`;
-ALTER TABLE `ospos_cash_up` DROP FOREIGN KEY `ospos_cash_up_ibfk_2`;
-
 ALTER TABLE `ospos_employees` MODIFY `deleted` tinyint(1) DEFAULT 0 NOT NULL;
 ALTER TABLE `ospos_employees` MODIFY `hash_version` tinyint(1) DEFAULT 2 NOT NULL;
 
@@ -67,7 +53,6 @@ ALTER TABLE `ospos_expense_categories` ADD INDEX(`category_description`);
 ALTER TABLE `ospos_giftcards` MODIFY `deleted` tinyint(1) DEFAULT 0 NOT NULL;
 
 #ospos_items table
-ALTER TABLE `ospos_items` DROP FOREIGN KEY `ospos_items_ibfk_1`;
 ALTER TABLE `ospos_items` MODIFY `deleted` tinyint(1) DEFAULT 0 NOT NULL;
 ALTER TABLE `ospos_items` MODIFY `stock_type` tinyint(1) DEFAULT 0 NOT NULL;
 ALTER TABLE `ospos_items` MODIFY `item_type` tinyint(1) DEFAULT 0 NOT NULL;
@@ -112,10 +97,6 @@ ALTER TABLE `ospos_sessions` ADD INDEX(`ip_address`);
 ALTER TABLE `ospos_stock_locations` MODIFY `deleted` tinyint(1) DEFAULT 0 NOT NULL;
 
 #ospos_suppliers table
-ALTER TABLE `ospos_expenses` DROP FOREIGN KEY `ospos_expenses_ibfk_3`;
-ALTER TABLE `ospos_receivings` DROP FOREIGN KEY `ospos_receivings_ibfk_2`;
-ALTER TABLE `ospos_suppliers` DROP FOREIGN KEY `ospos_suppliers_ibfk_1`;
-
 ALTER TABLE `ospos_suppliers` MODIFY `deleted` tinyint(1) DEFAULT 0 NOT NULL;
 ALTER TABLE `ospos_suppliers` MODIFY `category` tinyint(1) NOT NULL;
 ALTER TABLE `ospos_suppliers` ADD INDEX(`category`);

--- a/app/Helpers/migration_helper.php
+++ b/app/Helpers/migration_helper.php
@@ -88,7 +88,7 @@ function executeScriptWithTransaction(string $path): bool
 }
 
 /**
- * Drops provided foreign key constraints from given table.
+ * Drops provided foreign key constraints from a given table if the constraint exists.
  * This is required to successfully create the generated unique constraint.
  *
  * @param array $foreignKeys names of the foreign key constraints to drop

--- a/app/Helpers/security_helper.php
+++ b/app/Helpers/security_helper.php
@@ -40,8 +40,8 @@ function check_encryption(): bool
 
             $config_file = file_get_contents($config_path);
 
-            if (preg_match('/^encryption\.key\s*=/m', $config_file)) {
-                $config_file = preg_replace("/^(encryption\.key\s*=\s*)('.*')/m", "$1'$key'", $config_file, 1);
+            if (preg_match('/^\s*encryption\.key\s*=/m', $config_file)) {
+                $config_file = preg_replace("/^(\s*encryption\.key\s*=\s*).*/m", "\$1'$key'", $config_file, 1);
             } else {
                 $config_file .= "\nencryption.key = '$key'\n";
             }

--- a/app/Helpers/security_helper.php
+++ b/app/Helpers/security_helper.php
@@ -40,17 +40,16 @@ function check_encryption(): bool
 
             $config_file = file_get_contents($config_path);
 
-            if (strpos($config_file, 'encryption.key') !== false) {
-                $config_file = preg_replace("/(encryption\.key.*=.*)('.*')/", "$1'$key'", $config_file);
+            if (preg_match('/^encryption\.key\s*=/m', $config_file)) {
+                $config_file = preg_replace("/^(encryption\.key\s*=\s*)('.*')/m", "$1'$key'", $config_file, 1);
             } else {
                 $config_file .= "\nencryption.key = '$key'\n";
             }
 
             if (!empty($old_key)) {
                 $old_line = "# encryption.key = '$old_key' REMOVE IF UNNEEDED\r\n";
-                $insertion_point = stripos($config_file, 'encryption.key');
-                if ($insertion_point !== false) {
-                    $config_file = substr_replace($config_file, $old_line, $insertion_point, 0);
+                if (preg_match('/^encryption\.key\s*=/m', $config_file, $matches, PREG_OFFSET_CAPTURE)) {
+                    $config_file = substr_replace($config_file, $old_line, $matches[0][1], 0);
                 }
             }
 


### PR DESCRIPTION
Database optimizations drops constraints blindly which could cause a migration failure in existing databases created pre-3.0.2.

- PSR refactors in touched code
- Removed dead parameter
- Properly replace encryption key in updates when an existing key is commented out.
- Add guards to constraint drops and primary key creations

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Database schema and index optimizations to improve performance and reliability.
  * Data cleanup and duplicate-attribute normalization, including safer date normalization with format fallback and non-destructive handling when parsing fails.

* **Security**
  * Improved encryption key handling and robust configuration update logic.

* **Documentation**
  * Clarified helper documentation describing foreign-key handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->