### PR TITLE
fix(security): sanitize filenames and escape logo path in config

### DIFF
--- a/app/Controllers/Config.php
+++ b/app/Controllers/Config.php
@@ -352,7 +352,7 @@ class Config extends Secure_Controller
 
         $file_info = [
             'orig_name' => $filename,
-            'raw_name'  => $info['filename'],
+            'raw_name'  => preg_replace('/[^a-zA-Z0-9_\-]/', '_', $info['filename']),
             'file_ext'  => $file->guessExtension()
         ];
 

--- a/app/Controllers/Config.php
+++ b/app/Controllers/Config.php
@@ -349,10 +349,11 @@ class Config extends Secure_Controller
 
         $filename = $file->getClientName();
         $info = pathinfo($filename);
+        helper('security');
 
         $file_info = [
             'orig_name' => $filename,
-            'raw_name'  => preg_replace('/[^a-zA-Z0-9_\-]/', '_', $info['filename']),
+            'raw_name'  => sanitize_filename($info['filename']),
             'file_ext'  => $file->guessExtension()
         ];
 

--- a/app/Views/configs/info_config.php
+++ b/app/Views/configs/info_config.php
@@ -36,7 +36,7 @@
                     <div class="fileinput <?= $logo_exists ? 'fileinput-exists' : 'fileinput-new' ?>" data-provides="fileinput">
                         <div class="fileinput-new thumbnail" style="width: 200px; height: 200px;"></div>
                         <div class="fileinput-preview fileinput-exists thumbnail" style="max-width: 200px; max-height: 200px;">
-                            <img data-src="holder.js/100%x100%" alt="<?= esc(lang('Config.company_logo')) ?>" src="<?= $logo_src ?>" style="max-height: 100%; max-width: 100%;">
+                            <img data-src="holder.js/100%x100%" alt="<?= esc(lang('Config.company_logo')) ?>" src="<?= esc($logo_src, 'attr') ?>" style="max-height: 100%; max-width: 100%;">
                         </div>
                         <div>
                             <span class="btn btn-default btn-sm btn-file">


### PR DESCRIPTION
- Sanitize uploaded filename in Config.php via preg_replace, strip chars outside [a-zA-Z0-9_-] before storing raw_name
- Escape $logo_src with esc(..., 'attr') in info_config.php view to prevent XSS via crafted logo path/filename

Prevents stored XSS and path traversal from unsanitized filenames used in config uploads.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved security when uploading company logos by sanitizing filenames.
  * Protected company-logo previews from unsafe characters in image paths.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->