### PR TITLE
Reject item CSV imports whose header row is missing required columns

### DIFF
--- a/app/Controllers/Items.php
+++ b/app/Controllers/Items.php
@@ -988,14 +988,14 @@ class Items extends Secure_Controller
 
                     $failCodes = [];
                     $csvRows = get_csv_file($_FILES['file_path']['tmp_name']);
+                    $allowedStockLocations = $this->stock_location->get_allowed_locations();
+                    $attributeDefinitionNames    = $this->attribute->get_definition_names();
 
-                    if (!csv_import_has_required_item_headers($csvRows)) {
+                    if (!csvImportHasRequiredItemHeaders($csvRows, $allowedStockLocations, $attributeDefinitionNames)) {
                         return $this->response->setJSON(['success' => false, 'message' => lang('Items.csv_import_nodata_wrongformat')]);
                     }
 
                     $employeeId = $this->employee->get_logged_in_employee_info()->person_id;
-                    $allowedStockLocations = $this->stock_location->get_allowed_locations();
-                    $attributeDefinitionNames    = $this->attribute->get_definition_names();
 
                     unset($attributeDefinitionNames[NEW_ENTRY]);    // Removes the common_none_selected_text from the array
 

--- a/app/Controllers/Items.php
+++ b/app/Controllers/Items.php
@@ -988,6 +988,11 @@ class Items extends Secure_Controller
 
                     $failCodes = [];
                     $csvRows = get_csv_file($_FILES['file_path']['tmp_name']);
+
+                    if (!csv_import_has_required_item_headers($csvRows)) {
+                        return $this->response->setJSON(['success' => false, 'message' => lang('Items.csv_import_nodata_wrongformat')]);
+                    }
+
                     $employeeId = $this->employee->get_logged_in_employee_info()->person_id;
                     $allowedStockLocations = $this->stock_location->get_allowed_locations();
                     $attributeDefinitionNames    = $this->attribute->get_definition_names();

--- a/app/Helpers/importfile_helper.php
+++ b/app/Helpers/importfile_helper.php
@@ -100,21 +100,28 @@ function bom_exists(&$file_handle): bool
 }
 
 /**
- * Checks that the parsed item import rows expose the columns the import expects.
- * A file whose header row does not match the template (for example when the
- * "Id" column is missing or renamed) would otherwise trigger "Undefined array
- * key" errors while building each item.
+ * Checks that the parsed item import rows expose the columns the current
+ * template requires. A file whose header row does not match the template
+ * (for example when the "Id" column is missing, an attribute column was
+ * renamed, or a stock location was added since the file was last downloaded)
+ * would otherwise trigger "Undefined array key" errors while building each
+ * item. The required columns are derived from generate_import_items_csv(),
+ * the same function that builds the downloadable template, so location and
+ * attribute columns stay in sync automatically.
  *
  * @param array $csv_rows Rows returned by get_csv_file().
+ * @param array $stock_locations Stock locations, as returned by Stock_location::get_allowed_locations().
+ * @param array $attribute_names Attribute definition names, as returned by Attribute::get_definition_names().
  * @return bool True when the required columns are present.
  */
-function csv_import_has_required_item_headers(array $csv_rows): bool
+function csvImportHasRequiredItemHeaders(array $csv_rows, array $stock_locations, array $attribute_names): bool
 {
     if (empty($csv_rows)) {
         return false;
     }
 
-    $required_headers = ['Id', 'Barcode', 'Item Name', 'Category', 'Supplier ID', 'Cost Price', 'Unit Price', 'Tax 1 Name', 'Tax 1 Percent', 'Tax 2 Name', 'Tax 2 Percent', 'Reorder Level', 'Description', 'Allow Alt Description', 'Item has Serial Number', 'Image', 'HSN'];
+    $template_header_line = substr(generate_import_items_csv($stock_locations, $attribute_names), 3);
+    $required_headers = str_getcsv($template_header_line);
 
     $present_headers = array_keys(reset($csv_rows));
 

--- a/app/Helpers/importfile_helper.php
+++ b/app/Helpers/importfile_helper.php
@@ -98,3 +98,25 @@ function bom_exists(&$file_handle): bool
 
     return $result;
 }
+
+/**
+ * Checks that the parsed item import rows expose the columns the import expects.
+ * A file whose header row does not match the template (for example when the
+ * "Id" column is missing or renamed) would otherwise trigger "Undefined array
+ * key" errors while building each item.
+ *
+ * @param array $csv_rows Rows returned by get_csv_file().
+ * @return bool True when the required columns are present.
+ */
+function csv_import_has_required_item_headers(array $csv_rows): bool
+{
+    if (empty($csv_rows)) {
+        return false;
+    }
+
+    $required_headers = ['Id', 'Item Name', 'Category', 'Cost Price', 'Unit Price', 'Reorder Level', 'Description', 'Allow Alt Description', 'Item has Serial Number', 'Image', 'HSN'];
+
+    $present_headers = array_keys($csv_rows[0]);
+
+    return empty(array_diff($required_headers, $present_headers));
+}

--- a/app/Helpers/importfile_helper.php
+++ b/app/Helpers/importfile_helper.php
@@ -114,9 +114,9 @@ function csv_import_has_required_item_headers(array $csv_rows): bool
         return false;
     }
 
-    $required_headers = ['Id', 'Item Name', 'Category', 'Cost Price', 'Unit Price', 'Reorder Level', 'Description', 'Allow Alt Description', 'Item has Serial Number', 'Image', 'HSN'];
+    $required_headers = ['Id', 'Barcode', 'Item Name', 'Category', 'Supplier ID', 'Cost Price', 'Unit Price', 'Tax 1 Name', 'Tax 1 Percent', 'Tax 2 Name', 'Tax 2 Percent', 'Reorder Level', 'Description', 'Allow Alt Description', 'Item has Serial Number', 'Image', 'HSN'];
 
-    $present_headers = array_keys($csv_rows[0]);
+    $present_headers = array_keys(reset($csv_rows));
 
     return empty(array_diff($required_headers, $present_headers));
 }

--- a/tests/Controllers/ItemsCsvImportTest.php
+++ b/tests/Controllers/ItemsCsvImportTest.php
@@ -219,6 +219,21 @@ class ItemsCsvImportTest extends CIUnitTestCase
         unlink($tempFile);
     }
 
+    public function testMissingSupplierIdHeaderIsRejected(): void
+    {
+        $csvContent = 'Id,Barcode,"Item Name",Category,"Cost Price","Unit Price","Tax 1 Name","Tax 1 Percent","Tax 2 Name","Tax 2 Percent","Reorder Level",Description,"Allow Alt Description","Item has Serial Number",Image,HSN' . "\n";
+        $csvContent .= ",ITEM001,Test Item,Electronics,10.00,15.00,,,,,5,Test Description,0,0,,HSN001\n";
+
+        $tempFile = tempnam(sys_get_temp_dir(), 'csv_test_headers_no_supplier_');
+        file_put_contents($tempFile, $csvContent);
+
+        $rows = get_csv_file($tempFile);
+
+        $this->assertFalse(csv_import_has_required_item_headers($rows));
+
+        unlink($tempFile);
+    }
+
     public function testEmptyCsvHasNoRequiredHeaders(): void
     {
         $this->assertFalse(csv_import_has_required_item_headers([]));

--- a/tests/Controllers/ItemsCsvImportTest.php
+++ b/tests/Controllers/ItemsCsvImportTest.php
@@ -199,7 +199,7 @@ class ItemsCsvImportTest extends CIUnitTestCase
 
         $rows = get_csv_file($tempFile);
 
-        $this->assertTrue(csv_import_has_required_item_headers($rows));
+        $this->assertTrue(csvImportHasRequiredItemHeaders($rows, [], []));
 
         unlink($tempFile);
     }
@@ -214,7 +214,7 @@ class ItemsCsvImportTest extends CIUnitTestCase
 
         $rows = get_csv_file($tempFile);
 
-        $this->assertFalse(csv_import_has_required_item_headers($rows));
+        $this->assertFalse(csvImportHasRequiredItemHeaders($rows, [], []));
 
         unlink($tempFile);
     }
@@ -229,14 +229,29 @@ class ItemsCsvImportTest extends CIUnitTestCase
 
         $rows = get_csv_file($tempFile);
 
-        $this->assertFalse(csv_import_has_required_item_headers($rows));
+        $this->assertFalse(csvImportHasRequiredItemHeaders($rows, [], []));
+
+        unlink($tempFile);
+    }
+
+    public function testMissingAttributeColumnIsRejected(): void
+    {
+        $csvContent = 'Id,Barcode,"Item Name",Category,"Supplier ID","Cost Price","Unit Price","Tax 1 Name","Tax 1 Percent","Tax 2 Name","Tax 2 Percent","Reorder Level",Description,"Allow Alt Description","Item has Serial Number",Image,HSN' . "\n";
+        $csvContent .= ",ITEM001,Test Item,Electronics,1,10.00,15.00,,,,,5,Test Description,0,0,,HSN001\n";
+
+        $tempFile = tempnam(sys_get_temp_dir(), 'csv_test_headers_no_attribute_');
+        file_put_contents($tempFile, $csvContent);
+
+        $rows = get_csv_file($tempFile);
+
+        $this->assertFalse(csvImportHasRequiredItemHeaders($rows, ['Warehouse'], ['Color']));
 
         unlink($tempFile);
     }
 
     public function testEmptyCsvHasNoRequiredHeaders(): void
     {
-        $this->assertFalse(csv_import_has_required_item_headers([]));
+        $this->assertFalse(csvImportHasRequiredItemHeaders([], [], []));
     }
 
     public function testBomExists(): void

--- a/tests/Controllers/ItemsCsvImportTest.php
+++ b/tests/Controllers/ItemsCsvImportTest.php
@@ -189,6 +189,41 @@ class ItemsCsvImportTest extends CIUnitTestCase
         unlink($tempFile);
     }
 
+    public function testRequiredHeadersDetectedForTemplate(): void
+    {
+        $csvContent = 'Id,Barcode,"Item Name",Category,"Supplier ID","Cost Price","Unit Price","Tax 1 Name","Tax 1 Percent","Tax 2 Name","Tax 2 Percent","Reorder Level",Description,"Allow Alt Description","Item has Serial Number",Image,HSN' . "\n";
+        $csvContent .= ",ITEM001,Test Item,Electronics,1,10.00,15.00,,,,,5,Test Description,0,0,,HSN001\n";
+
+        $tempFile = tempnam(sys_get_temp_dir(), 'csv_test_headers_ok_');
+        file_put_contents($tempFile, $csvContent);
+
+        $rows = get_csv_file($tempFile);
+
+        $this->assertTrue(csv_import_has_required_item_headers($rows));
+
+        unlink($tempFile);
+    }
+
+    public function testMissingIdHeaderIsRejected(): void
+    {
+        $csvContent = "Barcode,\"Item Name\",Category\n";
+        $csvContent .= "ITEM001,Test Item,Electronics\n";
+
+        $tempFile = tempnam(sys_get_temp_dir(), 'csv_test_headers_bad_');
+        file_put_contents($tempFile, $csvContent);
+
+        $rows = get_csv_file($tempFile);
+
+        $this->assertFalse(csv_import_has_required_item_headers($rows));
+
+        unlink($tempFile);
+    }
+
+    public function testEmptyCsvHasNoRequiredHeaders(): void
+    {
+        $this->assertFalse(csv_import_has_required_item_headers([]));
+    }
+
     public function testBomExists(): void
     {
         $bom = pack('CCC', 0xef, 0xbb, 0xbf);
@@ -1112,3 +1147,4 @@ class ItemsCsvImportTest extends CIUnitTestCase
         $this->assertTrue($isValid, 'Valid location name should pass validation');
     }
 }
+


### PR DESCRIPTION
Fixes #4593

When an uploaded item CSV has a header row that does not match the template (for example the `Id` column is missing or was renamed by a spreadsheet editor), `get_csv_file()` keys each row off the file's own headers, so the first `$row['Id']` access in `postImportCsvFile()` throws `Undefined array key "Id"`. The exception is caught and surfaced to the user as the raw PHP message, and nothing is imported.

This adds a header check right after the file is parsed. If the required item columns are not all present the import returns the existing `csv_import_nodata_wrongformat` message instead of crashing partway through the loop.

- `csv_import_has_required_item_headers()` in `importfile_helper.php` verifies the parsed rows expose the columns the loop dereferences.
- `postImportCsvFile()` calls it before iterating and bails out early on a mismatch.
- Added tests in `ItemsCsvImportTest` for the template header set, a file missing `Id`, and an empty file.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * CSV item imports now validate required column headers immediately before processing, failing fast with a clear format error when headers are missing or invalid.
  * Required headers are now derived from the current downloadable CSV template, improving consistency and catching missing attribute columns.
* **Tests**
  * Updated and expanded CSV import header-validation tests to cover empty files and missing required headers (including attribute columns).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->