### PR TITLE
Plugin system: sale document view hooks and a webhook CSRF exemption

### DIFF
--- a/app/Config/Filters.php
+++ b/app/Config/Filters.php
@@ -73,7 +73,16 @@ class Filters extends BaseFilters
     public array $globals = [
         'before' => [
             'honeypot',
-            'csrf' => ['except' => 'login|migrate'],
+            // Listed as an array rather than a pipe-delimited string so each entry is
+            // anchored independently. CI4 matches every entry as \A<pattern>\z, so the
+            // string form 'login|migrate' produced one pattern whose inner alternatives
+            // were unanchored and matched far more than intended.
+            //
+            // 'plugins/*/webhook' lets a plugin expose an inbound provider callback.
+            // A CSRF token cannot exist on a server-to-server delivery, so plugins must
+            // authenticate these requests themselves (e.g. verifying the provider's
+            // signature header against a shared secret).
+            'csrf' => ['except' => ['login', 'migrate', 'plugins/*/webhook']],
             'invalidchars',
         ],
         'after' => [

--- a/app/Config/Filters.php
+++ b/app/Config/Filters.php
@@ -73,15 +73,6 @@ class Filters extends BaseFilters
     public array $globals = [
         'before' => [
             'honeypot',
-            // Listed as an array rather than a pipe-delimited string so each entry is
-            // anchored independently. CI4 matches every entry as \A<pattern>\z, so the
-            // string form 'login|migrate' produced one pattern whose inner alternatives
-            // were unanchored and matched far more than intended.
-            //
-            // 'plugins/*/webhook' lets a plugin expose an inbound provider callback.
-            // A CSRF token cannot exist on a server-to-server delivery, so plugins must
-            // authenticate these requests themselves (e.g. verifying the provider's
-            // signature header against a shared secret).
             'csrf' => ['except' => ['login', 'migrate', 'plugins/*/webhook']],
             'invalidchars',
         ],

--- a/app/Plugins/README.md
+++ b/app/Plugins/README.md
@@ -226,7 +226,15 @@ These hook points are currently defined in core views:
 | `view:customer_tab_nav`       | `app/Views/customers/form.php:28`       | `['customer' => $person_info]`    | Add `<li>` tab navigation entries to customer form  |
 | `view:customer_tab_panels`    | `app/Views/customers/form.php:326`      | `['customer' => $person_info]`    | Add `<div>` tab panel content to customer form      |
 | `view:sales_receipt_buttons`  | `app/Views/sales/receipt.php:51`        | `['saleId' => $sale_id_num]`      | Add buttons to the receipt view                     |
+| `view:sales_invoice_buttons`  | `app/Views/sales/invoice.php:59`        | `['saleId' => $sale_id_num]`      | Add buttons to the invoice view                     |
+| `view:sales_quote_buttons`    | `app/Views/sales/quote.php:55`          | `['saleId' => $sale_id_num]`      | Add buttons to the quote view                       |
+| `view:sales_work_order_buttons` | `app/Views/sales/work_order.php:57`   | `['saleId' => $sale_id_num]`      | Add buttons to the work order view                  |
 | `view:sales_register_buttons` | `app/Views/sales/register.php`          | *(none)*                          | Add UI controls to the register checkout area       |
+
+The four sales document hooks are deliberately symmetrical: a plugin that delivers a
+sale document (print, email, messaging) can register the same callback for all four and
+branch on the document type. Only `saleId` is passed, so resolve any further sale or
+customer data inside the plugin.
 
 ### Benefits
 
@@ -601,6 +609,31 @@ Always use fully qualified controller names:
 - `\App\Plugins\ExamplePlugin\Controllers\ExampleController::methodName`
 
 This ensures routes work correctly regardless of autoloader state.
+
+### Inbound Webhook Routes
+
+A plugin that integrates with an external provider may need to receive server-to-server
+callbacks. Such a request carries no CSRF token and no session, so the route must be
+both public and CSRF-exempt.
+
+Name the route exactly `plugins/<plugin_id>/webhook`. `app/Config/Filters.php` exempts
+that pattern (`plugins/*/webhook`) from the global CSRF filter, so no core change is
+needed per plugin:
+
+```php
+// app/Plugins/ExamplePlugin/Config/Routes.php
+$routes->get('plugins/example/webhook', '\App\Plugins\ExamplePlugin\Controllers\WebhookController::index');
+$routes->post('plugins/example/webhook', '\App\Plugins\ExamplePlugin\Controllers\WebhookController::index');
+```
+
+The exemption is anchored, so only that exact path is exempt — sibling routes such as
+`plugins/example/sync` keep full CSRF protection.
+
+**The plugin is responsible for authenticating these requests.** Because the endpoint is
+unauthenticated by design, the webhook controller must extend `BaseController` (not
+`Secure_Controller`) and verify the caller itself — typically by recomputing the
+provider's signature header over the raw request body with a shared secret and comparing
+using `hash_equals()`. Never trust a webhook payload that failed that check.
 
 ## Internationalization (Language Files)
 

--- a/app/Views/sales/invoice.php
+++ b/app/Views/sales/invoice.php
@@ -56,6 +56,7 @@ if (isset($error_message)) {
 <?= view('partial/print_receipt', ['print_after_sale' => $print_after_sale, 'selected_printer' => 'invoice_printer']) ?>
 
 <div class="print_hide" id="control_buttons" style="text-align: right;">
+    <?= pluginContent('sales_invoice_buttons', ['saleId' => $sale_id_num]) ?>
     <a href="javascript:printdoc();">
         <div class="btn btn-info btn-sm" id="show_print_button"><?= '<span class="glyphicon glyphicon-print">&nbsp;</span>' . lang('Common.print') ?></div>
     </a>

--- a/app/Views/sales/quote.php
+++ b/app/Views/sales/quote.php
@@ -52,6 +52,7 @@ if (isset($error_message)) {
 <?= view('partial/print_receipt', ['print_after_sale' => $print_after_sale, 'selected_printer' => 'invoice_printer']) ?>
 
 <div class="print_hide" id="control_buttons" style="text-align: right;">
+    <?= pluginContent('sales_quote_buttons', ['saleId' => $sale_id_num]) ?>
     <a href="javascript:printdoc();">
         <div class="btn btn-info btn-sm" id="show_print_button"><?= '<span class="glyphicon glyphicon-print">&nbsp;</span>' . lang('Common.print') ?></div>
     </a>

--- a/app/Views/sales/work_order.php
+++ b/app/Views/sales/work_order.php
@@ -54,6 +54,7 @@ if (isset($error_message)) {
 <?= view('partial/print_receipt', ['print_after_sale' => $print_after_sale, 'selected_printer' => 'invoice_printer']) ?>
 
 <div class="print_hide" id="control_buttons" style="text-align: right;">
+    <?= pluginContent('sales_work_order_buttons', ['saleId' => $sale_id_num]) ?>
     <a href="javascript:printdoc();">
         <div class="btn btn-info btn-sm" id="show_print_button"><?= '<span class="glyphicon glyphicon-print">&nbsp;</span>' . lang('Common.print') ?></div>
     </a>


### PR DESCRIPTION
The plugin system can inject content into the sales receipt, but the invoice, quote and work order views have no hook point, so a plugin that delivers sale documents can only reach one of the four. Plugins also have no way to expose an inbound provider webhook, because a server-to-server callback carries no CSRF token and the global csrf filter has no plugin-safe exemption — leaving a core edit as the only option, which is what the plugin system exists to avoid.

This adds view:sales_invoice_buttons, view:sales_quote_buttons and view:sales_work_order_buttons — same position and same ['saleId' => ...] payload as the existing receipt hook — and exempts the plugins/*/webhook path from CSRF, with the plugin responsible for authenticating the caller itself. Documented in app/Plugins/README.md. Groundwork for the WhatsApp plugin, but not specific to it.