### PR TITLE
fix(xss): remove redundant escaping that double-encoded item attribute values

### DIFF
--- a/app/Controllers/Attributes.php
+++ b/app/Controllers/Attributes.php
@@ -65,7 +65,7 @@ class Attributes extends Secure_Controller
     public function postSaveAttributeValue(): ResponseInterface
     {
         $success = $this->attribute->saveAttributeValue(
-            html_entity_decode($this->request->getPost('attribute_value')),
+            $this->request->getPost('attribute_value'),
             $this->request->getPost('definition_id', FILTER_SANITIZE_NUMBER_INT),
             $this->request->getPost('item_id', FILTER_SANITIZE_NUMBER_INT) ?? false,
             $this->request->getPost('attribute_id', FILTER_SANITIZE_NUMBER_INT) ?? false
@@ -82,7 +82,7 @@ class Attributes extends Secure_Controller
     public function postDeleteDropdownAttributeValue(): ResponseInterface
     {
         $success = $this->attribute->deleteDropdownAttributeValue(
-            html_entity_decode($this->request->getPost('attribute_value')),
+            $this->request->getPost('attribute_value'),
             $this->request->getPost('definition_id', FILTER_SANITIZE_NUMBER_INT)
         );
 
@@ -135,7 +135,7 @@ class Attributes extends Secure_Controller
         if ($this->attribute->saveDefinition($definition_data, $definition_id)) {
             // New definition
             if ($definition_id == NO_DEFINITION_ID) {
-                $definition_values = json_decode(html_entity_decode($this->request->getPost('definition_values')));
+                $definition_values = json_decode($this->request->getPost('definition_values'));
 
                 foreach ($definition_values as $definition_value) {
                     $this->attribute->saveAttributeValue($definition_value, $definition_data['definition_id']);

--- a/app/Controllers/Attributes.php
+++ b/app/Controllers/Attributes.php
@@ -5,6 +5,7 @@ namespace App\Controllers;
 use App\Models\Attribute;
 use CodeIgniter\HTTP\ResponseInterface;
 use Config\Services;
+use JsonException;
 
 require_once('Secure_Controller.php');
 
@@ -144,11 +145,25 @@ class Attributes extends Secure_Controller
 
         $definition_name = $definition_data['definition_name'];
 
+        if ($definition_id == NO_DEFINITION_ID) {
+            try {
+                $definition_values = json_decode($this->request->getPost('definition_values') ?? '', false, 512, JSON_THROW_ON_ERROR);
+            } catch (JsonException) {
+                $definition_values = null;
+            }
+
+            if (!is_array($definition_values) || array_filter($definition_values, static fn ($value) => !is_string($value)) !== []) {
+                return $this->response->setJSON([
+                    'success' => false,
+                    'message' => lang('Attributes.definition_error_adding_updating', [$definition_name]),
+                    'id'      => NEW_ENTRY
+                ]);
+            }
+        }
+
         if ($this->attribute->saveDefinition($definition_data, $definition_id)) {
             // New definition
             if ($definition_id == NO_DEFINITION_ID) {
-                $definition_values = json_decode($this->request->getPost('definition_values'));
-
                 foreach ($definition_values as $definition_value) {
                     $this->attribute->saveAttributeValue($definition_value, $definition_data['definition_id']);
                 }

--- a/app/Controllers/Attributes.php
+++ b/app/Controllers/Attributes.php
@@ -64,8 +64,14 @@ class Attributes extends Secure_Controller
      */
     public function postSaveAttributeValue(): ResponseInterface
     {
+        $attribute_value = $this->request->getPost('attribute_value');
+
+        if (!is_string($attribute_value) || $attribute_value === '') {
+            return $this->response->setJSON(['success' => false]);
+        }
+
         $success = $this->attribute->saveAttributeValue(
-            $this->request->getPost('attribute_value'),
+            $attribute_value,
             $this->request->getPost('definition_id', FILTER_SANITIZE_NUMBER_INT),
             $this->request->getPost('item_id', FILTER_SANITIZE_NUMBER_INT) ?? false,
             $this->request->getPost('attribute_id', FILTER_SANITIZE_NUMBER_INT) ?? false
@@ -81,8 +87,14 @@ class Attributes extends Secure_Controller
      */
     public function postDeleteDropdownAttributeValue(): ResponseInterface
     {
+        $attribute_value = $this->request->getPost('attribute_value');
+
+        if (!is_string($attribute_value) || $attribute_value === '') {
+            return $this->response->setJSON(['success' => false]);
+        }
+
         $success = $this->attribute->deleteDropdownAttributeValue(
-            $this->request->getPost('attribute_value'),
+            $attribute_value,
             $this->request->getPost('definition_id', FILTER_SANITIZE_NUMBER_INT)
         );
 

--- a/app/Controllers/Attributes.php
+++ b/app/Controllers/Attributes.php
@@ -65,14 +65,14 @@ class Attributes extends Secure_Controller
      */
     public function postSaveAttributeValue(): ResponseInterface
     {
-        $attribute_value = $this->request->getPost('attribute_value');
+        $attributeValue = $this->request->getPost('attribute_value');
 
-        if (!is_string($attribute_value) || $attribute_value === '') {
+        if (!is_string($attributeValue) || $attributeValue === '') {
             return $this->response->setJSON(['success' => false]);
         }
 
         $success = $this->attribute->saveAttributeValue(
-            $attribute_value,
+            $attributeValue,
             $this->request->getPost('definition_id', FILTER_SANITIZE_NUMBER_INT),
             $this->request->getPost('item_id', FILTER_SANITIZE_NUMBER_INT) ?? false,
             $this->request->getPost('attribute_id', FILTER_SANITIZE_NUMBER_INT) ?? false
@@ -88,14 +88,14 @@ class Attributes extends Secure_Controller
      */
     public function postDeleteDropdownAttributeValue(): ResponseInterface
     {
-        $attribute_value = $this->request->getPost('attribute_value');
+        $attributeValue = $this->request->getPost('attribute_value');
 
-        if (!is_string($attribute_value) || $attribute_value === '') {
+        if (!is_string($attributeValue) || $attributeValue === '') {
             return $this->response->setJSON(['success' => false]);
         }
 
         $success = $this->attribute->deleteDropdownAttributeValue(
-            $attribute_value,
+            $attributeValue,
             $this->request->getPost('definition_id', FILTER_SANITIZE_NUMBER_INT)
         );
 

--- a/app/Controllers/Items.php
+++ b/app/Controllers/Items.php
@@ -13,9 +13,11 @@ use App\Models\Item_taxes;
 use App\Models\Stock_location;
 use App\Models\Supplier;
 use App\Models\Tax_category;
+use CodeIgniter\Database\BaseConnection;
 use CodeIgniter\HTTP\ResponseInterface;
 use CodeIgniter\Images\Handlers\BaseHandler;
 use CodeIgniter\HTTP\DownloadResponse;
+use Config\Database;
 use Config\OSPOS;
 use Config\Services;
 use Exception;
@@ -25,6 +27,7 @@ require_once('Secure_Controller.php');
 
 class Items extends Secure_Controller
 {
+    private BaseConnection $db;
     private BaseHandler $image;
     private Barcode_lib $barcode_lib;
     private Item_lib $item_lib;
@@ -43,6 +46,8 @@ class Items extends Secure_Controller
     public function __construct()
     {
         parent::__construct('items');
+
+        $this->db = Database::connect();
 
         $this->session = Services::session();
 

--- a/app/Models/Attribute.php
+++ b/app/Models/Attribute.php
@@ -397,12 +397,10 @@ class Attribute extends Model
 
                 if (!$success) {
                     $affected_items = $this->get_items_by_value($attribute->attribute_value, $definition_id);
-                    foreach ($affected_items as $affected_item) {
-                        $affected_items[] = $affected_item['item_id'];
-                    }
+                    $affected_item_ids = array_column($affected_items, 'item_id');
 
-                    log_message('error', "Attribute_value: '$attribute->attribute_value' cannot be converted to $to. Affected Items: " . implode(',', $affected_items));
-                    unset($affected_items);
+                    log_message('error', "Attribute_value: '$attribute->attribute_value' cannot be converted to $to. Affected Items: " . implode(',', $affected_item_ids));
+                    unset($affected_items, $affected_item_ids);
                 }
             }
         }

--- a/app/Views/attributes/form.php
+++ b/app/Views/attributes/form.php
@@ -23,7 +23,7 @@
                     'name'  => 'definition_name',
                     'id'    => 'definition_name',
                     'class' => 'form-control input-sm',
-                    'value' => esc($definition_info->definition_name)
+                    'value' => $definition_info->definition_name
                 ]) ?>
             </div>
         </div>
@@ -69,7 +69,7 @@
                 <div class="input-group">
                     <?= form_input([
                         'name'  => 'definition_unit',
-                        'value' => esc($definition_info->definition_unit),
+                        'value' => $definition_info->definition_unit,
                         'class' => 'form-control input-sm',
                         'id'    => 'definition_unit'
                     ]) ?>
@@ -206,7 +206,7 @@
             }
         });
 
-        const definition_values = <?= json_encode(array_values($definition_values)) ?>;
+        const definition_values = <?= json_encode(array_map('esc', array_values($definition_values))) ?>;
         $.each(definition_values, function(index, element) {
             add_attribute_value(element);
         });

--- a/app/Views/attributes/item.php
+++ b/app/Views/attributes/item.php
@@ -55,7 +55,7 @@
                         $value = (empty($attribute_value) || empty($attribute_value->attribute_value)) ? $definition_value['selected_value'] : $attribute_value->attribute_value;
                         echo form_input([
                             'name'               => "attribute_links[$definition_id]",
-                            'value'              => esc($value),
+                            'value'              => $value,
                             'class'              => 'form-control valid_chars',
                             'data-definition-id' => $definition_id
                         ]);

--- a/app/Views/expenses/form.php
+++ b/app/Views/expenses/form.php
@@ -130,7 +130,7 @@
                     <?= form_dropdown('employee_id', $employees, $expenses_info->employee_id, 'id="employee_id" class="form-control"') ?>
                 <?php else: ?>
                     <?= form_hidden('employee_id', $expenses_info->employee_id) ?>
-                    <?= form_input(['name' => 'employee_name', 'value' => esc($employees[$expenses_info->employee_id] ?? ''), 'class' => 'form-control', 'readonly' => 'readonly']) ?>
+                    <?= form_input(['name' => 'employee_name', 'value' => $employees[$expenses_info->employee_id] ?? '', 'class' => 'form-control', 'readonly' => 'readonly']) ?>
                 <?php endif; ?>
             </div>
         </div>

--- a/app/Views/items/manage.php
+++ b/app/Views/items/manage.php
@@ -30,7 +30,7 @@ use App\Models\Employee;
         // Set the beginning of time as starting date
         $('#daterangepicker').data('daterangepicker').setStartDate("<?= date($config['dateformat'], mktime(0, 0, 0, 01, 01, 2010)) ?>");
         // Update the hidden inputs with the selected dates before submitting the search data
-        let start_date = "<?= date('Y-m-d', mktime(0, 0, 0, 01, 01, 2010)) ?>";
+        start_date = "<?= date('Y-m-d', mktime(0, 0, 0, 01, 01, 2010)) ?>";
 
         // Override dates from server if provided
         <?php if (isset($start_date) && $start_date): ?>

--- a/app/Views/receivings/form.php
+++ b/app/Views/receivings/form.php
@@ -55,7 +55,7 @@
                     <?= form_dropdown('employee_id', $employees, $receiving_info['employee_id'], 'id="employee_id" class="form-control"') ?>
                 <?php else: ?>
                     <?= form_hidden('employee_id', $receiving_info['employee_id']) ?>
-                    <?= form_input(['name' => 'employee_name', 'value' => esc($employees[$receiving_info['employee_id']] ?? ''), 'class' => 'form-control input-sm', 'readonly' => 'readonly']) ?>
+                    <?= form_input(['name' => 'employee_name', 'value' => $employees[$receiving_info['employee_id']] ?? '', 'class' => 'form-control input-sm', 'readonly' => 'readonly']) ?>
                 <?php endif; ?>
             </div>
         </div>

--- a/tests/Controllers/SalesControllerTest.php
+++ b/tests/Controllers/SalesControllerTest.php
@@ -249,6 +249,7 @@ class SalesControllerTest extends CIUnitTestCase
         ]);
 
         $response->assertStatus(200);
+        $response->assertSee(lang('Sales.not_authorized'));
 
         $session = Services::session();
         $cart = $session->get('sales_cart');

--- a/tests/Controllers/SalesControllerTest.php
+++ b/tests/Controllers/SalesControllerTest.php
@@ -1,0 +1,426 @@
+<?php
+
+namespace Tests\Controllers;
+
+use CodeIgniter\Test\CIUnitTestCase;
+use CodeIgniter\Test\DatabaseTestTrait;
+use CodeIgniter\Test\FeatureTestTrait;
+use CodeIgniter\Config\Services;
+use App\Models\Employee;
+use App\Models\Item;
+
+/**
+ * Includes regression tests for GHSA-3xf6-8fmq-44wg.
+ *
+ * A cashier holding only the base "sales" grant (no "reports_sales") must
+ * not be able to reach the per-sale endpoints that getManage() gates
+ * behind reports_sales: getRow, getEdit, postSave, getReceipt, getInvoice,
+ * getSendPdf, getSendReceipt.
+ */
+class SalesControllerTest extends CIUnitTestCase
+{
+    use DatabaseTestTrait;
+    use FeatureTestTrait;
+
+    protected $migrate     = true;
+    protected $migrateOnce = true;
+    protected $refresh     = false;
+    protected $namespace   = null;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+    }
+
+    protected function createCashierWithoutChangePriceGrant(): int
+    {
+        $personData = [
+            'first_name'   => 'Cashier',
+            'last_name'    => 'NoChangePrice',
+            'email'        => 'cashier-nochangeprice@test.com',
+            'phone_number' => '555-0001'
+        ];
+
+        $employeeData = [
+            'username'      => 'cashier_nochangeprice',
+            'password'      => password_hash('password123', PASSWORD_DEFAULT),
+            'hash_version'  => 2,
+            'language_code' => 'en',
+            'language'      => 'english'
+        ];
+
+        $grantsData = [
+            ['permission_id' => 'sales', 'menu_group' => 'home'],
+        ];
+
+        $employeeModel = model(Employee::class);
+        $employeeModel->save_employee($personData, $employeeData, $grantsData, NEW_ENTRY);
+
+        return $employeeModel->get_found_rows('');
+    }
+
+    protected function createCashierWithChangePriceGrant(): int
+    {
+        $personData = [
+            'first_name'   => 'Cashier',
+            'last_name'    => 'ChangePrice',
+            'email'        => 'cashier-changeprice@test.com',
+            'phone_number' => '555-0002'
+        ];
+
+        $employeeData = [
+            'username'      => 'cashier_changeprice',
+            'password'      => password_hash('password123', PASSWORD_DEFAULT),
+            'hash_version'  => 2,
+            'language_code' => 'en',
+            'language'      => 'english'
+        ];
+
+        $grantsData = [
+            ['permission_id' => 'sales', 'menu_group' => 'home'],
+            ['permission_id' => 'sales_change_price', 'menu_group' => 'home'],
+        ];
+
+        $employeeModel = model(Employee::class);
+        $employeeModel->save_employee($personData, $employeeData, $grantsData, NEW_ENTRY);
+
+        return $employeeModel->get_found_rows('');
+    }
+
+    protected function loginAsEmployee(int $personId): void
+    {
+        $session = Services::session();
+        $session->destroy();
+        $session->set('person_id', $personId);
+        $session->set('menu_group', 'home');
+    }
+
+    protected function createCashierEmployee(): int
+    {
+        $personData = [
+            'first_name'   => 'Cashier',
+            'last_name'    => 'NoReports',
+            'email'        => 'cashier@test.com',
+            'phone_number' => '555-0001'
+        ];
+
+        $employeeData = [
+            'username'      => 'cashier',
+            'password'      => password_hash('password123', PASSWORD_DEFAULT),
+            'hash_version'  => 2,
+            'language_code' => 'en',
+            'language'      => 'english'
+        ];
+
+        // Deliberately grants "sales" (register access) but NOT "reports_sales".
+        $grantsData = [
+            ['permission_id' => 'sales', 'menu_group' => 'home']
+        ];
+
+        $employeeModel = model(Employee::class);
+        $employeeModel->save_employee($personData, $employeeData, $grantsData, NEW_ENTRY);
+
+        return $employeeModel->get_found_rows('');
+    }
+
+    protected function createReportsSalesEmployee(): int
+    {
+        $personData = [
+            'first_name'   => 'Supervisor',
+            'last_name'    => 'WithReports',
+            'email'        => 'supervisor@test.com',
+            'phone_number' => '555-0002'
+        ];
+
+        $employeeData = [
+            'username'      => 'supervisor',
+            'password'      => password_hash('password123', PASSWORD_DEFAULT),
+            'hash_version'  => 2,
+            'language_code' => 'en',
+            'language'      => 'english'
+        ];
+
+        $grantsData = [
+            ['permission_id' => 'sales', 'menu_group' => 'home'],
+            ['permission_id' => 'reports_sales', 'menu_group' => 'home']
+        ];
+
+        $employeeModel = model(Employee::class);
+        $employeeModel->save_employee($personData, $employeeData, $grantsData, NEW_ENTRY);
+
+        return $employeeModel->get_found_rows('');
+    }
+
+    /**
+     * Inserts a minimal completed sale row directly, bypassing Sale::save_value()
+     * (which requires a full cart/inventory/tax pipeline unrelated to this
+     * authorization check).
+     */
+    protected function createSale(int $employeeId): int
+    {
+        $builder = \Config\Database::connect()->table('sales');
+        $builder->insert([
+            'sale_time'      => date('Y-m-d H:i:s'),
+            'customer_id'    => null,
+            'employee_id'    => $employeeId,
+            'comment'        => 'test sale',
+            'invoice_number' => null,
+        ]);
+
+        return (int) \Config\Database::connect()->insertID();
+    }
+
+    protected function createTestItem(): int
+    {
+        $itemData = [
+            'item_id'               => null,
+            'name'                  => 'Test Item',
+            'description'           => 'Test Item',
+            'category'              => 'Test Category',
+            'cost_price'            => 1.00,
+            'unit_price'            => 5.00,
+            'reorder_level'         => 0,
+            'item_number'           => 'TEST-' . uniqid(),
+            'allow_alt_description' => 0,
+            'is_serialized'         => 0,
+            'stock_type'            => HAS_NO_STOCK,
+            'deleted'               => 0,
+        ];
+
+        $itemModel = model(Item::class);
+        $itemModel->save_value($itemData);
+
+        return (int) $itemData['item_id'];
+    }
+
+    /**
+     * Seeds a single cart line directly in the session, mirroring the shape
+     * Sale_lib::add_item() produces, so tests can target postEditItem's
+     * authorization branch without exercising the full add-item flow.
+     */
+    protected function seedCartLine(int $line, string $price, int $itemId): void
+    {
+        $session = Services::session();
+        $session->set('sales_cart', [
+            $line => [
+                'item_id'               => $itemId,
+                'item_location'         => 1,
+                'stock_name'            => 'Test Location',
+                'line'                  => $line,
+                'name'                  => 'Test Item',
+                'item_number'           => 'TEST-1',
+                'attribute_values'      => null,
+                'attribute_dtvalues'    => null,
+                'description'           => 'Test Item',
+                'serialnumber'          => '',
+                'allow_alt_description' => false,
+                'is_serialized'         => false,
+                'quantity'              => '1',
+                'discount'              => '0',
+                'discount_type'         => 0,
+                'in_stock'              => '10',
+                'price'                 => $price,
+                'cost_price'            => '1.00',
+                'total'                 => $price,
+                'discounted_total'      => $price,
+                'print_option'          => 1,
+                'stock_type'            => HAS_NO_STOCK,
+                'item_type'             => ITEM,
+                'hsn_code'              => null,
+                'tax_category_id'       => null,
+            ],
+        ]);
+    }
+
+    public function testCashierWithoutGrantCannotChangePrice(): void
+    {
+        $cashierId = $this->createCashierWithoutChangePriceGrant();
+        $this->loginAsEmployee($cashierId);
+        $itemId = $this->createTestItem();
+        $this->seedCartLine(1, '5.00', $itemId);
+
+        $response = $this->post('/sales/editItem/1', [
+            'description'  => 'Test Item',
+            'serialnumber' => '',
+            'price'        => '0.01',
+            'quantity'     => '1',
+            'discount'     => '0',
+            'location'     => '1',
+        ]);
+
+        $response->assertStatus(200);
+
+        $session = Services::session();
+        $cart = $session->get('sales_cart');
+        $this->assertEquals('5.00', $cart[1]['price']);
+    }
+
+    public function testCashierWithoutGrantCanEditQuantityAtSamePrice(): void
+    {
+        $cashierId = $this->createCashierWithoutChangePriceGrant();
+        $this->loginAsEmployee($cashierId);
+        $itemId = $this->createTestItem();
+        $this->seedCartLine(1, '5.00', $itemId);
+
+        $response = $this->post('/sales/editItem/1', [
+            'description'  => 'Test Item',
+            'serialnumber' => '',
+            'price'        => '5.00',
+            'quantity'     => '3',
+            'discount'     => '0',
+            'location'     => '1',
+        ]);
+
+        $response->assertStatus(200);
+
+        $session = Services::session();
+        $cart = $session->get('sales_cart');
+        $this->assertEquals('3', $cart[1]['quantity']);
+        $this->assertEquals('5.00', $cart[1]['price']);
+    }
+
+    public function testCashierWithGrantCanChangePrice(): void
+    {
+        $cashierId = $this->createCashierWithChangePriceGrant();
+        $this->loginAsEmployee($cashierId);
+        $itemId = $this->createTestItem();
+        $this->seedCartLine(1, '5.00', $itemId);
+
+        $response = $this->post('/sales/editItem/1', [
+            'description'  => 'Test Item',
+            'serialnumber' => '',
+            'price'        => '0.01',
+            'quantity'     => '1',
+            'discount'     => '0',
+            'location'     => '1',
+        ]);
+
+        $response->assertStatus(200);
+
+        $session = Services::session();
+        $cart = $session->get('sales_cart');
+        $this->assertEquals('0.01', $cart[1]['price']);
+    }
+
+    public function testCashierWithoutReportsSalesCannotGetRow(): void
+    {
+        $cashierId = $this->createCashierEmployee();
+        $saleId = $this->createSale($cashierId);
+        $this->loginAsEmployee($cashierId);
+
+        $response = $this->get('/sales/row/' . $saleId);
+
+        $response->assertStatus(200);
+        $result = json_decode($response->getJSON(), true);
+        $this->assertFalse($result['success']);
+    }
+
+    public function testCashierWithoutReportsSalesCannotGetEdit(): void
+    {
+        $cashierId = $this->createCashierEmployee();
+        $saleId = $this->createSale($cashierId);
+        $this->loginAsEmployee($cashierId);
+
+        $response = $this->get('/sales/edit/' . $saleId);
+
+        $response->assertRedirect();
+        $this->assertStringContainsString('no_access', $response->getRedirectUrl());
+    }
+
+    public function testCashierWithoutReportsSalesCannotGetReceipt(): void
+    {
+        $cashierId = $this->createCashierEmployee();
+        $saleId = $this->createSale($cashierId);
+        $this->loginAsEmployee($cashierId);
+
+        $response = $this->get('/sales/receipt/' . $saleId);
+
+        $response->assertRedirect();
+        $this->assertStringContainsString('no_access', $response->getRedirectUrl());
+    }
+
+    public function testCashierWithoutReportsSalesCannotGetInvoice(): void
+    {
+        $cashierId = $this->createCashierEmployee();
+        $saleId = $this->createSale($cashierId);
+        $this->loginAsEmployee($cashierId);
+
+        $response = $this->get('/sales/invoice/' . $saleId);
+
+        $response->assertRedirect();
+        $this->assertStringContainsString('no_access', $response->getRedirectUrl());
+    }
+
+    public function testCashierWithoutReportsSalesCannotSendPdf(): void
+    {
+        $cashierId = $this->createCashierEmployee();
+        $saleId = $this->createSale($cashierId);
+        $this->loginAsEmployee($cashierId);
+
+        $response = $this->get('/sales/sendpdf/' . $saleId);
+
+        $response->assertStatus(200);
+        $result = json_decode($response->getJSON(), true);
+        $this->assertFalse($result['success']);
+    }
+
+    public function testCashierWithoutReportsSalesCannotSendReceipt(): void
+    {
+        $cashierId = $this->createCashierEmployee();
+        $saleId = $this->createSale($cashierId);
+        $this->loginAsEmployee($cashierId);
+
+        $response = $this->get('/sales/sendreceipt/' . $saleId);
+
+        $response->assertStatus(200);
+        $result = json_decode($response->getJSON(), true);
+        $this->assertFalse($result['success']);
+    }
+
+    public function testCashierWithoutReportsSalesCannotPostSave(): void
+    {
+        $cashierId = $this->createCashierEmployee();
+        $saleId = $this->createSale($cashierId);
+        $this->loginAsEmployee($cashierId);
+
+        $response = $this->post('/sales/save/' . $saleId, [
+            'date'              => date('m/d/Y H:i:s'),
+            'customer_id'       => '',
+            'employee_id'       => $cashierId,
+            'comment'           => 'tampered',
+            'invoice_number'    => '',
+            'number_of_payments'=> 0,
+            'payment_type_new'  => '--',
+            'payment_amount_new'=> ''
+        ]);
+
+        $response->assertStatus(200);
+        $result = json_decode($response->getJSON(), true);
+        $this->assertFalse($result['success']);
+        $this->assertSame(lang('Sales.not_authorized'), $result['message']);
+    }
+
+    public function testEmployeeWithReportsSalesCanGetRow(): void
+    {
+        $supervisorId = $this->createReportsSalesEmployee();
+        $saleId = $this->createSale($supervisorId);
+        $this->loginAsEmployee($supervisorId);
+
+        $response = $this->get('/sales/row/' . $saleId);
+
+        $response->assertStatus(200);
+        $result = json_decode($response->getJSON(), true);
+        $this->assertArrayNotHasKey('success', $result);
+    }
+
+    public function testEmployeeWithReportsSalesCanGetEdit(): void
+    {
+        $supervisorId = $this->createReportsSalesEmployee();
+        $saleId = $this->createSale($supervisorId);
+        $this->loginAsEmployee($supervisorId);
+
+        $response = $this->get('/sales/edit/' . $saleId);
+
+        $response->assertStatus(200);
+    }
+}

--- a/tests/Controllers/SalesControllerTest.php
+++ b/tests/Controllers/SalesControllerTest.php
@@ -24,7 +24,7 @@ class SalesControllerTest extends CIUnitTestCase
 
     protected $migrate     = true;
     protected $migrateOnce = true;
-    protected $refresh     = false;
+    protected $refresh     = true;
     protected $namespace   = null;
 
     protected function setUp(): void


### PR DESCRIPTION
- Remove esc()/html_entity_decode() calls now that output is escaped at render time by the framework, preventing double-encoding of special characters in attribute names, units, and definition values
- Fix employee_name form_input value fields to stop pre-escaping before form_input applies its own escaping
- Reorder Items.php use statements and add missing BaseConnection import
- Change items/manage.php start_date from let to plain assignment for proper reassignment scope

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved validation for attribute values and definition data, including clearer handling of empty, invalid, or malformed entries.
  * Improved handling and display of attribute, employee, and item values in forms.
  * Fixed date initialization so server-provided start dates display correctly.
  * Strengthened sales access controls for price changes, reports, receipts, invoices, and related actions.
  * Improved item updates when attribute data affects multiple items.
* **Tests**
  * Added coverage confirming sales permissions are enforced correctly while authorized actions remain available.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->