### PR TITLE
refactor: apply PSR-12 naming and return documentation to Attribute definition methods

### DIFF
--- a/app/Controllers/Attributes.php
+++ b/app/Controllers/Attributes.php
@@ -221,7 +221,7 @@ class Attributes extends Secure_Controller
     private function get_attributes(int $definition_flags = 0): array
     {
         $definition_flag_names = [];
-        foreach (Attribute::get_definition_flags() as $id => $term) {
+        foreach (Attribute::getDefinitionFlags() as $id => $term) {
             if ($id & $definition_flags) {
                 $definition_flag_names[$id] = lang('Attributes.' . strtolower($term) . '_visibility');
             }
@@ -241,8 +241,8 @@ class Attributes extends Secure_Controller
         }
 
         $data['definition_id'] = $definition_id;
-        $data['definition_values'] = $this->attribute->get_definition_values($definition_id);
-        $data['definition_group'] = $this->attribute->get_definitions_by_type(GROUP, $definition_id);
+        $data['definition_values'] = $this->attribute->getDefinitionValues($definition_id);
+        $data['definition_group'] = $this->attribute->getDefinitionsByType(GROUP, $definition_id);
         $data['definition_group'][''] = lang('Common.none_selected_text');
         $data['definition_info'] = $info;
 

--- a/app/Controllers/Items.php
+++ b/app/Controllers/Items.php
@@ -110,7 +110,7 @@ class Items extends Secure_Controller
 
         $this->item_lib->set_item_location($this->request->getGet('stock_location'));
 
-        $definition_names = $this->attribute->get_definitions_by_flags(Attribute::SHOW_IN_ITEMS);
+        $definition_names = $this->attribute->getDefinitionsByFlags(Attribute::SHOW_IN_ITEMS);
 
         $filters = [
             'start_date'        => $this->request->getGet('start_date'),
@@ -304,7 +304,7 @@ class Items extends Secure_Controller
         $data['default_tax_2_rate'] = '';
         $data['item_kit_disabled'] = !$this->employee->has_grant('item_kits', $this->employee->get_logged_in_employee_info()->person_id);
         $data['definition_values'] = $this->attribute->get_attributes_by_item($item_id);
-        $data['definition_names'] = $this->attribute->get_definition_names();
+        $data['definition_names'] = $this->attribute->getDefinitionNames();
 
         foreach ($data['definition_values'] as $definition_id => $definition) {
             unset($data['definition_names'][$definition_id]);
@@ -320,7 +320,7 @@ class Items extends Secure_Controller
 
         if ($data['category_dropdown'] === '1') {
             $categories = ['' => lang('Items.none')];
-            $category_options = $this->attribute->get_definition_values(CATEGORY_DEFINITION_ID);
+            $category_options = $this->attribute->getDefinitionValues(CATEGORY_DEFINITION_ID);
             $category_options = array_combine($category_options, $category_options);    // Overwrite indexes with values for saving in items table instead of attributes
             $data['categories'] = array_merge($categories, $category_options);
 
@@ -518,7 +518,7 @@ class Items extends Secure_Controller
         $data['item_id'] = $item_id;
         $definition_ids = json_decode($this->request->getGet('definition_ids') ?? '', true);
         $data['definition_values'] = $this->attribute->get_attributes_by_item($item_id) + $this->attribute->get_values_by_definitions($definition_ids);
-        $data['definition_names'] = $this->attribute->get_definition_names();
+        $data['definition_names'] = $this->attribute->getDefinitionNames();
 
         foreach ($data['definition_values'] as $definition_id => $definition_value) {
             $attribute_value = $this->attribute->getAttributeValue($item_id, $definition_id);
@@ -529,7 +529,7 @@ class Items extends Secure_Controller
             $values['selected_value'] = '';
 
             if ($definition_value['definition_type'] === DROPDOWN) {
-                $values['values'] = $this->attribute->get_definition_values($definition_id);
+                $values['values'] = $this->attribute->getDefinitionValues($definition_id);
                 $link_value = $this->attribute->get_link_value($item_id, $definition_id);
                 $values['selected_value'] = (empty($link_value)) ? '' : $link_value->attribute_id;
             }
@@ -554,7 +554,7 @@ class Items extends Secure_Controller
         $data['item_id'] = $item_id;
         $definition_ids = json_decode($this->request->getPost('definition_ids'), true);
         $data['definition_values'] = $this->attribute->get_attributes_by_item($item_id) + $this->attribute->get_values_by_definitions($definition_ids);
-        $data['definition_names'] = $this->attribute->get_definition_names();
+        $data['definition_names'] = $this->attribute->getDefinitionNames();
 
         foreach ($data['definition_values'] as $definition_id => $definition_value) {
             $attribute_value = $this->attribute->getAttributeValue($item_id, $definition_id);
@@ -565,7 +565,7 @@ class Items extends Secure_Controller
             $values['selected_value'] = '';
 
             if ($definition_value['definition_type'] === DROPDOWN) {
-                $values['values'] = $this->attribute->get_definition_values($definition_id);
+                $values['values'] = $this->attribute->getDefinitionValues($definition_id);
                 $link_value = $this->attribute->get_link_value($item_id, $definition_id);
                 $values['selected_value'] = (empty($link_value)) ? '' : $link_value->attribute_id;
             }
@@ -959,7 +959,7 @@ class Items extends Secure_Controller
         helper('importfile');
         $name = 'import_items.csv';
         $allowed_locations = $this->stock_location->get_allowed_locations();
-        $allowed_attributes = $this->attribute->get_definition_names();
+        $allowed_attributes = $this->attribute->getDefinitionNames();
         $data = generate_import_items_csv($allowed_locations, $allowed_attributes);
 
         return $this->response->download($name, $data);
@@ -993,7 +993,7 @@ class Items extends Secure_Controller
                     $csvRows = get_csv_file($_FILES['file_path']['tmp_name']);
                     $employeeId = $this->employee->get_logged_in_employee_info()->person_id;
                     $allowedStockLocations = $this->stock_location->get_allowed_locations();
-                    $attributeDefinitionNames    = $this->attribute->get_definition_names();
+                    $attributeDefinitionNames    = $this->attribute->getDefinitionNames();
 
                     unset($attributeDefinitionNames[NEW_ENTRY]);    // Removes the common_none_selected_text from the array
 
@@ -1001,10 +1001,10 @@ class Items extends Secure_Controller
 
 
                     foreach ($attributeDefinitionNames as $definitionName) {
-                        $attributeData[$definitionName] = $this->attribute->get_definition_by_name($definitionName);
+                        $attributeData[$definitionName] = $this->attribute->getDefinitionByName($definitionName);
 
                         if ($attributeData[$definitionName]['definition_type'] === DROPDOWN) {
-                            $attributeData[$definitionName]['dropdown_values'] = $this->attribute->get_definition_values($attributeData[$definitionName]['definition_id']);
+                            $attributeData[$definitionName]['dropdown_values'] = $this->attribute->getDefinitionValues($attributeData[$definitionName]['definition_id']);
                         }
                     }
                     $db = db_connect();

--- a/app/Controllers/Reports.php
+++ b/app/Controllers/Reports.php
@@ -1778,7 +1778,7 @@ class Reports extends Secure_Controller
     {
         $this->clearCache();
 
-        $definition_names = $this->attribute->get_definitions_by_flags(attribute::SHOW_IN_SALES, true);
+        $definition_names = $this->attribute->getDefinitionsByFlags(attribute::SHOW_IN_SALES, true);
 
         $inputs = [
             'start_date'     => $start_date,
@@ -1937,7 +1937,7 @@ class Reports extends Secure_Controller
     {
         $this->clearCache();
 
-        $definition_names = $this->attribute->get_definitions_by_flags(attribute::SHOW_IN_RECEIVINGS, true);
+        $definition_names = $this->attribute->getDefinitionsByFlags(attribute::SHOW_IN_RECEIVINGS, true);
 
         $inputs = ['start_date' => $start_date, 'end_date' => $end_date, 'receiving_type' => $receiving_type, 'location_id' => $location_id, 'definition_ids' => array_keys($definition_names)];
 

--- a/app/Helpers/tabular_helper.php
+++ b/app/Helpers/tabular_helper.php
@@ -409,7 +409,7 @@ function get_items_manage_table_headers(): string
 {
     $attribute = model(Attribute::class);
     $config = config(OSPOS::class)->settings;
-    $definitionsWithTypes = $attribute->get_definitions_by_flags($attribute::SHOW_IN_ITEMS, true);
+    $definitionsWithTypes = $attribute->getDefinitionsByFlags($attribute::SHOW_IN_ITEMS, true);
 
     $headers = item_headers();
 
@@ -480,7 +480,7 @@ function get_item_data_row(object $item): array
         $item->name .= NAME_SEPARATOR . $item->pack_name;
     }
 
-    $definition_names = $attribute->get_definitions_by_flags($attribute::SHOW_IN_ITEMS, true);
+    $definition_names = $attribute->getDefinitionsByFlags($attribute::SHOW_IN_ITEMS, true);
 
     $columns = [
         'items.item_id' => $item->item_id,
@@ -699,7 +699,7 @@ function get_attribute_definition_data_row(object $attribute_row): array
     $attribute = model(Attribute::class);
     $controller = get_controller();
 
-    if (count($attribute->get_definition_flags()) == 0) {
+    if (count($attribute->getDefinitionFlags()) == 0) {
         $definition_flags = lang('Common.none_selected_text');
     } elseif ($attribute->definition_type == GROUP) {
         $definition_flags = "-";

--- a/app/Models/Attribute.php
+++ b/app/Models/Attribute.php
@@ -60,7 +60,7 @@ class Attribute extends Model
     /**
      * @return array
      */
-    public static function get_definition_flags(): array
+    public static function getDefinitionFlags(): array
     {
         $class = new ReflectionClass(__CLASS__);
 
@@ -245,7 +245,7 @@ class Attribute extends Model
      * @param int $definition_id
      * @return array
      */
-    public function get_definitions_by_type(string $attribute_type, int $definition_id = NO_DEFINITION_ID): array
+    public function getDefinitionsByType(string $attribute_type, int $definition_id = NO_DEFINITION_ID): array
     {
         $builder = $this->db->table('attribute_definitions');
         $builder->where('definition_type', $attribute_type);
@@ -266,7 +266,7 @@ class Attribute extends Model
      * @param bool $include_types If true, returns array with definition_id => ['name' => name, 'type' => type]
      * @return array
      */
-    public function get_definitions_by_flags(int $definition_flags, bool $include_types = false): array
+    public function getDefinitionsByFlags(int $definition_flags, bool $include_types = false): array
     {
         $builder = $this->db->table('attribute_definitions');
         $builder->where(new RawSql("definition_flags & $definition_flags"));    // TODO: we need to heed CI warnings to escape properly
@@ -296,7 +296,7 @@ class Attribute extends Model
      * @param     boolean        $groups        If false does not return GROUP type attributes in the array
      * @return    array                    Array containing definition IDs, attribute names and -1 index with the local language '[SELECT]' line.
      */
-    public function get_definition_names(bool $groups = true): array
+    public function getDefinitionNames(bool $groups = true): array
     {
         $builder = $this->db->table('attribute_definitions');
         $builder->where('deleted', 0);
@@ -316,7 +316,7 @@ class Attribute extends Model
      * @param int $definition_id
      * @return array
      */
-    public function get_definition_values(int $definition_id): array
+    public function getDefinitionValues(int $definition_id): array
     {
         $attribute_values = [];
 
@@ -574,11 +574,13 @@ class Attribute extends Model
     }
 
     /**
-     * @param string $definition_name
-     * @param string|bool $definition_type
-     * @return array
+     * Looks up a single, non-deleted attribute definition by name.
+     *
+     * @param string $definition_name Name of the definition to look up
+     * @param string|bool $definition_type Optional definition type used to further constrain the lookup
+     * @return array The matching definition row as an associative array, or an empty array when no definition matches
      */
-    public function get_definition_by_name(string $definition_name, string|bool $definition_type = false): array
+    public function getDefinitionByName(string $definition_name, string|bool $definition_type = false): array
     {
         $builder = $this->db->table('attribute_definitions');
         $builder->where('definition_name', $definition_name);


### PR DESCRIPTION
## Summary

Renames the Attribute-specific definition methods from `snake_case` to PSR-12 `camelCase` and updates every call site, plus documents `getDefinitionByName()`'s return contract.

| before | after |
|---|---|
| `get_definition_by_name()` | `getDefinitionByName()` |
| `get_definition_names()` | `getDefinitionNames()` |
| `get_definition_values()` | `getDefinitionValues()` |
| `get_definitions_by_type()` | `getDefinitionsByType()` |
| `get_definitions_by_flags()` | `getDefinitionsByFlags()` |
| `get_definition_flags()` | `getDefinitionFlags()` |

The `getDefinitionByName()` PHPDoc now states that it returns one definition row as an associative array, or `[]` when no definition exists — matching the `getRowArray()` behaviour introduced in #4464. Behaviour is otherwise unchanged; this is a pure rename.

## Scope decision (please sanity-check)

I deliberately did **not** rename `get_found_rows()` and `get_total_rows()`. They're declared in 15 models (`Sale`, `Customer`, `Item`, `Employee`, `Supplier`, …), so they read as a shared model convention rather than Attribute-specific naming — renaming them only in `Attribute` would leave the codebase inconsistent. Happy to do them as a separate codebase-wide PR if you want that; I raised this in #4622 before starting.

## Verification

- Every renamed symbol was located repo-wide first (25 occurrences: 6 declarations + 19 call sites across `Models/Attribute.php`, `Controllers/Items.php`, `Controllers/Attributes.php`, `Controllers/Reports.php`, `Helpers/tabular_helper.php`). After the rename, a repo-wide grep for all six old names returns **0 hits**.
- Checked for dynamic dispatch that a grep-based rename would miss (`$this->{...}()`, `call_user_func`, `method_exists`) — the only dynamic access in these files is *property* access (`$obj->$field`), no dynamic method calls, so the rename is complete.
- `php -l` passes on all five changed files.

## On the CS fixer and tests

Two things I want to be upfront about rather than imply a clean run I didn't get:

- **PHP-CS-Fixer**: I did not run `vendor/bin/php-cs-fixer fix` over these files. On current `master` the fixer reports 1256 of 1403 files as fixable, and running it on just these five would add ~2200 lines of unrelated formatting churn on top of a ~30-line rename. Keeping the diff reviewable seemed more useful; happy to run it if you'd prefer, or to open a separate formatting PR.
- **PHPUnit**: `phpunit.xml.dist` points the suite at a live MySQL instance, which I don't have provisioned, so I did not run `composer test`. Nothing under `tests/` references any of the renamed methods, so I'd expect no impact — but I haven't proven that with a green run.

Refs #4622

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Standardized attribute handling across item management, reports, forms, CSV import/export, and attribute configuration.
  * Improved consistency of attribute lookups and value retrieval throughout the application.
* **Bug Fixes**
  * Preserved existing behavior while ensuring attribute-based searches, reports, imports, exports, and dropdowns continue working reliably.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->