### PR TITLE
hotfix(auth): hash throttler keys to improve security

### DIFF
--- a/app/Config/Events.php
+++ b/app/Config/Events.php
@@ -28,12 +28,15 @@ use App\Events\Method;
  */
 
 Events::on('pre_system', static function (): void {
-    $encryptionKey = config('Encryption')->key;
-    if (ENVIRONMENT !== 'testing' && (empty($encryptionKey) || strlen($encryptionKey) < 64)) {
-        throw new ConfigException('Encryption key is missing or invalid. Run the installer/migrations to provision one.');
-    }
-
     if (ENVIRONMENT !== 'testing') {
+        helper('security');
+        check_encryption();
+
+        $encryptionKey = config('Encryption')->key;
+        if (empty($encryptionKey) || strlen($encryptionKey) < 64) {
+            throw new ConfigException('Encryption key could not be provisioned. Check that .env is writable.');
+        }
+
         if (ini_get('zlib.output_compression')) {
             throw FrameworkException::forEnabledZlibOutputCompression();
         }

--- a/app/Config/Events.php
+++ b/app/Config/Events.php
@@ -3,6 +3,7 @@
 namespace Config;
 
 use CodeIgniter\Events\Events;
+use CodeIgniter\Exceptions\ConfigException;
 use CodeIgniter\Exceptions\FrameworkException;
 use CodeIgniter\HotReloader\HotReloader;
 use App\Events\Db_log;
@@ -27,6 +28,11 @@ use App\Events\Method;
  */
 
 Events::on('pre_system', static function (): void {
+    $encryptionKey = config('Encryption')->key;
+    if (ENVIRONMENT !== 'testing' && (empty($encryptionKey) || strlen($encryptionKey) < 64)) {
+        throw new ConfigException('Encryption key is missing or invalid. Run the installer/migrations to provision one.');
+    }
+
     if (ENVIRONMENT !== 'testing') {
         if (ini_get('zlib.output_compression')) {
             throw FrameworkException::forEnabledZlibOutputCompression();

--- a/app/Filters/Throttle.php
+++ b/app/Filters/Throttle.php
@@ -24,12 +24,15 @@ class Throttle implements FilterInterface
             return null;
         }
 
-        $throttler = Services::throttler();
+        check_encryption();
 
-        $ipKey       = 'login-ip-' . md5($request->getIPAddress());
+        $throttler = Services::throttler();
+        $secret    = config('Encryption')->key;
+
+        $ipKey       = 'login-ip-' . hash_hmac('sha256', $request->getIPAddress(), $secret);
         $rawUsername = $request->getPost('username');
         $username    = is_scalar($rawUsername) ? strtolower((string) $rawUsername) : '';
-        $usernameKey = $username !== '' ? 'login-user-' . md5($username) : null;
+        $usernameKey = $username !== '' ? 'login-user-' . hash_hmac('sha256', $username, $secret) : null;
 
         $ipOk       = $throttler->check($ipKey, self::CAPACITY, self::SECONDS);
         $usernameOk = $usernameKey === null || $throttler->check($usernameKey, self::CAPACITY, self::SECONDS);

--- a/app/Filters/Throttle.php
+++ b/app/Filters/Throttle.php
@@ -26,9 +26,9 @@ class Throttle implements FilterInterface
 
         $throttler = Services::throttler();
 
-        $ipKey       = 'login-ip-' . $request->getIPAddress();
+        $ipKey       = 'login-ip-' . md5($request->getIPAddress());
         $username    = strtolower((string) $request->getPost('username'));
-        $usernameKey = $username !== '' ? 'login-user-' . $username : null;
+        $usernameKey = $username !== '' ? 'login-user-' . md5($username) : null;
 
         $ipOk       = $throttler->check($ipKey, self::CAPACITY, self::SECONDS);
         $usernameOk = $usernameKey === null || $throttler->check($usernameKey, self::CAPACITY, self::SECONDS);

--- a/app/Filters/Throttle.php
+++ b/app/Filters/Throttle.php
@@ -24,8 +24,6 @@ class Throttle implements FilterInterface
             return null;
         }
 
-        check_encryption();
-
         $throttler = Services::throttler();
         $secret    = config('Encryption')->key;
 

--- a/app/Filters/Throttle.php
+++ b/app/Filters/Throttle.php
@@ -27,7 +27,8 @@ class Throttle implements FilterInterface
         $throttler = Services::throttler();
 
         $ipKey       = 'login-ip-' . md5($request->getIPAddress());
-        $username    = strtolower((string) $request->getPost('username'));
+        $rawUsername = $request->getPost('username');
+        $username    = is_scalar($rawUsername) ? strtolower((string) $rawUsername) : '';
         $usernameKey = $username !== '' ? 'login-user-' . md5($username) : null;
 
         $ipOk       = $throttler->check($ipKey, self::CAPACITY, self::SECONDS);

--- a/tests/Filters/ThrottleTest.php
+++ b/tests/Filters/ThrottleTest.php
@@ -16,7 +16,7 @@ class ThrottleTest extends CIUnitTestCase
     {
         parent::setUp();
 
-        check_encryption();
+        config('Encryption')->key = bin2hex(random_bytes(32));
 
         $this->filter = new Throttle();
     }

--- a/tests/Filters/ThrottleTest.php
+++ b/tests/Filters/ThrottleTest.php
@@ -38,10 +38,10 @@ class ThrottleTest extends CIUnitTestCase
         $request->method('getIPAddress')->willReturn($ip);
         $request->method('getPost')->with('username')->willReturn($username);
 
-        $this->usedKeys[] = 'login-ip-' . $ip;
+        $this->usedKeys[] = 'login-ip-' . md5($ip);
 
         if ($username !== null && $username !== '') {
-            $this->usedKeys[] = 'login-user-' . strtolower($username);
+            $this->usedKeys[] = 'login-user-' . md5(strtolower($username));
         }
 
         return $request;
@@ -110,6 +110,21 @@ class ThrottleTest extends CIUnitTestCase
 
         $this->assertFalse($body['success']);
         $this->assertSame(lang('Login.too_many_attempts'), $body['message']);
+    }
+
+    public function testHandlesIpv6AddressWithoutThrowing(): void
+    {
+        $ip = '::1';
+
+        for ($i = 0; $i < 5; $i++) {
+            $result = $this->filter->before($this->makeRequest('POST', $ip, "user{$i}"));
+            $this->assertNull($result, "Attempt {$i} should not be throttled");
+        }
+
+        $result = $this->filter->before($this->makeRequest('POST', $ip, 'user-final'));
+
+        $this->assertNotNull($result);
+        $this->assertSame(429, $result->getStatusCode());
     }
 
     public function testMissingUsernameOnlyThrottlesByIp(): void

--- a/tests/Filters/ThrottleTest.php
+++ b/tests/Filters/ThrottleTest.php
@@ -16,6 +16,8 @@ class ThrottleTest extends CIUnitTestCase
     {
         parent::setUp();
 
+        check_encryption();
+
         $this->filter = new Throttle();
     }
 
@@ -38,10 +40,12 @@ class ThrottleTest extends CIUnitTestCase
         $request->method('getIPAddress')->willReturn($ip);
         $request->method('getPost')->with('username')->willReturn($username);
 
-        $this->usedKeys[] = 'login-ip-' . md5($ip);
+        $secret = config('Encryption')->key;
+
+        $this->usedKeys[] = 'login-ip-' . hash_hmac('sha256', $ip, $secret);
 
         if ($username !== null && $username !== '') {
-            $this->usedKeys[] = 'login-user-' . md5(strtolower($username));
+            $this->usedKeys[] = 'login-user-' . hash_hmac('sha256', strtolower($username), $secret);
         }
 
         return $request;

--- a/tests/Filters/ThrottleTest.php
+++ b/tests/Filters/ThrottleTest.php
@@ -32,7 +32,7 @@ class ThrottleTest extends CIUnitTestCase
         parent::tearDown();
     }
 
-    private function makeRequest(string $method, string $ip, ?string $username = null): IncomingRequest
+    private function makeRequest(string $method, string $ip, mixed $username = null): IncomingRequest
     {
         $request = $this->createMock(IncomingRequest::class);
 
@@ -44,8 +44,8 @@ class ThrottleTest extends CIUnitTestCase
 
         $this->usedKeys[] = 'login-ip-' . hash_hmac('sha256', $ip, $secret);
 
-        if ($username !== null && $username !== '') {
-            $this->usedKeys[] = 'login-user-' . hash_hmac('sha256', strtolower($username), $secret);
+        if (is_scalar($username) && (string) $username !== '') {
+            $this->usedKeys[] = 'login-user-' . hash_hmac('sha256', strtolower((string) $username), $secret);
         }
 
         return $request;
@@ -140,6 +140,23 @@ class ThrottleTest extends CIUnitTestCase
         }
 
         $result = $this->filter->before($this->makeRequest('POST', $ip, null));
+
+        $this->assertNotNull($result);
+        $this->assertSame(429, $result->getStatusCode());
+    }
+
+    public function testArrayUsernameIsIgnoredAndOnlyIpThrottles(): void
+    {
+        $ip       = '203.0.113.6';
+        $username = ['a', 'b'];
+
+        for ($i = 0; $i < 5; $i++) {
+            $result = $this->filter->before($this->makeRequest('POST', $ip, $username));
+
+            $this->assertNull($result, "Attempt {$i} should not be throttled");
+        }
+
+        $result = $this->filter->before($this->makeRequest('POST', $ip, $username));
 
         $this->assertNotNull($result);
         $this->assertSame(429, $result->getStatusCode());


### PR DESCRIPTION
- Use MD5 hashing for IP and username-based throttler keys to obfuscate sensitive data while maintaining functionality.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Security Improvements**
  * Enhanced request throttling by securely protecting IP addresses and submitted usernames before tracking them.
  * Improved protection against tampering by using configured encryption settings for throttling records.
  * Added reliable throttling support for IPv6 addresses.
  * Empty or invalid usernames continue to be excluded from throttling records.
  * Requests exceeding the configured limit are consistently rejected with HTTP 429 responses.
  * Added validation to ensure a sufficiently strong encryption key is configured before the application starts.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->