### PR TITLE
Codeigniter changes between 4.7.2 and 4.7.4

### DIFF
--- a/app/Config/Events.php
+++ b/app/Config/Events.php
@@ -37,7 +37,8 @@ Events::on('pre_system', static function (): void {
             throw new ConfigException('Encryption key could not be provisioned. Check that .env is writable.');
         }
 
-        if (ini_get('zlib.output_compression')) {
+        $value = ini_get('zlib.output_compression');
+        if (filter_var($value, FILTER_VALIDATE_BOOLEAN) || (int) $value > 0) {
             throw FrameworkException::forEnabledZlibOutputCompression();
         }
 

--- a/app/Config/Routes.php
+++ b/app/Config/Routes.php
@@ -2,9 +2,7 @@
 
 use CodeIgniter\Router\RouteCollection;
 
-/**
- * @var RouteCollection $routes
- */
+/** @var RouteCollection $routes */
 $routes->setDefaultController('Login');
 
 $routes->get('/', 'Login::index');

--- a/app/Config/Session.php
+++ b/app/Config/Session.php
@@ -15,6 +15,7 @@ class Session extends BaseConfig
      * --------------------------------------------------------------------------
      *
      * The session storage driver to use:
+     * - `CodeIgniter\Session\Handlers\ArrayHandler` (for testing)
      * - `CodeIgniter\Session\Handlers\FileHandler`
      * - `CodeIgniter\Session\Handlers\DatabaseHandler`
      * - `CodeIgniter\Session\Handlers\MemcachedHandler`

--- a/app/Config/View.php
+++ b/app/Config/View.php
@@ -5,10 +5,6 @@ namespace Config;
 use CodeIgniter\Config\View as BaseView;
 use CodeIgniter\View\ViewDecoratorInterface;
 
-/**
- * @phpstan-type parser_callable (callable(mixed): mixed)
- * @phpstan-type parser_callable_string (callable(mixed): mixed)&string
- */
 class View extends BaseView
 {
     /**
@@ -34,8 +30,7 @@ class View extends BaseView
      *  { title|esc(js) }
      *  { created_on|date(Y-m-d)|esc(attr) }
      *
-     * @var         array<string, string>
-     * @phpstan-var array<string, parser_callable_string>
+     * @var array<string, (callable(mixed): mixed)&string>
      */
     public $filters = [];
 
@@ -44,8 +39,7 @@ class View extends BaseView
      * by the core Parser by creating aliases that will be replaced with
      * any callable. Can be single or tag pair.
      *
-     * @var         array<string, callable|list<string>|string>
-     * @phpstan-var array<string, list<parser_callable_string>|parser_callable_string|parser_callable>
+     * @var array<string, (callable(mixed...): mixed)|((callable(mixed...): mixed)&string)|list<(callable(mixed...): mixed)&string>>
      */
     public $plugins = [];
 


### PR DESCRIPTION
#4638 merged a change upgrading CodeIgniter 4.7.2 to 4.7.4 without doing a diff on the changes between framework files and our code.  Doing this every time is important for a few reasons.
- It prevents code drift over time that could lead to more difficult upgrades down the road.
- It catches vulnerability fixes in our CodeIgniter4 code which is not pulled from vendor/codeigniter4/framework/

In most cases doing the diff against files in /vendor/codeigniter4/framework/ yields small docblock changes, but sometimes, like in this case, it yields code changes which reduce attack vectors. Rarely, but possible, it yields breaking changes in our code that we need to change in order for the new version to be compatible.

We should always consult https://www.codeigniter.com/user_guide/installation/upgrading.html when pushing an upgrade to Codeigniter to prevent breaking changes.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved detection of enabled output compression settings, including boolean and positive numeric values, preventing incorrect configuration errors.

- **Documentation**
  - Added the array-based session handler to the list of available testing drivers.

- **Maintenance**
  - Clarified configuration type documentation and standardized routing configuration annotations without changing application behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->