### PR TITLE
bugfix(reports): crash on detailed sales report when sale has multiple payments with reference codes

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -4,10 +4,14 @@ This document provides guidance for AI agents working on the Open Source Point o
 
 ## Code Style
 
+- **PSR-12** enforced via PHP-CS-Fixer (config: `.php-cs-fixer.no-header.php`)
 - Follow PHP CodeIgniter 4 coding standards
-- Run PHP-CS-Fixer before committing: `vendor/bin/php-cs-fixer fix --config=.php-cs-fixer.no-header.php`
-- Write PHP 8.1+ compatible code with proper type declarations
-- Use PSR-12 naming conventions: `camelCase` for variables and functions, `PascalCase` for classes, `UPPER_CASE` for constants
+- `camelCase` for variables and methods; `PascalCase` for classes; `UPPER_CASE` for constants
+- PHP 8.2+ features acceptable (named arguments, enums, readonly properties)
+- Write PHP 8.2+ compatible code with proper type declarations
+- Views in `app/Views/errors/html/` are excluded from the fixer
+- Run fixer before committing: `vendor/bin/php-cs-fixer fix --config=.php-cs-fixer.no-header.php`
+- **JavaScript**: use `const` for variables that are never reassigned, `let` for variables that are. Never use `var`.
 
 ## Development
 
@@ -36,8 +40,11 @@ This document provides guidance for AI agents working on the Open Source Point o
 ## Localization
 
 - When adding new keys to language files, add the key to all `app/Language/*/` variants
-- Non-English files must use an empty string (`""` or `''`) as the value when no translation is provided — CodeIgniter automatically falls back to the default (`en`) language
+- **New keys must be inserted in alphabetical order** within the language array
+- Non-English files must use an empty string (`''`) as the value when no translation is provided — CodeIgniter automatically falls back to the default (`en`) language
 - Only `app/Language/en/` and `app/Language/en-GB/` should contain English strings
+- Plugin language files (`app/Plugins/*/Language/`) follow the same localization rules as `app/Language/`
+- Use `'` to encapsulate key and string values. If the value contains `'` then it should be escaped as `\'`
 
 ## Security
 

--- a/app/Models/Sale.php
+++ b/app/Models/Sale.php
@@ -1095,12 +1095,12 @@ class Sale extends Model
                     SUM(CASE WHEN payments.cash_adjustment = 1 THEN payments.payment_amount ELSE 0 END) AS sale_cash_adjustment,
                     SUM(payments.cash_refund) AS sale_cash_refund,
                     GROUP_CONCAT(CONCAT(payments.payment_type, " ", (payments.payment_amount - payments.cash_refund)) SEPARATOR ", ") AS payment_type,
-                    payments.reference_code AS reference_code
+                    GROUP_CONCAT(payments.reference_code SEPARATOR ", ") AS reference_code
                 FROM ' . $this->db->prefixTable('sales_payments') . ' AS payments
                 INNER JOIN ' . $this->db->prefixTable('sales') . ' AS sales
                     ON sales.sale_id = payments.sale_id
                 WHERE ' . $where . '
-                GROUP BY payments.sale_id, payments.reference_code
+                GROUP BY payments.sale_id
             )';
 
         $this->db->query($sql);

--- a/app/Models/Sale.php
+++ b/app/Models/Sale.php
@@ -1095,7 +1095,7 @@ class Sale extends Model
                     SUM(CASE WHEN payments.cash_adjustment = 1 THEN payments.payment_amount ELSE 0 END) AS sale_cash_adjustment,
                     SUM(payments.cash_refund) AS sale_cash_refund,
                     GROUP_CONCAT(CONCAT(payments.payment_type, " ", (payments.payment_amount - payments.cash_refund)) SEPARATOR ", ") AS payment_type,
-                    GROUP_CONCAT(payments.reference_code SEPARATOR ", ") AS reference_code
+                    GROUP_CONCAT(NULLIF(payments.reference_code, '') SEPARATOR ", ") AS reference_code
                 FROM ' . $this->db->prefixTable('sales_payments') . ' AS payments
                 INNER JOIN ' . $this->db->prefixTable('sales') . ' AS sales
                     ON sales.sale_id = payments.sale_id


### PR DESCRIPTION
Problem
Running the detailed sales report fails with:

Duplicate entry '<sale_id>' for key 'ospos_sales_payments_temp.PRIMARY'

This occurs on any sale that has multiple payment rows in ospos_sales_payments with different reference_code values (e.g. split tender with a reference-code payment type, or two separate card swipes).

create_temp_table() in Sale.php builds ospos_sales_payments_temp with PRIMARY KEY(sale_id), but the subquery grouped by (payments.sale_id, payments.reference_code). When a sale has N payments with distinct reference codes, the subquery returns N rows for the same sale_id, violating the primary key constraint on insert.

Note: ospos_sales_payments legitimately stores multiple rows per sale (its PK is auto-increment payment_id). The temp table is reporting-only and is intentionally one row per sale — the bug was in the GROUP BY not matching that intent.

Fix
In app/Models/Sale.php, create_temp_table():

Changed payments.reference_code AS reference_code → GROUP_CONCAT(payments.reference_code SEPARATOR ", ") AS reference_code
Changed GROUP BY payments.sale_id, payments.reference_code → GROUP BY payments.sale_id
This produces one row per sale in the temp table (satisfying the PRIMARY KEY), aggregates all reference codes into a comma-separated string alongside the already-aggregated payment_type column, and has no impact on write operations — the temp table is read-only and used solely for report display.

Testing
Run the detailed sales report for a date range containing a sale with multiple payment types or a reference-code payment. Report should complete without error and display all payment types and reference codes concatenated in the respective columns.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved sales payment data handling by consolidating multiple non-empty payment reference codes into a single sale record.
  * Reduced the likelihood of duplicate sale entries caused by splitting records across different reference codes.
* **Documentation**
  * Updated contributor guidance with clearer PHP/JS style rules (including PHP-CS-Fixer and PHP 8.2+), refined view exclusion constraints, and strengthened localization and security checklists (including alphabetical insertion of new language keys and input validation/sanitization).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->