### PR TITLE
fix(login): skip auth validation on new install to allow migration

### DIFF
--- a/app/Controllers/Login.php
+++ b/app/Controllers/Login.php
@@ -18,9 +18,9 @@ class Login extends BaseController
     public Model $employee;
 
     /**
-     * @return RedirectResponse|string
+     * @return RedirectResponse|ResponseInterface|string
      */
-    public function index(): string|RedirectResponse
+    public function index(): string|RedirectResponse|ResponseInterface
     {
         $this->employee = model(Employee::class);
         if (!$this->employee->is_logged_in()) {
@@ -33,13 +33,24 @@ class Login extends BaseController
 
             $migration->migrateToCI4();
 
+            $currentVersion = MY_Migration::getCurrentVersion();
+
+            if ($currentVersion === null) {
+                return $this->response->setJSON([
+                    'success' => false,
+                    'message' => lang('Login.migration_error_connection')
+                ])->setStatusCode(503);
+            }
+
+            $latestVersion = $migration->getLatestMigration();
+
             $validation = Services::validation();
 
             $data = [
                 'hasErrors'       => false,
-                'isNewInstall'   => MY_Migration::getCurrentVersion() === 0,
-                'isLatest'        => $migration->isLatest(),
-                'latestVersion'   => $migration->getLatestMigration(),
+                'isNewInstall'   => $currentVersion === 0,
+                'isLatest'        => $latestVersion === $currentVersion,
+                'latestVersion'   => $latestVersion,
                 'gcaptchaEnabled' => $gcaptchaEnabled,
                 'config'           => $config,
                 'validation'       => $validation

--- a/app/Controllers/Login.php
+++ b/app/Controllers/Login.php
@@ -37,7 +37,7 @@ class Login extends BaseController
 
             $data = [
                 'hasErrors'       => false,
-                'isNewInstall'   => !(MY_Migration::getCurrentVersion()),
+                'isNewInstall'   => MY_Migration::getCurrentVersion() === 0,
                 'isLatest'        => $migration->isLatest(),
                 'latestVersion'   => $migration->getLatestMigration(),
                 'gcaptchaEnabled' => $gcaptchaEnabled,
@@ -76,7 +76,17 @@ class Login extends BaseController
 
     public function migrate(): ResponseInterface
     {
-        $isNewInstall = !MY_Migration::getCurrentVersion();
+        $currentVersion = MY_Migration::getCurrentVersion();
+
+        if ($currentVersion === null) {
+            return $this->response->setJSON([
+                'success' => false,
+                'message' => lang('Login.migration_error_connection')
+            ])->setStatusCode(503);
+        }
+
+        // Only a confirmed empty database counts as a new install with no credentials to check.
+        $isNewInstall = $currentVersion === 0;
 
         if (!$isNewInstall) {
             $rules = ['username' => 'required|login_check[data]'];

--- a/app/Controllers/Login.php
+++ b/app/Controllers/Login.php
@@ -76,19 +76,23 @@ class Login extends BaseController
 
     public function migrate(): ResponseInterface
     {
-        $rules = ['username' => 'required|login_check[data]'];
-        $messages = [
-            'username' => [
-                'required'    => lang('Login.required_username'),
-                'login_check' => lang('Login.invalid_username_and_password'),
-            ]
-        ];
+        $isNewInstall = !MY_Migration::getCurrentVersion();
 
-        if (!$this->validate($rules, $messages)) {
-            return $this->response->setJSON([
-                'success' => false,
-                'message' => lang('Login.invalid_username_and_password')
-            ])->setStatusCode(401);
+        if (!$isNewInstall) {
+            $rules = ['username' => 'required|login_check[data]'];
+            $messages = [
+                'username' => [
+                    'required'    => lang('Login.required_username'),
+                    'login_check' => lang('Login.invalid_username_and_password'),
+                ]
+            ];
+
+            if (!$this->validate($rules, $messages)) {
+                return $this->response->setJSON([
+                    'success' => false,
+                    'message' => lang('Login.invalid_username_and_password')
+                ])->setStatusCode(401);
+            }
         }
 
         try {

--- a/app/Libraries/MY_Migration.php
+++ b/app/Libraries/MY_Migration.php
@@ -32,9 +32,10 @@ class MY_Migration extends MigrationRunner
     /**
      * Gets the database version number
      *
-     * @return int The version number of the last successfully run database migration.
+     * @return int|null The version number of the last successfully run database migration,
+     *                  0 for a confirmed empty database, or null if the database is unavailable.
      */
-    public static function getCurrentVersion(): int
+    public static function getCurrentVersion(): ?int
     {
         try {
             $db = Database::connect();
@@ -45,9 +46,9 @@ class MY_Migration extends MigrationRunner
                 return $result ? (int) $result->version : 0;
             }
         } catch (Exception $e) {
-            // Database not available yet (e.g. fresh install before schema).
+            // Database unavailable — distinct from a confirmed empty database.
             // Catches mysqli_sql_exception which is not a DatabaseException.
-            return 0;
+            return null;
         }
 
         return 0;


### PR DESCRIPTION
On fresh installs with no DB version, login validation would fail before migrations could run. Check MY_Migration::getCurrentVersion() and bypass credential check when no version exists.

closing #4603 4603

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Updated the installation/migration flow to more reliably detect new installs versus existing ones, ensuring username validation runs only when appropriate.
  * Improved behavior when the current migration version can’t be determined, returning a clear error response instead of continuing with an incorrect assumption.
  * Refined version detection to properly distinguish an “unknown/unavailable” state from an “empty” database state.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->