### PR TITLE
Fix Regression caused by PSR compliance renaming that did not propagate.

### DIFF
--- a/app/Libraries/Email_lib.php
+++ b/app/Libraries/Email_lib.php
@@ -29,7 +29,7 @@ class Email_lib
         $encrypter = Services::encrypter();
 
         $smtp_pass = $this->config['smtp_pass'] ?? '';
-        if (!empty($smtp_pass) && check_encryption()) {
+        if (!empty($smtp_pass) && checkEncryption()) {
             try {
                 $smtp_pass = $encrypter->decrypt($smtp_pass);
             } catch (\EncryptionException $e) {


### PR DESCRIPTION
Corrected `check_encryption()` to `checkEncryption()` to align with coding standards.

One location previously had been missed in the refactor of check_encryption() to checkEncryption