### PR TITLE
bugfix(giftcard): correct return type and rename getGiftcardId method

### DIFF
--- a/app/Controllers/Giftcards.php
+++ b/app/Controllers/Giftcards.php
@@ -163,7 +163,7 @@ class Giftcards extends Secure_Controller
     {
         $existing_id = $this->request->getPost('giftcard_id', FILTER_SANITIZE_NUMBER_INT);
         $giftcard_number = $this->request->getPost('giftcard_number', FILTER_SANITIZE_NUMBER_INT);
-        $giftcard_id = $this->giftcard->get_giftcard_id($giftcard_number);
+        $giftcard_id = $this->giftcard->getGiftcardId($giftcard_number);
         $success = ($giftcard_id == (int) $existing_id || !$giftcard_id );
 
         return $this->response->setJSON($success ? 'true' : 'false');

--- a/app/Models/Giftcard.php
+++ b/app/Models/Giftcard.php
@@ -106,15 +106,15 @@ class Giftcard extends Model
     /**
      * Gets a giftcard id given a giftcard number
      */
-    public function get_giftcard_id(string $giftcard_number): bool
+    public function getGiftcardId(string $giftcardNumber): int|false
     {
         $builder = $this->db->table('giftcards');
-        $builder->where('giftcard_number', $giftcard_number);
+        $builder->where('giftcard_number', $giftcardNumber);
         $builder->where('deleted', 0);
 
         $query = $builder->get();
 
-        if ($query->getNumRows() == 1) {    // TODO: ===
+        if ($query->getNumRows() === 1) {
             return $query->getRow()->giftcard_id;
         }
 
@@ -291,7 +291,7 @@ class Giftcard extends Model
      */
     public function get_giftcard_value(string $giftcard_number): float    // TODO: we may need to do a search for all float values and for currencies cast them to strings at the point where we get them from the database.
     {
-        if (!$this->exists($this->get_giftcard_id($giftcard_number))) {
+        if (!$this->exists($this->getGiftcardId($giftcard_number))) {
             return 0;
         }
 
@@ -349,7 +349,7 @@ class Giftcard extends Model
      */
     public function get_giftcard_customer(string $giftcard_number): int|null
     {
-        if (!$this->exists($this->get_giftcard_id($giftcard_number))) {
+        if (!$this->exists($this->getGiftcardId($giftcard_number))) {
             return 0;
         }
 

--- a/app/Models/Sale.php
+++ b/app/Models/Sale.php
@@ -1016,7 +1016,7 @@ class Sale extends Model
     {
         $giftcard = model(Giftcard::class);
 
-        if (!$giftcard->exists($giftcard->get_giftcard_id($giftcardNumber))) {    // TODO: camelCase is used here for the variable name but we are using _ everywhere else. CI4 moved to camelCase... we should pick one and do that.
+        if (!$giftcard->exists($giftcard->getGiftcardId($giftcardNumber))) {    // TODO: camelCase is used here for the variable name but we are using _ everywhere else. CI4 moved to camelCase... we should pick one and do that.
             return 0;
         }
 


### PR DESCRIPTION
During the CI4 conversion bool was added as the return type but this creates a bug which causes the system to think the balance of the card is zero.

- Rename get_giftcard_id to getGiftcardId (PSR-12 camelCase)
- Fix return type from bool to int|false
- Replace loose == with strict === comparison
- Update all call sites in Giftcards controller and Sale model

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved gift card verification and lookup reliability.
  * Gift card value and associated details now resolve correctly when a valid gift card is provided.
  * Invalid or unavailable gift card numbers continue to return the appropriate negative response.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->