### PR TITLE
perf: bound management table pagination

### DIFF
--- a/app/Controllers/Attributes.php
+++ b/app/Controllers/Attributes.php
@@ -41,8 +41,10 @@ class Attributes extends Secure_Controller
     public function getSearch(): ResponseInterface
     {
         $search = $this->request->getGet('search');
-        $limit  = $this->request->getGet('limit', FILTER_SANITIZE_NUMBER_INT);
-        $offset = $this->request->getGet('offset', FILTER_SANITIZE_NUMBER_INT);
+        [$limit, $offset] = $this->sanitizeTablePagination(
+            $this->request->getGet('limit'),
+            $this->request->getGet('offset')
+        );
         $sort   = $this->sanitizeSortColumn(attribute_definition_headers(), $this->request->getGet('sort', FILTER_SANITIZE_FULL_SPECIAL_CHARS), 'definition_id');
         $order  = $this->request->getGet('order', FILTER_SANITIZE_FULL_SPECIAL_CHARS);
 

--- a/app/Controllers/Cashups.php
+++ b/app/Controllers/Cashups.php
@@ -48,8 +48,10 @@ class Cashups extends Secure_Controller
     public function getSearch(): ResponseInterface
     {
         $search = $this->request->getGet('search');
-        $limit = $this->request->getGet('limit', FILTER_SANITIZE_NUMBER_INT);
-        $offset = $this->request->getGet('offset', FILTER_SANITIZE_NUMBER_INT);
+        [$limit, $offset] = $this->sanitizeTablePagination(
+            $this->request->getGet('limit'),
+            $this->request->getGet('offset')
+        );
         $sort = $this->sanitizeSortColumn(cashup_headers(), $this->request->getGet('sort', FILTER_SANITIZE_FULL_SPECIAL_CHARS), 'cashup_id');
         $order = $this->request->getGet('order', FILTER_SANITIZE_FULL_SPECIAL_CHARS);
         $filters = [

--- a/app/Controllers/Config.php
+++ b/app/Controllers/Config.php
@@ -388,7 +388,7 @@ class Config extends Secure_Controller
             'default_receivings_discount'       => parse_decimals($this->request->getPost('default_receivings_discount')),
             'enforce_privacy'                   => $this->request->getPost('enforce_privacy') != null,
             'receiving_calculate_average_price' => $this->request->getPost('receiving_calculate_average_price') != null,
-            'lines_per_page'                    => $this->request->getPost('lines_per_page', FILTER_SANITIZE_NUMBER_INT),
+            'lines_per_page'                    => $this->sanitizeTablePageSize($this->request->getPost('lines_per_page')),
             'notify_horizontal_position'        => $this->request->getPost('notify_horizontal_position'),
             'notify_vertical_position'          => $this->request->getPost('notify_vertical_position'),
             'image_max_width'                   => $this->request->getPost('image_max_width', FILTER_SANITIZE_NUMBER_INT),

--- a/app/Controllers/Customers.php
+++ b/app/Controllers/Customers.php
@@ -86,8 +86,10 @@ class Customers extends Persons
     public function getSearch(): ResponseInterface
     {
         $search = $this->request->getGet('search');
-        $limit = $this->request->getGet('limit', FILTER_SANITIZE_NUMBER_INT);
-        $offset = $this->request->getGet('offset', FILTER_SANITIZE_NUMBER_INT);
+        [$limit, $offset] = $this->sanitizeTablePagination(
+            $this->request->getGet('limit'),
+            $this->request->getGet('offset')
+        );
         $sort = $this->sanitizeSortColumn(customer_headers(), $this->request->getGet('sort', FILTER_SANITIZE_FULL_SPECIAL_CHARS), 'people.person_id');
         $order = $this->request->getGet('order', FILTER_SANITIZE_FULL_SPECIAL_CHARS);
 

--- a/app/Controllers/Employees.php
+++ b/app/Controllers/Employees.php
@@ -30,8 +30,10 @@ class Employees extends Persons
     public function getSearch(): ResponseInterface
     {
         $search = $this->request->getGet('search');
-        $limit  = $this->request->getGet('limit', FILTER_SANITIZE_NUMBER_INT);
-        $offset = $this->request->getGet('offset', FILTER_SANITIZE_NUMBER_INT);
+        [$limit, $offset] = $this->sanitizeTablePagination(
+            $this->request->getGet('limit'),
+            $this->request->getGet('offset')
+        );
         $sort   = $this->sanitizeSortColumn(person_headers(), $this->request->getGet('sort', FILTER_SANITIZE_FULL_SPECIAL_CHARS), 'people.person_id');
         $order  = $this->request->getGet('order', FILTER_SANITIZE_FULL_SPECIAL_CHARS);
 

--- a/app/Controllers/Expenses.php
+++ b/app/Controllers/Expenses.php
@@ -50,8 +50,10 @@ class Expenses extends Secure_Controller
     public function getSearch(): ResponseInterface
     {
         $search   = $this->request->getGet('search');
-        $limit    = $this->request->getGet('limit', FILTER_SANITIZE_NUMBER_INT);
-        $offset   = $this->request->getGet('offset', FILTER_SANITIZE_NUMBER_INT);
+        [$limit, $offset] = $this->sanitizeTablePagination(
+            $this->request->getGet('limit'),
+            $this->request->getGet('offset')
+        );
         $sort     = $this->sanitizeSortColumn(expense_headers(), $this->request->getGet('sort', FILTER_SANITIZE_FULL_SPECIAL_CHARS), 'expense_id');
         $order    = $this->request->getGet('order', FILTER_SANITIZE_FULL_SPECIAL_CHARS);
         $filters  = [

--- a/app/Controllers/Expenses_categories.php
+++ b/app/Controllers/Expenses_categories.php
@@ -33,8 +33,10 @@ class Expenses_categories extends Secure_Controller    // TODO: Is this class ev
     public function getSearch(): ResponseInterface
     {
         $search = $this->request->getGet('search');
-        $limit  = $this->request->getGet('limit', FILTER_SANITIZE_NUMBER_INT);
-        $offset = $this->request->getGet('offset', FILTER_SANITIZE_NUMBER_INT);
+        [$limit, $offset] = $this->sanitizeTablePagination(
+            $this->request->getGet('limit'),
+            $this->request->getGet('offset')
+        );
         $sort   = $this->sanitizeSortColumn(expense_category_headers(), $this->request->getGet('sort', FILTER_SANITIZE_FULL_SPECIAL_CHARS), 'expense_category_id');
         $order  = $this->request->getGet('order', FILTER_SANITIZE_FULL_SPECIAL_CHARS);
 

--- a/app/Controllers/Giftcards.php
+++ b/app/Controllers/Giftcards.php
@@ -34,8 +34,10 @@ class Giftcards extends Secure_Controller
     public function getSearch(): ResponseInterface
     {
         $search = $this->request->getGet('search');
-        $limit  = $this->request->getGet('limit', FILTER_SANITIZE_NUMBER_INT);
-        $offset = $this->request->getGet('offset', FILTER_SANITIZE_NUMBER_INT);
+        [$limit, $offset] = $this->sanitizeTablePagination(
+            $this->request->getGet('limit'),
+            $this->request->getGet('offset')
+        );
         $sort   = $this->sanitizeSortColumn(giftcard_headers(), $this->request->getGet('sort', FILTER_SANITIZE_FULL_SPECIAL_CHARS), 'giftcard_id');
         $order  = $this->request->getGet('order', FILTER_SANITIZE_FULL_SPECIAL_CHARS);
 

--- a/app/Controllers/Item_kits.php
+++ b/app/Controllers/Item_kits.php
@@ -75,8 +75,10 @@ class Item_kits extends Secure_Controller
     public function getSearch(): ResponseInterface
     {
         $search = $this->request->getGet('search') ?? '';
-        $limit  = $this->request->getGet('limit', FILTER_SANITIZE_NUMBER_INT);
-        $offset = $this->request->getGet('offset', FILTER_SANITIZE_NUMBER_INT);
+        [$limit, $offset] = $this->sanitizeTablePagination(
+            $this->request->getGet('limit'),
+            $this->request->getGet('offset')
+        );
         $sort   = $this->sanitizeSortColumn(item_kit_headers(), $this->request->getGet('sort', FILTER_SANITIZE_FULL_SPECIAL_CHARS), 'item_kit_id');
         $order  = $this->request->getGet('order', FILTER_SANITIZE_FULL_SPECIAL_CHARS);
 

--- a/app/Controllers/Items.php
+++ b/app/Controllers/Items.php
@@ -109,8 +109,10 @@ class Items extends Secure_Controller
     public function getSearch(): ResponseInterface
     {
         $search = $this->request->getGet('search', FILTER_SANITIZE_FULL_SPECIAL_CHARS);
-        $limit = $this->request->getGet('limit', FILTER_SANITIZE_NUMBER_INT);
-        $offset = $this->request->getGet('offset', FILTER_SANITIZE_NUMBER_INT);
+        [$limit, $offset] = $this->sanitizeTablePagination(
+            $this->request->getGet('limit'),
+            $this->request->getGet('offset')
+        );
         $sort = $this->sanitizeSortColumn(item_headers(), $this->request->getGet('sort', FILTER_SANITIZE_FULL_SPECIAL_CHARS), 'item_id');
         $order = $this->request->getGet('order', FILTER_SANITIZE_FULL_SPECIAL_CHARS);
 

--- a/app/Controllers/Sales.php
+++ b/app/Controllers/Sales.php
@@ -148,8 +148,10 @@ class Sales extends Secure_Controller
     public function getSearch(): ResponseInterface
     {
         $search = $this->request->getGet('search', FILTER_SANITIZE_FULL_SPECIAL_CHARS);
-        $limit = $this->request->getGet('limit', FILTER_SANITIZE_NUMBER_INT);
-        $offset = $this->request->getGet('offset', FILTER_SANITIZE_NUMBER_INT);
+        [$limit, $offset] = $this->sanitizeTablePagination(
+            $this->request->getGet('limit'),
+            $this->request->getGet('offset')
+        );
         $sort = $this->sanitizeSortColumn(sales_headers(), $this->request->getGet('sort', FILTER_SANITIZE_FULL_SPECIAL_CHARS), 'sale_id');
         $order = $this->request->getGet('order', FILTER_SANITIZE_FULL_SPECIAL_CHARS);
 

--- a/app/Controllers/Secure_Controller.php
+++ b/app/Controllers/Secure_Controller.php
@@ -23,6 +23,9 @@ use Config\Services;
  */
 class Secure_Controller extends BaseController
 {
+    private const DEFAULT_TABLE_PAGE_SIZE = 25;
+    private const MAX_TABLE_PAGE_SIZE = 100;
+
     public array $global_view_data;
     protected Employee $employee;
     protected Module $module;
@@ -76,6 +79,38 @@ class Secure_Controller extends BaseController
     public function sanitizeSortColumn($headers, $field, $default): string
     {
         return $field != null && in_array($field, array_keys(array_merge(...$headers))) ? $field : $default;
+    }
+
+    protected static function sanitizeTablePagination(mixed $limit, mixed $offset): array
+    {
+        $pageSize = self::sanitizeTablePageSize($limit);
+
+        return [$pageSize, self::sanitizeTableOffset($offset)];
+    }
+
+    protected static function sanitizeTablePageSize(mixed $limit): int
+    {
+        if (! is_int($limit) && ! is_string($limit)) {
+            return self::DEFAULT_TABLE_PAGE_SIZE;
+        }
+
+        $pageSize = (string) $limit;
+        if ($pageSize === '' || !ctype_digit($pageSize) || $pageSize === '0') {
+            return self::DEFAULT_TABLE_PAGE_SIZE;
+        }
+
+        return min((int) $pageSize, self::MAX_TABLE_PAGE_SIZE);
+    }
+
+    protected static function sanitizeTableOffset(mixed $offset): int
+    {
+        if (! is_int($offset) && ! is_string($offset)) {
+            return 0;
+        }
+
+        $offset = (string) $offset;
+
+        return $offset !== '' && ctype_digit($offset) ? (int) $offset : 0;
     }
 
     /**

--- a/app/Controllers/Suppliers.php
+++ b/app/Controllers/Suppliers.php
@@ -47,8 +47,10 @@ class Suppliers extends Persons
     public function getSearch(): ResponseInterface
     {
         $search = $this->request->getGet('search');
-        $limit = $this->request->getGet('limit', FILTER_SANITIZE_NUMBER_INT);
-        $offset = $this->request->getGet('offset', FILTER_SANITIZE_NUMBER_INT);
+        [$limit, $offset] = $this->sanitizeTablePagination(
+            $this->request->getGet('limit'),
+            $this->request->getGet('offset')
+        );
         $sort = $this->sanitizeSortColumn(supplier_headers(), $this->request->getGet('sort', FILTER_SANITIZE_FULL_SPECIAL_CHARS), 'people.person_id');
         $order = $this->request->getGet('order', FILTER_SANITIZE_FULL_SPECIAL_CHARS);
 

--- a/app/Controllers/Tax_categories.php
+++ b/app/Controllers/Tax_categories.php
@@ -38,8 +38,10 @@ class Tax_categories extends Secure_Controller
     public function getSearch(): ResponseInterface
     {
         $search = $this->request->getGet('search');
-        $limit  = $this->request->getGet('limit', FILTER_SANITIZE_NUMBER_INT);
-        $offset = $this->request->getGet('offset', FILTER_SANITIZE_NUMBER_INT);
+        [$limit, $offset] = $this->sanitizeTablePagination(
+            $this->request->getGet('limit'),
+            $this->request->getGet('offset')
+        );
         $sort   = $this->sanitizeSortColumn(get_tax_categories_table_headers(), $this->request->getGet('sort', FILTER_SANITIZE_FULL_SPECIAL_CHARS), 'tax_category_id');
         $order  = $this->request->getGet('order', FILTER_SANITIZE_FULL_SPECIAL_CHARS);
 

--- a/app/Controllers/Tax_codes.php
+++ b/app/Controllers/Tax_codes.php
@@ -48,8 +48,10 @@ class Tax_codes extends Secure_Controller
     public function getSearch(): ResponseInterface
     {
         $search = $this->request->getGet('search');
-        $limit  = $this->request->getGet('limit', FILTER_SANITIZE_NUMBER_INT);
-        $offset = $this->request->getGet('offset', FILTER_SANITIZE_NUMBER_INT);
+        [$limit, $offset] = $this->sanitizeTablePagination(
+            $this->request->getGet('limit'),
+            $this->request->getGet('offset')
+        );
         $sort   = $this->sanitizeSortColumn(get_tax_code_table_headers(), $this->request->getGet('sort', FILTER_SANITIZE_FULL_SPECIAL_CHARS), 'tax_code');
         $order  = $this->request->getGet('order', FILTER_SANITIZE_FULL_SPECIAL_CHARS);
 

--- a/app/Controllers/Tax_jurisdictions.php
+++ b/app/Controllers/Tax_jurisdictions.php
@@ -41,8 +41,10 @@ class Tax_jurisdictions extends Secure_Controller
     public function getSearch(): ResponseInterface
     {
         $search = $this->request->getGet('search');
-        $limit  = $this->request->getGet('limit', FILTER_SANITIZE_NUMBER_INT);
-        $offset = $this->request->getGet('offset', FILTER_SANITIZE_NUMBER_INT);
+        [$limit, $offset] = $this->sanitizeTablePagination(
+            $this->request->getGet('limit'),
+            $this->request->getGet('offset')
+        );
         $sort   = $this->sanitizeSortColumn(get_tax_jurisdictions_table_headers(), $this->request->getGet('sort', FILTER_SANITIZE_FULL_SPECIAL_CHARS), 'jurisdiction_id');
         $order  = $this->request->getGet('order', FILTER_SANITIZE_FULL_SPECIAL_CHARS);
 

--- a/app/Controllers/Taxes.php
+++ b/app/Controllers/Taxes.php
@@ -79,8 +79,10 @@ class Taxes extends Secure_Controller
     public function getSearch(): ResponseInterface
     {
         $search = $this->request->getGet('search');
-        $limit = $this->request->getGet('limit', FILTER_SANITIZE_NUMBER_INT);
-        $offset = $this->request->getGet('offset', FILTER_SANITIZE_NUMBER_INT);
+        [$limit, $offset] = $this->sanitizeTablePagination(
+            $this->request->getGet('limit'),
+            $this->request->getGet('offset')
+        );
         $sort = $this->sanitizeSortColumn(get_tax_rates_manage_table_headers(), $this->request->getGet('sort', FILTER_SANITIZE_FULL_SPECIAL_CHARS), 'tax_rate_id');
         $order = $this->request->getGet('order', FILTER_SANITIZE_FULL_SPECIAL_CHARS);
 

--- a/tests/Controllers/SecureControllerTest.php
+++ b/tests/Controllers/SecureControllerTest.php
@@ -1,0 +1,29 @@
+<?php
+
+namespace Tests\Controllers;
+
+use App\Controllers\Secure_Controller;
+use CodeIgniter\Test\CIUnitTestCase;
+
+class SecureControllerTest extends CIUnitTestCase
+{
+    public function testTablePaginationUsesSafeDefaultsForInvalidValues(): void
+    {
+        $this->assertSame([25, 0], TestableSecureController::sanitizePagination('0', '-1'));
+        $this->assertSame([25, 0], TestableSecureController::sanitizePagination('not-a-number', []));
+    }
+
+    public function testTablePaginationCapsPageSizeAndPreservesValidOffset(): void
+    {
+        $this->assertSame([100, 50], TestableSecureController::sanitizePagination('1000', '50'));
+        $this->assertSame([50, 0], TestableSecureController::sanitizePagination(50, 0));
+    }
+}
+
+class TestableSecureController extends Secure_Controller
+{
+    public static function sanitizePagination(mixed $limit, mixed $offset): array
+    {
+        return self::sanitizeTablePagination($limit, $offset);
+    }
+}


### PR DESCRIPTION
## Summary

This PR centralizes pagination validation for management tables and adds consistent limits across pagination inputs.

* Caps search results at 100 rows per request.
* Falls back to the default page size of 25 for invalid or zero limits.
* Normalizes invalid offsets to `0`.
* Caps the **Lines per Page** configuration value at 100.

This prevents `limit=0` from bypassing SQL pagination and avoids unnecessarily large responses when loading management tables.

## Testing

* Ran PHP syntax checks on all modified files.
* Tested pagination handling with invalid, zero, oversized, and valid values.

The full PHPUnit suite was not run because Composer/PHPUnit is not available in the current environment.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved table pagination handling across searches and listings.
  * Invalid or empty pagination values now use safe defaults.
  * Page sizes are capped at 100 items, while valid offsets are preserved.
  * General page-size settings now receive consistent validation.

* **Tests**
  * Added coverage for default pagination behavior, maximum page sizes, and valid offsets.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->