### PR TITLE
fix: use db_connect() for item save transactions

### DIFF
--- a/app/Controllers/Items.php
+++ b/app/Controllers/Items.php
@@ -679,7 +679,8 @@ class Items extends Secure_Controller
         $employeeId = $this->employee->get_logged_in_employee_info()->person_id;
 
         // Wrap the entire save sequence in a single transaction for atomicity
-        $this->db->transBegin();
+        $db = db_connect();
+        $db->transBegin();
 
         $success = $this->item->save_value($itemData, $itemId);
         $newItem = false;
@@ -748,14 +749,14 @@ class Items extends Secure_Controller
 
         // Check all success conditions before committing
         if ($success && $uploadSuccess) {
-            $this->db->transCommit();
+            $db->transCommit();
             $message = lang('Items.successful_' . ($newItem ? 'adding' : 'updating')) . ' ' . $itemData['name'];
 
             return $this->response->setJSON(['success' => true, 'message' => $message, 'id' => $itemId]);
         }
 
         // Rollback on failure
-        $this->db->transRollback();
+        $db->transRollback();
         $message = $uploadSuccess ? lang('Items.error_adding_updating') . ' ' . $itemData['name'] : strip_tags($uploadData['error']);
 
         return $this->response->setJSON(['success' => false, 'message' => $message, 'id' => $itemId]);


### PR DESCRIPTION
postSave() used $this->db which is not initialized on the Items controller, causing Undefined property errors when saving items. Obtain the connection with db_connect() like the CSV import path already does.

Fixes #4623

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved transaction handling when saving items by using a direct database connection.
  * Preserved existing success and failure responses for item saves.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->