### PR TITLE
chore(deps): add xlsx via SheetJS CDN and upgrade tableexport plugin

### DIFF
--- a/app/Views/reports/tabular.php
+++ b/app/Views/reports/tabular.php
@@ -62,7 +62,7 @@
                 sortable: true,
                 showExport: true,
                 exportDataType: 'all',
-                exportTypes: ['json', 'xml', 'csv', 'txt', 'sql', 'excel', 'pdf'],
+                exportTypes: ['json', 'xml', 'csv', 'txt', 'sql', 'xlsx', 'pdf'],
                 pagination: true,
                 showColumns: true,
                 data: <?= json_encode($data) ?>,

--- a/app/Views/reports/tabular_details.php
+++ b/app/Views/reports/tabular_details.php
@@ -67,7 +67,7 @@
                 uniqueId: 'id',
                 showExport: true,
                 exportDataType: 'all',
-                exportTypes: ['json', 'xml', 'csv', 'txt', 'sql', 'excel', 'pdf'],
+                exportTypes: ['json', 'xml', 'csv', 'txt', 'sql', 'xlsx', 'pdf'],
                 data: <?= json_encode($summary_data) ?>,
                 iconSize: 'sm',
                 paginationVAlign: 'bottom',

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -123,6 +123,7 @@ gulp.task('debug-js', function() {
         './node_modules/jspdf/dist/jspdf.umd.js',
         './node_modules/dompurify/dist/purify.js',
         './node_modules/jspdf-autotable/dist/jspdf.plugin.autotable.js',
+        './node_modules/xlsx/dist/xlsx.full.min.js',
         './node_modules/tableexport.jquery.plugin/tableExport.min.js',
         './node_modules/chartist/dist/chartist.js',
         './node_modules/chartist-plugin-pointlabels/dist/chartist-plugin-pointlabels.js',
@@ -172,6 +173,7 @@ gulp.task('prod-js', function() {
         './node_modules/chartist-plugin-axistitle/dist/chartist-plugin-axistitle.min.js',
         './node_modules/chartist-plugin-tooltips/dist/chartist-plugin-tooltip.min.js',
         './node_modules/chartist-plugin-barlabels/dist/chartist-plugin-barlabels.min.js',
+        './node_modules/xlsx/dist/xlsx.full.min.js',
         './node_modules/tableexport.jquery.plugin/tableExport.min.js'], { allowEmpty: true });
 
     var opensourcepos2js = gulp.src(['./node_modules/bootstrap-daterangepicker/daterangepicker.js',

--- a/package-lock.json
+++ b/package-lock.json
@@ -40,7 +40,7 @@
                 "jquery-validation": "^1.19.5",
                 "jspdf": "^4.2.1",
                 "jspdf-autotable": "^5.0.7",
-                "tableexport.jquery.plugin": "^1.30.0"
+                "tableexport.jquery.plugin": "^1.33.0"
             },
             "devDependencies": {
                 "gulp": "^5.0.1",
@@ -311,14 +311,6 @@
             },
             "engines": {
                 "node": ">=6.5"
-            }
-        },
-        "node_modules/adler-32": {
-            "version": "1.3.1",
-            "resolved": "https://registry.npmjs.org/adler-32/-/adler-32-1.3.1.tgz",
-            "integrity": "sha512-ynZ4w/nUUv5rrsR8UUGoe1VC9hZj6V5hU9Qw1HlMDJGEJw5S7TfTErWTjMys6M7vr0YWcPqs3qAr4ss0nDfP+A==",
-            "engines": {
-                "node": ">=0.8"
             }
         },
         "node_modules/ansi-colors": {
@@ -917,9 +909,9 @@
             "license": "MIT"
         },
         "node_modules/brace-expansion": {
-            "version": "2.1.0",
-            "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.1.0.tgz",
-            "integrity": "sha512-TN1kCZAgdgweJhWWpgKYrQaMNHcDULHkWwQIspdtjV4Y5aurRdZpjAqn6yX3FPqTA9ngHCc4hJxMAMgGfve85w==",
+            "version": "2.1.4",
+            "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.1.4.tgz",
+            "integrity": "sha512-hGfVzPxthbf3+2yjg/RBs60cB0FhqBS/zvdV/4wn4/BmN0bNMMHPc4V/BbFieqf1TKAGGAHnY4eSjajCl0f2Xg==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
@@ -1074,18 +1066,6 @@
             "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.13.11.tgz",
             "integrity": "sha512-kY1AZVr2Ra+t+piVaJ4gxaFaReZVH40AKNo7UCX6W+dEwBo/2oZJzqfuN1qLq1oL45o56cPaTXELwrTh8Fpggg==",
             "optional": true
-        },
-        "node_modules/cfb": {
-            "version": "1.2.2",
-            "resolved": "https://registry.npmjs.org/cfb/-/cfb-1.2.2.tgz",
-            "integrity": "sha512-KfdUZsSOw19/ObEWasvBP/Ac4reZvAGauZhs6S/gqNhXhI7cKwvlH7ulj+dOEYnca4bm4SGo8C1bTAQvnTjgQA==",
-            "dependencies": {
-                "adler-32": "~1.3.0",
-                "crc-32": "~1.2.0"
-            },
-            "engines": {
-                "node": ">=0.8"
-            }
         },
         "node_modules/chalk": {
             "version": "5.3.0",
@@ -1325,14 +1305,6 @@
                 "safe-buffer": "~5.1.0"
             }
         },
-        "node_modules/codepage": {
-            "version": "1.15.0",
-            "resolved": "https://registry.npmjs.org/codepage/-/codepage-1.15.0.tgz",
-            "integrity": "sha512-3g6NUTPd/YtuuGrhMnOMRjFc+LJw/bnMp3+0r/Wcz3IXUuCosKRJvMphm5+Q+bvTVGcJJuRvVLuYba+WojaFaA==",
-            "engines": {
-                "node": ">=0.8"
-            }
-        },
         "node_modules/coffeescript": {
             "version": "2.7.0",
             "resolved": "https://registry.npmjs.org/coffeescript/-/coffeescript-2.7.0.tgz",
@@ -1461,6 +1433,7 @@
             "version": "1.2.2",
             "resolved": "https://registry.npmjs.org/crc-32/-/crc-32-1.2.2.tgz",
             "integrity": "sha512-ROmzCKrTnOwybPcJApAA6WBWij23HVfGVNKqqrZpuyZOHqK2CwHSvpGuyt/UNNvaIjEd8X5IFGp4Mh+Ie1IHJQ==",
+            "dev": true,
             "bin": {
                 "crc32": "bin/crc32.njs"
             },
@@ -2117,14 +2090,6 @@
             "license": "MIT",
             "engines": {
                 "node": ">= 18"
-            }
-        },
-        "node_modules/frac": {
-            "version": "1.1.2",
-            "resolved": "https://registry.npmjs.org/frac/-/frac-1.1.2.tgz",
-            "integrity": "sha512-w/XBfkibaTl3YDqASwfDUqkna4Z2p9cFSr1aHDt0WoMTECnRfBOv2WArlZILlqgWlmdIlALXGpM2AOhEk5W3IA==",
-            "engines": {
-                "node": ">=0.8"
             }
         },
         "node_modules/fs-mkdirp-stream": {
@@ -5262,9 +5227,9 @@
             }
         },
         "node_modules/rimraf/node_modules/brace-expansion": {
-            "version": "1.1.12",
-            "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.12.tgz",
-            "integrity": "sha512-9T9UjW3r0UW5c1Q7GTwllptXwhvYmEzFhzMfZ9H7FQWt+uZePjZPjBP/W1ZEyZ1twGWom5/56TF4lPcqjnDHcg==",
+            "version": "1.1.18",
+            "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.18.tgz",
+            "integrity": "sha512-Edep/X9fGqVNmzKBVsDYIOtD+z1tuezV70LBjdCst9Tqu76lsnvRiZ6oTic1n+/BIwX6QDGAO94PN4N2SADvtw==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
@@ -5481,17 +5446,6 @@
             "dev": true,
             "engines": {
                 "node": ">= 0.10"
-            }
-        },
-        "node_modules/ssf": {
-            "version": "0.11.2",
-            "resolved": "https://registry.npmjs.org/ssf/-/ssf-0.11.2.tgz",
-            "integrity": "sha512-+idbmIXoYET47hH+d7dfm2epdOMUDjqcB4648sTZ+t2JwoyBFL/insLfB/racrDmsKB3diwsDA696pZMieAC5g==",
-            "dependencies": {
-                "frac": "~1.1.2"
-            },
-            "engines": {
-                "node": ">=0.8"
             }
         },
         "node_modules/stackblur-canvas": {
@@ -6545,22 +6499,6 @@
                 "url": "https://github.com/sponsors/ljharb"
             }
         },
-        "node_modules/wmf": {
-            "version": "1.0.2",
-            "resolved": "https://registry.npmjs.org/wmf/-/wmf-1.0.2.tgz",
-            "integrity": "sha512-/p9K7bEh0Dj6WbXg4JG0xvLQmIadrner1bi45VMJTfnbVHsc7yIajZyoSoK60/dtVBs12Fm6WkUI5/3WAVsNMw==",
-            "engines": {
-                "node": ">=0.8"
-            }
-        },
-        "node_modules/word": {
-            "version": "0.3.0",
-            "resolved": "https://registry.npmjs.org/word/-/word-0.3.0.tgz",
-            "integrity": "sha512-OELeY0Q61OXpdUfTp+oweA/vtLVg5VDOXh+3he3PNzLGG/y0oylSOC1xRVj0+l4vQ3tj/bB1HVHv1ocXkQceFA==",
-            "engines": {
-                "node": ">=0.8"
-            }
-        },
         "node_modules/wordwrapjs": {
             "version": "5.1.1",
             "resolved": "https://registry.npmjs.org/wordwrapjs/-/wordwrapjs-5.1.1.tgz",
@@ -6721,18 +6659,10 @@
             "dev": true
         },
         "node_modules/xlsx": {
-            "version": "0.18.5",
-            "resolved": "https://registry.npmjs.org/xlsx/-/xlsx-0.18.5.tgz",
-            "integrity": "sha512-dmg3LCjBPHZnQp5/F/+nnTa+miPJxUXB6vtk42YjBBKayDNagxGEeIdWApkYPOf3Z3pm3k62Knjzp7lMeTEtFQ==",
-            "dependencies": {
-                "adler-32": "~1.3.0",
-                "cfb": "~1.2.1",
-                "codepage": "~1.15.0",
-                "crc-32": "~1.2.1",
-                "ssf": "~0.11.2",
-                "wmf": "~1.0.1",
-                "word": "~0.3.0"
-            },
+            "version": "0.20.3",
+            "resolved": "https://cdn.sheetjs.com/xlsx-0.20.3/xlsx-0.20.3.tgz",
+            "integrity": "sha512-oLDq3jw7AcLqKWH2AhCpVTZl8mf6X2YReP+Neh0SJUzV/BdZYjth94tG5toiMB1PPrYtxOCfaoUCkvtuH+3AJA==",
+            "license": "Apache-2.0",
             "bin": {
                 "xlsx": "bin/xlsx.njs"
             },

--- a/package.json
+++ b/package.json
@@ -60,7 +60,10 @@
         "jquery-validation": "^1.19.5",
         "jspdf": "^4.2.1",
         "jspdf-autotable": "^5.0.7",
-        "tableexport.jquery.plugin": "^1.30.0"
+        "tableexport.jquery.plugin": "^1.33.0"
+    },
+    "overrides": {
+        "xlsx": "https://cdn.sheetjs.com/xlsx-0.20.3/xlsx-0.20.3.tgz"
     },
     "devDependencies": {
         "gulp": "^5.0.1",


### PR DESCRIPTION
This resolves Dependabot dependency alert 72 (https://github.com/opensourcepos/opensourcepos/security/dependabot/72) and 71 (https://github.com/opensourcepos/opensourcepos/security/dependabot/71) 
- Add xlsx 0.20.3 from SheetJS CDN via package overrides
- Bump tableexport.jquery.plugin from ^1.30.0 to ^1.33.0
- Add xlsx bundle to gulp JS pipeline before tableexport

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Updated report exports to use the XLSX spreadsheet format.
  * Added XLSX support to both development and production builds.
* **Bug Fixes**
  * Improved compatibility and reliability for spreadsheet exports in tabular and detailed reports.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->