### PR TITLE
Bugfix: normalize quote style in SQL GROUP_CONCAT expression

### DIFF
--- a/app/Models/Sale.php
+++ b/app/Models/Sale.php
@@ -1095,7 +1095,7 @@ class Sale extends Model
                     SUM(CASE WHEN payments.cash_adjustment = 1 THEN payments.payment_amount ELSE 0 END) AS sale_cash_adjustment,
                     SUM(payments.cash_refund) AS sale_cash_refund,
                     GROUP_CONCAT(CONCAT(payments.payment_type, " ", (payments.payment_amount - payments.cash_refund)) SEPARATOR ", ") AS payment_type,
-                    GROUP_CONCAT(NULLIF(payments.reference_code, '') SEPARATOR ", ") AS reference_code
+                    GROUP_CONCAT(NULLIF(payments.reference_code, "") SEPARATOR ", ") AS reference_code
                 FROM ' . $this->db->prefixTable('sales_payments') . ' AS payments
                 INNER JOIN ' . $this->db->prefixTable('sales') . ' AS sales
                     ON sales.sale_id = payments.sale_id


### PR DESCRIPTION
MySQL doesn't like single quotes here.  This replaces it with double-quotes.  This fixes a problem with a recent change to the master branch.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved compatibility when combining payment reference codes during sales payment processing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->