### PR TITLE
fix: print item kit name on receipts for Kit Only print

### DIFF
--- a/app/Controllers/Sales.php
+++ b/app/Controllers/Sales.php
@@ -564,19 +564,30 @@ class Sales extends Secure_Controller
                 $discount_type = $item_kit_info->kit_discount_type;
             }
 
-            $print_option = PRINT_ALL; // Always include in list of items on invoice // TODO: This variable is never used in the code
-
             if (!empty($kit_item_id)) {
-                if (!$this->sale_lib->add_item($kit_item_id, $item_location, $quantity, $discount, $discount_type, PRICE_MODE_KIT, $kit_price_option, $kit_print_option, $price)) {
+                // Kit Only print must force the linked kit item line printable (item_type may not be ITEM_KIT).
+                $kit_line_print = ((int)$kit_print_option === PRINT_KIT) ? PRINT_YES : null;
+                if (!$this->sale_lib->add_item($kit_item_id, $item_location, $quantity, $discount, $discount_type, PRICE_MODE_KIT, $kit_price_option, $kit_print_option, $price, null, null, null, false, $kit_line_print)) {
                     $data['error'] = lang('Sales.unable_to_add_item');
                 } else {
+                    // Show the Item Kit name on the receipt, not only the linked item's name.
+                    $cart = $this->sale_lib->get_cart();
+                    foreach ($cart as $line => $cart_item) {
+                        if ((string)$cart_item['item_id'] === (string)$kit_item_id) {
+                            $cart[$line]['name'] = $item_kit_info->name;
+                            if ((int)$kit_print_option === PRINT_KIT) {
+                                $cart[$line]['print_option'] = PRINT_YES;
+                            }
+                        }
+                    }
+                    $this->sale_lib->set_cart($cart);
                     $data['warning'] = $this->sale_lib->out_of_stock($item_kit_id, $item_location);
                 }
             }
 
             // Add item kit items to order
             $stock_warning = null;
-            if (!$this->sale_lib->add_item_kit($item_id_or_number_or_item_kit_or_receipt, $item_location, $discount, $discount_type, $kit_price_option, $kit_print_option, $stock_warning)) {
+            if (!$this->sale_lib->add_item_kit($item_id_or_number_or_item_kit_or_receipt, $item_location, $discount, $discount_type, (int)$kit_price_option, (int)$kit_print_option, $stock_warning)) {
                 $data['error'] = lang('Sales.unable_to_add_item');
             } elseif ($stock_warning != null) {
                 $data['warning'] = $stock_warning;

--- a/app/Libraries/Sale_lib.php
+++ b/app/Libraries/Sale_lib.php
@@ -1029,11 +1029,11 @@ class Sale_lib
      * @param string|null $serialnumber
      * @param int|null $sale_id
      * @param bool $include_deleted
-     * @param bool|null $print_option
+     * @param int|null $print_option
      * @param bool|null $line
      * @return bool
      */
-    public function add_item(string &$item_id, int $item_location, string $quantity = '1', string &$discount = '0.0', int $discount_type = 0, int $price_mode = PRICE_MODE_STANDARD, ?int $kit_price_option = null, ?int $kit_print_option = null, ?string $price_override = null, ?string $description = null, ?string $serialnumber = null, ?int $sale_id = null, bool $include_deleted = false, ?bool $print_option = null, ?bool $line = null): bool
+    public function add_item(string &$item_id, int $item_location, string $quantity = '1', string &$discount = '0.0', int $discount_type = 0, int $price_mode = PRICE_MODE_STANDARD, ?int $kit_price_option = null, ?int $kit_print_option = null, ?string $price_override = null, ?string $description = null, ?string $serialnumber = null, ?int $sale_id = null, bool $include_deleted = false, ?int $print_option = null, ?bool $line = null): bool
     {
         $item_info = $this->item->get_info_by_id_or_number($item_id, $include_deleted);
 
@@ -1115,7 +1115,10 @@ class Sale_lib
         // Array/cart records are identified by $insertkey and item_id is just another field.
 
         if ($price_mode == PRICE_MODE_KIT) {    // TODO: === ?
-            if ($kit_print_option == PRINT_ALL) {    // TODO: === ?
+            // Explicit override (e.g. force kit header line printable when Print Option is Kit Only)
+            if ($print_option !== null) {
+                $print_option_selected = $print_option;
+            } elseif ($kit_print_option == PRINT_ALL) {    // TODO: === ?
                 $print_option_selected = PRINT_YES;
             } elseif ($kit_print_option == PRINT_KIT && $item_type == ITEM_KIT) {    // TODO: === ?
                 $print_option_selected = PRINT_YES;
@@ -1328,12 +1331,12 @@ class Sale_lib
      * @param int $item_location
      * @param float $discount
      * @param string $discount_type
-     * @param bool $kit_price_option
-     * @param bool $kit_print_option
+     * @param int $kit_price_option
+     * @param int $kit_print_option
      * @param string $stock_warning
      * @return bool
      */
-    public function add_item_kit(string $external_item_kit_id, int $item_location, float $discount, string $discount_type, bool $kit_price_option, bool $kit_print_option, ?string &$stock_warning): bool
+    public function add_item_kit(string $external_item_kit_id, int $item_location, float $discount, string $discount_type, int $kit_price_option, int $kit_print_option, ?string &$stock_warning): bool
     {
         // KIT #
         $pieces = explode(' ', $external_item_kit_id);


### PR DESCRIPTION
Kit price/print options were typed as bool, so PRINT_KIT was coerced and kit-mode print overrides were ignored. This passes ints, honors an explicit print override for the linked kit item, and displays item_kits.name on the receipt line.

Fixes #4154

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved item-kit printing behavior in sales.
  * Kit-only printing now correctly marks linked items for printing and labels cart lines with the kit name.
  * Explicit print selections now take priority over default kit printing rules.
  * Improved handling of kit pricing and print options when adding items to a sale.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->