### PR TITLE
bugfix(validation): tighten mailpath validation with strict path rule

### DIFF
--- a/app/Config/Validation/OSPOSRules.php
+++ b/app/Config/Validation/OSPOSRules.php
@@ -225,4 +225,24 @@ class OSPOSRules
 
         return true;
     }
+
+    /**
+     * Validates that the candidate is a plain filesystem path: only letters, digits,
+     * underscore, dash, dot and forward slash. Uses \A...\z (not ^...$) because PCRE's $
+     * also matches immediately before a single trailing newline, which would let a
+     * value like "/usr/bin/php\n" slip through — the bug behind GHSA-jc56-j8m6-q627.
+     *
+     * @param string $candidate
+     * @param string|null $error
+     * @return bool
+     * @noinspection PhpUnused
+     */
+    public function valid_path_strict(string $candidate, ?string &$error = null): bool
+    {
+        if ($candidate === '') {
+            return false;
+        }
+
+        return (bool) preg_match('/\A[a-zA-Z0-9_\-\/.]+\z/', $candidate);
+    }
 }

--- a/app/Controllers/Config.php
+++ b/app/Controllers/Config.php
@@ -540,16 +540,21 @@ class Config extends Secure_Controller
         $protocol = $this->request->getPost('protocol');
         $mailpath = $this->request->getPost('mailpath');
 
-        // Validate mailpath: required for sendmail, optional for others but must be safe if provided
-        $isMailpathRequired = ($protocol === 'sendmail');
-        $isMailpathProvided = !empty($mailpath);
-        $isMailpathValid = $isMailpathProvided && preg_match('/^[a-zA-Z0-9_\-\/.]+$/', $mailpath);
+        $rules = [
+            'mailpath' => [
+                'label' => lang('Config.email_mailpath'),
+                'rules' => ($protocol === 'sendmail' ? 'required' : 'permit_empty') . '|valid_path_strict'
+            ]
+        ];
+        $messages = [
+            'mailpath' => [
+                'required'          => lang('Config.mailpath_invalid'),
+                'valid_path_strict' => lang('Config.mailpath_invalid')
+            ]
+        ];
 
-        if (($isMailpathRequired && !$isMailpathProvided) || ($isMailpathProvided && !$isMailpathValid)) {
-            return $this->response->setJSON([
-                'success' => false,
-                'message' => lang('Config.mailpath_invalid')
-            ]);
+        if ($error = $this->validateFields($rules, $messages)) {
+            return $error;
         }
 
         $batch_save_data = [

--- a/tests/Config/Validation/OSPOSRulesTest.php
+++ b/tests/Config/Validation/OSPOSRulesTest.php
@@ -100,6 +100,32 @@ class OSPOSRulesTest extends CIUnitTestCase
         $this->assertNull($error);
     }
 
+    /**
+     * @dataProvider validPathStrictProvider
+     */
+    public function testValidPathStrict(string $candidate, bool $expected): void
+    {
+        $rules = new OSPOSRules();
+
+        $this->assertSame($expected, $rules->valid_path_strict($candidate));
+    }
+
+    public static function validPathStrictProvider(): array
+    {
+        return [
+            'plain sendmail path'                   => ['/usr/sbin/sendmail', true],
+            'plain php path'                        => ['/usr/bin/php', true],
+            'path with dash and underscore'         => ['/opt/my-mail_bin/sendmail.exe', true],
+            'empty string'                           => ['', false],
+            'trailing newline bypass payload'       => ["/usr/bin/php\n", false],
+            'trailing newline plus injected command' => ["/usr/bin/php\nid", false],
+            'embedded newline mid-string'           => ["/usr/bin/php\n/bin/sh", false],
+            'semicolon injection'                   => ['/usr/bin/php;id', false],
+            'pipe injection'                        => ['/usr/bin/php|id', false],
+            'space separated args'                  => ['/usr/bin/php -r "phpinfo();"', false],
+        ];
+    }
+
     private function injectSettings(array $settings): void
     {
         $ospos = new OSPOS();


### PR DESCRIPTION
## Summary

Refactors mailpath validation in `Config::verifyEmailSettings` to use the framework's standard validation pipeline instead of ad-hoc `preg_match` checks. Adds a new reusable `valid_path_strict` rule to `OSPOSRules` that restricts input to plain filesystem path characters (letters, digits, `_`, `-`, `.`, `/`).

## Changes

- `app/Config/Validation/OSPOSRules.php` — new `valid_path_strict` rule
- `app/Controllers/Config.php` — mailpath field now validated via `$this->validateFields()` with `required`/`permit_empty` + `valid_path_strict` rules, replacing manual regex/empty checks
- `tests/Config/Validation/OSPOSRulesTest.php` — unit tests covering valid paths and rejected inputs

## Test plan

- [X] Run `OSPOSRulesTest::testValidPathStrict` via PHPUnit
- [x] In Config settings, save email settings with protocol `sendmail` and a valid mailpath (e.g. `/usr/sbin/sendmail`) — should save successfully
- [x] Save with `sendmail` protocol and empty mailpath — should show validation error
- [x] Save with non-sendmail protocol and empty mailpath — should save successfully


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved email configuration validation for mail delivery paths.
  * Sendmail configurations now require a valid mail path.
  * Other mail protocols accept empty paths or safely formatted filesystem paths.
  * Invalid paths, including those containing commands, spaces, or unexpected line breaks, are rejected with clearer validation feedback.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->