### PR TITLE
fix(sales): escape quote number in email template to prevent XSS

### DIFF
--- a/app/Views/sales/quote_email.php
+++ b/app/Views/sales/quote_email.php
@@ -149,7 +149,7 @@
                 <?= nl2br(esc($config['return_policy'])) ?>
             </div>
             <div id="barcode">
-                <?= $quote_number ?>
+                <?= esc($quote_number) ?>
             </div>
         </div>
     </div>


### PR DESCRIPTION
Wrap $quote_number output with esc() in quote_email.php. Raw interpolation allowed injected HTML/JS via quote number field.

Hardens GHSA-hwjh-f7jr-846c

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved security in quote emails by safely escaping quote numbers displayed in barcodes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->