### PR TITLE
chore(deps): bump lodash.template from 4.5.0 to 4.18.1

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -4369,10 +4369,12 @@
             "license": "MIT"
         },
         "node_modules/lodash.template": {
-            "version": "4.5.0",
-            "resolved": "https://registry.npmjs.org/lodash.template/-/lodash.template-4.5.0.tgz",
-            "integrity": "sha512-84vYFxIkmidUiFxidA/KjjH9pAycqW+h980j7Fuz5qxRtO9pgB7MDFTdys1N7A5mcucRiDyEq4fusljItR1T/A==",
+            "version": "4.18.1",
+            "resolved": "https://registry.npmjs.org/lodash.template/-/lodash.template-4.18.1.tgz",
+            "integrity": "sha512-5urZrLnV/VD6zHK5KsVtZgt7H19v51mIzoS0aBNH8yp3I8tbswrEjOABOPY8m8uB7NuibubLrMX+Y0PXsU9X+w==",
+            "deprecated": "This package is deprecated. Use https://socket.dev/npm/package/eta instead.",
             "dev": true,
+            "license": "MIT",
             "dependencies": {
                 "lodash._reinterpolate": "^3.0.0",
                 "lodash.templatesettings": "^4.0.0"


### PR DESCRIPTION
Fixes dependabot alert 126 (https://github.com/opensourcepos/opensourcepos/security/dependabot/126)