### PR TITLE
fix(config): validate theme param to prevent XSS via invalid theme

### DIFF
--- a/app/Config/Validation/OSPOSRules.php
+++ b/app/Config/Validation/OSPOSRules.php
@@ -165,7 +165,12 @@ class OSPOSRules
         $dir = new DirectoryIterator('resources/bootswatch');
 
         foreach ($dir as $fileInfo) {
-            if ($fileInfo->isDir() && !$fileInfo->isDot() && $fileInfo->getFilename() === $theme) {
+            if (
+                $fileInfo->isDir()
+                && !$fileInfo->isDot()
+                && $fileInfo->getFilename() !== 'fonts'
+                && $fileInfo->getFilename() === $theme
+            ) {
                 return true;
             }
         }

--- a/app/Config/Validation/OSPOSRules.php
+++ b/app/Config/Validation/OSPOSRules.php
@@ -6,6 +6,7 @@ use App\Models\Employee;
 use CodeIgniter\HTTP\IncomingRequest;
 use Config\OSPOS;
 use Config\Services;
+use DirectoryIterator;
 
 /**
  * @property Employee employee
@@ -149,5 +150,26 @@ class OSPOSRules
         $value = parse_decimals($candidate);
 
         return $value !== false && $value >= 0;
+    }
+
+    /**
+     * Validates that the candidate theme name matches an installed bootswatch theme directory.
+     *
+     * @param string $theme
+     * @param string|null $error
+     * @return bool
+     * @noinspection PhpUnused
+     */
+    public function themeExists(string $theme, ?string &$error = null): bool
+    {
+        $dir = new DirectoryIterator('resources/bootswatch');
+
+        foreach ($dir as $fileInfo) {
+            if ($fileInfo->isDir() && !$fileInfo->isDot() && $fileInfo->getFilename() === $theme) {
+                return true;
+            }
+        }
+
+        return false;
     }
 }

--- a/app/Controllers/Config.php
+++ b/app/Controllers/Config.php
@@ -370,6 +370,14 @@ class Config extends Secure_Controller
      */
     public function postSaveGeneral(): ResponseInterface
     {
+        $rules = [
+            'theme' => 'permit_empty|themeExists',
+        ];
+        if (!$this->validate($rules)) {
+            $errors = $this->validator->getErrors();
+            return $this->response->setJSON(['success' => false, 'message' => reset($errors)]);
+        }
+
         $batchSaveData = [
             'theme'                             => $this->request->getPost('theme'),
             'login_form'                        => $this->request->getPost('login_form'),

--- a/app/Views/login.php
+++ b/app/Views/login.php
@@ -32,7 +32,7 @@ $request = Services::request();
         ? 'flatly'
         : $config['theme']);
     ?>
-    <link rel="stylesheet" href="resources/bootswatch5/<?= "$theme" ?>/bootstrap.min.css">
+    <link rel="stylesheet" href="resources/bootswatch5/<?= esc($theme, 'attr') ?>/bootstrap.min.css">
     <link rel="stylesheet" href="css/login.css">
     <meta name="theme-color" content="#2c3e50">
 </head>

--- a/tests/Controllers/ConfigTest.php
+++ b/tests/Controllers/ConfigTest.php
@@ -284,4 +284,107 @@ class ConfigTest extends CIUnitTestCase
         $result = json_decode($response->getJSON(), true);
         $this->assertTrue($result['success']);
     }
+
+    // ========== postSaveGeneral: theme validation ==========
+
+    private function baseGeneralPayload(array $overrides = []): array
+    {
+        return array_merge([
+            'theme'                          => 'flatly',
+            'login_form'                     => 'floating_labels',
+            'default_sales_discount_type'    => '',
+            'default_sales_discount'         => '0.00',
+            'default_receivings_discount_type' => '',
+            'default_receivings_discount'    => '0.00',
+            'enforce_privacy'                => '',
+            'receiving_calculate_average_price' => '',
+            'lines_per_page'                 => '20',
+            'notify_horizontal_position'     => 'bottom',
+            'notify_vertical_position'       => 'right',
+            'image_max_width'                => '1000',
+            'image_max_height'               => '1000',
+            'image_max_size'                 => '5120',
+            'image_allowed_types'            => ['jpg', 'jpeg', 'gif', 'png'],
+            'gcaptcha_enable'                => '',
+            'gcaptcha_secret_key'            => '',
+            'gcaptcha_site_key'              => '',
+            'suggestions_first_column'       => 'name',
+            'suggestions_second_column'      => '',
+            'suggestions_third_column'       => '',
+            'giftcard_number'                => '',
+            'derive_sale_quantity'           => '',
+            'multi_pack_enabled'             => '',
+            'include_hsn'                    => '',
+            'category_dropdown'              => '',
+            'show_office_group'              => '',
+        ], $overrides);
+    }
+
+    public function testSaveGeneral_AcceptsValidTheme(): void
+    {
+        $this->resetSession();
+
+        $response = $this->post('/config/saveGeneral', $this->baseGeneralPayload([
+            'theme' => 'darkly',
+        ]));
+
+        $response->assertStatus(200);
+        $result = json_decode($response->getJSON(), true);
+        $this->assertTrue($result['success']);
+    }
+
+    public function testSaveGeneral_AcceptsEmptyTheme(): void
+    {
+        $this->resetSession();
+
+        $response = $this->post('/config/saveGeneral', $this->baseGeneralPayload([
+            'theme' => '',
+        ]));
+
+        $response->assertStatus(200);
+        $result = json_decode($response->getJSON(), true);
+        $this->assertTrue($result['success']);
+    }
+
+    public function testSaveGeneral_RejectsUnknownTheme(): void
+    {
+        $this->resetSession();
+
+        $response = $this->post('/config/saveGeneral', $this->baseGeneralPayload([
+            'theme' => 'nonexistent',
+        ]));
+
+        $response->assertStatus(200);
+        $result = json_decode($response->getJSON(), true);
+        $this->assertFalse($result['success']);
+        $this->assertStringContainsString('theme', strtolower($result['message']));
+    }
+
+    public function testSaveGeneral_RejectsXssPayloadInTheme(): void
+    {
+        $this->resetSession();
+
+        $response = $this->post('/config/saveGeneral', $this->baseGeneralPayload([
+            'theme' => 'x" onerror="alert(document.domain)" x="',
+        ]));
+
+        $response->assertStatus(200);
+        $result = json_decode($response->getJSON(), true);
+        $this->assertFalse($result['success']);
+        $this->assertStringContainsString('theme', strtolower($result['message']));
+    }
+
+    public function testSaveGeneral_RejectsNonThemeDirectory(): void
+    {
+        $this->resetSession();
+
+        $response = $this->post('/config/saveGeneral', $this->baseGeneralPayload([
+            'theme' => 'fonts',
+        ]));
+
+        $response->assertStatus(200);
+        $result = json_decode($response->getJSON(), true);
+        $this->assertFalse($result['success']);
+        $this->assertStringContainsString('theme', strtolower($result['message']));
+    }
 }


### PR DESCRIPTION
Add validation rule for theme field before batch save, rejecting requests with unrecognized theme values. Add test coverage for theme validation in postSaveGeneral.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Added validation to prevent invalid or unsafe theme selections from being saved.
  * Theme-related errors are now clearly returned when configuration updates fail.
  * Improved security when displaying the selected login-page theme.
  * Non-theme directories can no longer be selected as application themes.
  * Valid and empty theme selections continue to save successfully.
* **Tests**
  * Added coverage for valid, empty, unknown, unsafe, and unsupported theme values.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->