### PR TITLE
fix(build): await all async gulp copy/exec calls to fix race condition breaking fresh-clone builds

### DIFF
--- a/BUILD.md
+++ b/BUILD.md
@@ -14,6 +14,7 @@ The build process uses the build tools "npm" and "gulp" to piece everything toge
 
 ## Prerequisites
 
+- Install Node.js 20 or later (the build fails on Node 18 and earlier - one of the license reporting dependencies requires newer JavaScript regex features)
 - Install the latest version of NPM (tested using version 9.4.2)
 - Install the latest version of Composer (tested using composer 2.5.1)
 

--- a/app/Controllers/Config.php
+++ b/app/Controllers/Config.php
@@ -158,14 +158,16 @@ class Config extends Secure_Controller
             $file = file_get_contents('license/npm-prod.LICENSES');
             $array = json_decode($file, true);
 
-            foreach ($array as $dependency) {
-                $license[$i]['text'] .= "library: {$dependency['name']}\n";
-                $license[$i]['text'] .= "authors: {$dependency['author']}\n";
-                $license[$i]['text'] .= "website: {$dependency['homepage']}\n";
-                $license[$i]['text'] .= "version: {$dependency['installedVersion']}\n";
-                $license[$i]['text'] .= "license: {$dependency['licenseType']}\n";
+            if (is_array($array)) {
+                foreach ($array as $dependency) {
+                    $license[$i]['text'] .= "library: {$dependency['name']}\n";
+                    $license[$i]['text'] .= "authors: {$dependency['author']}\n";
+                    $license[$i]['text'] .= "website: {$dependency['homepage']}\n";
+                    $license[$i]['text'] .= "version: {$dependency['installedVersion']}\n";
+                    $license[$i]['text'] .= "license: {$dependency['licenseType']}\n";
 
-                $license[$i]['text'] .= "\n";
+                    $license[$i]['text'] .= "\n";
+                }
             }
             $license[$i]['text'] = rtrim($license[$i]['text'], "\n");
         }
@@ -178,14 +180,16 @@ class Config extends Secure_Controller
             $file = file_get_contents('license/npm-dev.LICENSES');
             $array = json_decode($file, true);
 
-            foreach ($array as $dependency) {
-                $license[$i]['text'] .= "library: {$dependency['name']}\n";
-                $license[$i]['text'] .= "authors: {$dependency['author']}\n";
-                $license[$i]['text'] .= "website: {$dependency['homepage']}\n";
-                $license[$i]['text'] .= "version: {$dependency['installedVersion']}\n";
-                $license[$i]['text'] .= "license: {$dependency['licenseType']}\n";
+            if (is_array($array)) {
+                foreach ($array as $dependency) {
+                    $license[$i]['text'] .= "library: {$dependency['name']}\n";
+                    $license[$i]['text'] .= "authors: {$dependency['author']}\n";
+                    $license[$i]['text'] .= "website: {$dependency['homepage']}\n";
+                    $license[$i]['text'] .= "version: {$dependency['installedVersion']}\n";
+                    $license[$i]['text'] .= "license: {$dependency['licenseType']}\n";
 
-                $license[$i]['text'] .= "\n";
+                    $license[$i]['text'] .= "\n";
+                }
             }
             $license[$i]['text'] = rtrim($license[$i]['text'], "\n");
         }

--- a/app/Controllers/Config.php
+++ b/app/Controllers/Config.php
@@ -160,6 +160,10 @@ class Config extends Secure_Controller
 
             if (is_array($array)) {
                 foreach ($array as $dependency) {
+                    if (!is_array($dependency) || count(array_intersect(['name', 'author', 'homepage', 'installedVersion', 'licenseType'], array_keys($dependency))) !== 5) {
+                        continue;
+                    }
+
                     $license[$i]['text'] .= "library: {$dependency['name']}\n";
                     $license[$i]['text'] .= "authors: {$dependency['author']}\n";
                     $license[$i]['text'] .= "website: {$dependency['homepage']}\n";
@@ -182,6 +186,10 @@ class Config extends Secure_Controller
 
             if (is_array($array)) {
                 foreach ($array as $dependency) {
+                    if (!is_array($dependency) || count(array_intersect(['name', 'author', 'homepage', 'installedVersion', 'licenseType'], array_keys($dependency))) !== 5) {
+                        continue;
+                    }
+
                     $license[$i]['text'] .= "library: {$dependency['name']}\n";
                     $license[$i]['text'] .= "authors: {$dependency['author']}\n";
                     $license[$i]['text'] .= "website: {$dependency['homepage']}\n";

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -97,9 +97,11 @@ gulp.task('copy-bootswatch5', function() {
 
 // Copy the bootstrap style into its own folder so OSPOS can select it from the collection
 gulp.task('copy-bootstrap', function() {
-    pipeline(gulp.src('./node_modules/bootstrap/dist/css/bootstrap.min.css*'),gulp.dest('public/resources/bootswatch/bootstrap'));
-    pipeline(gulp.src('./node_modules/bootstrap5/dist/css/bootstrap.min.css*'),gulp.dest('public/resources/bootswatch5/bootstrap'));
-    return pipeline(gulp.src('./node_modules/bootstrap5/dist/css/bootstrap.rtl.min.css*'),gulp.dest('public/resources/bootswatch5/bootstrap'));
+    return Promise.all([
+        pipeline(gulp.src('./node_modules/bootstrap/dist/css/bootstrap.min.css*'),gulp.dest('public/resources/bootswatch/bootstrap')),
+        pipeline(gulp.src('./node_modules/bootstrap5/dist/css/bootstrap.min.css*'),gulp.dest('public/resources/bootswatch5/bootstrap')),
+        pipeline(gulp.src('./node_modules/bootstrap5/dist/css/bootstrap.rtl.min.css*'),gulp.dest('public/resources/bootswatch5/bootstrap'))
+    ]);
 });
 
 // /public/resources/ospos - contains the minimized files to be packed into opensourcepos.min.[css/js]

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -39,50 +39,56 @@ gulp.task('compress', function() {
 
 
 gulp.task('update-licenses', function() {
-    run('composer licenses --format=json --no-dev > public/license/composer.LICENSES').exec();
-    run('npx license-report --only=prod --output=json --fields=name --fields=author --fields=homepage --fields=installedVersion --fields=licenseType > public/license/npm-prod.LICENSES').exec();
-    run('npx license-report --only=dev --output=json --fields=name --fields=author --fields=homepage --fields=installedVersion --fields=licenseType > public/license/npm-dev.LICENSES').exec();
-    return pipeline(gulp.src('LICENSE'),gulp.dest('public/license'));
+    return Promise.all([
+        run('composer licenses --format=json --no-dev > public/license/composer.LICENSES').exec(),
+        run('npx license-report --only=prod --output=json --fields=name --fields=author --fields=homepage --fields=installedVersion --fields=licenseType > public/license/npm-prod.LICENSES').exec(),
+        run('npx license-report --only=dev --output=json --fields=name --fields=author --fields=homepage --fields=installedVersion --fields=licenseType > public/license/npm-dev.LICENSES').exec(),
+        pipeline(gulp.src('LICENSE'),gulp.dest('public/license'))
+    ]);
 });
 
 
 // Copy the bootswatch styles into their own folder so OSPOS can select one from the collection
 gulp.task('copy-bootswatch', function() {
-    pipeline(gulp.src('./node_modules/bootswatch/cerulean/*.min.css'),gulp.dest('public/resources/bootswatch/cerulean'));
-    pipeline(gulp.src('./node_modules/bootswatch/cosmo/*.min.css'),gulp.dest('public/resources/bootswatch/cosmo'));
-    pipeline(gulp.src('./node_modules/bootswatch/cyborg/*.min.css'),gulp.dest('public/resources/bootswatch/cyborg'));
-    pipeline(gulp.src('./node_modules/bootswatch/darkly/*.min.css'),gulp.dest('public/resources/bootswatch/darkly'));
-    pipeline(gulp.src('./node_modules/bootswatch/flatly/*.min.css'),gulp.dest('public/resources/bootswatch/flatly'));
-    pipeline(gulp.src('./node_modules/bootswatch/journal/*.min.css'),gulp.dest('public/resources/bootswatch/journal'));
-    pipeline(gulp.src('./node_modules/bootswatch/lumen/*.min.css'),gulp.dest('public/resources/bootswatch/lumen'));
-    pipeline(gulp.src('./node_modules/bootswatch/paper/*.min.css'),gulp.dest('public/resources/bootswatch/paper'));
-    pipeline(gulp.src('./node_modules/bootswatch/readable/*.min.css'),gulp.dest('public/resources/bootswatch/readable'));
-    pipeline(gulp.src('./node_modules/bootswatch/sandstone/*.min.css'),gulp.dest('public/resources/bootswatch/sandstone'));
-    pipeline(gulp.src('./node_modules/bootswatch/simplex/*.min.css'),gulp.dest('public/resources/bootswatch/simplex'));
-    pipeline(gulp.src('./node_modules/bootswatch/slate/*.min.css'),gulp.dest('public/resources/bootswatch/slate'));
-    pipeline(gulp.src('./node_modules/bootswatch/spacelab/*.min.css'),gulp.dest('public/resources/bootswatch/spacelab'));
-    pipeline(gulp.src('./node_modules/bootswatch/superhero/*.min.css'),gulp.dest('public/resources/bootswatch/superhero'));
-    pipeline(gulp.src('./node_modules/bootswatch/united/*.min.css'),gulp.dest('public/resources/bootswatch/united'));
-    pipeline(gulp.src('./node_modules/bootswatch/yeti/*.min.css'),gulp.dest('public/resources/bootswatch/yeti'));
-    return pipeline(gulp.src('./node_modules/bootswatch/fonts/*.*', {encoding:false}),gulp.dest('public/resources/bootswatch/fonts'));
+    return Promise.all([
+        pipeline(gulp.src('./node_modules/bootswatch/cerulean/*.min.css'),gulp.dest('public/resources/bootswatch/cerulean')),
+        pipeline(gulp.src('./node_modules/bootswatch/cosmo/*.min.css'),gulp.dest('public/resources/bootswatch/cosmo')),
+        pipeline(gulp.src('./node_modules/bootswatch/cyborg/*.min.css'),gulp.dest('public/resources/bootswatch/cyborg')),
+        pipeline(gulp.src('./node_modules/bootswatch/darkly/*.min.css'),gulp.dest('public/resources/bootswatch/darkly')),
+        pipeline(gulp.src('./node_modules/bootswatch/flatly/*.min.css'),gulp.dest('public/resources/bootswatch/flatly')),
+        pipeline(gulp.src('./node_modules/bootswatch/journal/*.min.css'),gulp.dest('public/resources/bootswatch/journal')),
+        pipeline(gulp.src('./node_modules/bootswatch/lumen/*.min.css'),gulp.dest('public/resources/bootswatch/lumen')),
+        pipeline(gulp.src('./node_modules/bootswatch/paper/*.min.css'),gulp.dest('public/resources/bootswatch/paper')),
+        pipeline(gulp.src('./node_modules/bootswatch/readable/*.min.css'),gulp.dest('public/resources/bootswatch/readable')),
+        pipeline(gulp.src('./node_modules/bootswatch/sandstone/*.min.css'),gulp.dest('public/resources/bootswatch/sandstone')),
+        pipeline(gulp.src('./node_modules/bootswatch/simplex/*.min.css'),gulp.dest('public/resources/bootswatch/simplex')),
+        pipeline(gulp.src('./node_modules/bootswatch/slate/*.min.css'),gulp.dest('public/resources/bootswatch/slate')),
+        pipeline(gulp.src('./node_modules/bootswatch/spacelab/*.min.css'),gulp.dest('public/resources/bootswatch/spacelab')),
+        pipeline(gulp.src('./node_modules/bootswatch/superhero/*.min.css'),gulp.dest('public/resources/bootswatch/superhero')),
+        pipeline(gulp.src('./node_modules/bootswatch/united/*.min.css'),gulp.dest('public/resources/bootswatch/united')),
+        pipeline(gulp.src('./node_modules/bootswatch/yeti/*.min.css'),gulp.dest('public/resources/bootswatch/yeti')),
+        pipeline(gulp.src('./node_modules/bootswatch/fonts/*.*', {encoding:false}),gulp.dest('public/resources/bootswatch/fonts'))
+    ]);
 });
 
 // Copy the bootswatch styles into their own folder so OSPOS can select one from the collection
 gulp.task('copy-bootswatch5', function() {
-    pipeline(gulp.src('./node_modules/bootswatch5/dist/cerulean/*.min.css'),gulp.dest('public/resources/bootswatch5/cerulean'));
-    pipeline(gulp.src('./node_modules/bootswatch5/dist/cosmo/*.min.css'),gulp.dest('public/resources/bootswatch5/cosmo'));
-    pipeline(gulp.src('./node_modules/bootswatch5/dist/cyborg/*.min.css'),gulp.dest('public/resources/bootswatch5/cyborg'));
-    pipeline(gulp.src('./node_modules/bootswatch5/dist/darkly/*.min.css'),gulp.dest('public/resources/bootswatch5/darkly'));
-    pipeline(gulp.src('./node_modules/bootswatch5/dist/flatly/*.min.css'),gulp.dest('public/resources/bootswatch5/flatly'));
-    pipeline(gulp.src('./node_modules/bootswatch5/dist/journal/*.min.css'),gulp.dest('public/resources/bootswatch5/journal'));
-    pipeline(gulp.src('./node_modules/bootswatch5/dist/lumen/*.min.css'),gulp.dest('public/resources/bootswatch5/lumen'));
-    pipeline(gulp.src('./node_modules/bootswatch5/dist/sandstone/*.min.css'),gulp.dest('public/resources/bootswatch5/sandstone'));
-    pipeline(gulp.src('./node_modules/bootswatch5/dist/simplex/*.min.css'),gulp.dest('public/resources/bootswatch5/simplex'));
-    pipeline(gulp.src('./node_modules/bootswatch5/dist/slate/*.min.css'),gulp.dest('public/resources/bootswatch5/slate'));
-    pipeline(gulp.src('./node_modules/bootswatch5/dist/spacelab/*.min.css'),gulp.dest('public/resources/bootswatch5/spacelab'));
-    pipeline(gulp.src('./node_modules/bootswatch5/dist/superhero/*.min.css'),gulp.dest('public/resources/bootswatch5/superhero'));
-    pipeline(gulp.src('./node_modules/bootswatch5/dist/united/*.min.css'),gulp.dest('public/resources/bootswatch5/united'));
-    return pipeline(gulp.src('./node_modules/bootswatch5/dist/yeti/*.min.css'),gulp.dest('public/resources/bootswatch5/yeti'));
+    return Promise.all([
+        pipeline(gulp.src('./node_modules/bootswatch5/dist/cerulean/*.min.css'),gulp.dest('public/resources/bootswatch5/cerulean')),
+        pipeline(gulp.src('./node_modules/bootswatch5/dist/cosmo/*.min.css'),gulp.dest('public/resources/bootswatch5/cosmo')),
+        pipeline(gulp.src('./node_modules/bootswatch5/dist/cyborg/*.min.css'),gulp.dest('public/resources/bootswatch5/cyborg')),
+        pipeline(gulp.src('./node_modules/bootswatch5/dist/darkly/*.min.css'),gulp.dest('public/resources/bootswatch5/darkly')),
+        pipeline(gulp.src('./node_modules/bootswatch5/dist/flatly/*.min.css'),gulp.dest('public/resources/bootswatch5/flatly')),
+        pipeline(gulp.src('./node_modules/bootswatch5/dist/journal/*.min.css'),gulp.dest('public/resources/bootswatch5/journal')),
+        pipeline(gulp.src('./node_modules/bootswatch5/dist/lumen/*.min.css'),gulp.dest('public/resources/bootswatch5/lumen')),
+        pipeline(gulp.src('./node_modules/bootswatch5/dist/sandstone/*.min.css'),gulp.dest('public/resources/bootswatch5/sandstone')),
+        pipeline(gulp.src('./node_modules/bootswatch5/dist/simplex/*.min.css'),gulp.dest('public/resources/bootswatch5/simplex')),
+        pipeline(gulp.src('./node_modules/bootswatch5/dist/slate/*.min.css'),gulp.dest('public/resources/bootswatch5/slate')),
+        pipeline(gulp.src('./node_modules/bootswatch5/dist/spacelab/*.min.css'),gulp.dest('public/resources/bootswatch5/spacelab')),
+        pipeline(gulp.src('./node_modules/bootswatch5/dist/superhero/*.min.css'),gulp.dest('public/resources/bootswatch5/superhero')),
+        pipeline(gulp.src('./node_modules/bootswatch5/dist/united/*.min.css'),gulp.dest('public/resources/bootswatch5/united')),
+        pipeline(gulp.src('./node_modules/bootswatch5/dist/yeti/*.min.css'),gulp.dest('public/resources/bootswatch5/yeti'))
+    ]);
 });
 
 // Copy the bootstrap style into its own folder so OSPOS can select it from the collection
@@ -277,25 +283,27 @@ gulp.task('copy-fonts', function() {
 
 
 gulp.task('copy-menubar', function() {
-    pipeline(gulp.src("./node_modules/elegant-circles/svg/full-color/star.svg"),rename("attributes.svg"),gulp.dest("public/images/menubar"));
-    pipeline(gulp.src("./node_modules/elegant-circles/svg/full-color/bookshelf.svg"),rename("cashups.svg"),gulp.dest("public/images/menubar"));
-    pipeline(gulp.src("./node_modules/elegant-circles/svg/full-color/gear.svg"),rename("config.svg"),gulp.dest("public/images/menubar"));
-    pipeline(gulp.src("./node_modules/elegant-circles/svg/full-color/contacts.svg"),rename("customers.svg"),gulp.dest("public/images/menubar"));
-    pipeline(gulp.src("./node_modules/elegant-circles/svg/full-color/profle.svg"),rename("employees.svg"),gulp.dest("public/images/menubar"));
-    pipeline(gulp.src("./node_modules/elegant-circles/svg/full-color/compose.svg"),rename("expenses.svg"),gulp.dest("public/images/menubar"));
-    pipeline(gulp.src("./node_modules/elegant-circles/svg/full-color/clipboard.svg"),rename("expenses_categories.svg"),gulp.dest("public/images/menubar"));
-    pipeline(gulp.src("./node_modules/elegant-circles/svg/full-color/heart.svg"),rename("giftcards.svg"),gulp.dest("public/images/menubar"));
-    pipeline(gulp.src("./node_modules/elegant-circles/svg/full-color/door.svg"),rename("home.svg"),gulp.dest("public/images/menubar"));
-    pipeline(gulp.src("./node_modules/elegant-circles/svg/full-color/stack.svg"),rename("item_kits.svg"),gulp.dest("public/images/menubar"));
-    pipeline(gulp.src("./node_modules/elegant-circles/svg/full-color/shop.svg"),rename("items.svg"),gulp.dest("public/images/menubar"));
-    pipeline(gulp.src("./node_modules/elegant-circles/svg/full-color/smartphone.svg"),rename("messages.svg"),gulp.dest("public/images/menubar"));
-    pipeline(gulp.src("./node_modules/elegant-circles/svg/full-color/tools.svg"),rename("migrate.svg"),gulp.dest("public/images/menubar"));
-    pipeline(gulp.src("./node_modules/elegant-circles/svg/full-color/door.svg"),rename("office.svg"),gulp.dest("public/images/menubar"));
-    pipeline(gulp.src("./node_modules/elegant-circles/svg/full-color/dolly.svg"),rename("receivings.svg"),gulp.dest("public/images/menubar"));
-    pipeline(gulp.src("./node_modules/elegant-circles/svg/full-color/bar-chart.svg"),rename("reports.svg"),gulp.dest("public/images/menubar"));
-    pipeline(gulp.src("./node_modules/elegant-circles/svg/full-color/cart.svg"),rename("sales.svg"),gulp.dest("public/images/menubar"));
-    pipeline(gulp.src("./node_modules/elegant-circles/svg/full-color/briefcase.svg"),rename("suppliers.svg"),gulp.dest("public/images/menubar"));
-    return pipeline(gulp.src('./node_modules/elegant-circles/svg/full-color/money.svg'),rename("taxes.svg"),gulp.dest("public/images/menubar"));
+    return Promise.all([
+        pipeline(gulp.src("./node_modules/elegant-circles/svg/full-color/star.svg"),rename("attributes.svg"),gulp.dest("public/images/menubar")),
+        pipeline(gulp.src("./node_modules/elegant-circles/svg/full-color/bookshelf.svg"),rename("cashups.svg"),gulp.dest("public/images/menubar")),
+        pipeline(gulp.src("./node_modules/elegant-circles/svg/full-color/gear.svg"),rename("config.svg"),gulp.dest("public/images/menubar")),
+        pipeline(gulp.src("./node_modules/elegant-circles/svg/full-color/contacts.svg"),rename("customers.svg"),gulp.dest("public/images/menubar")),
+        pipeline(gulp.src("./node_modules/elegant-circles/svg/full-color/profle.svg"),rename("employees.svg"),gulp.dest("public/images/menubar")),
+        pipeline(gulp.src("./node_modules/elegant-circles/svg/full-color/compose.svg"),rename("expenses.svg"),gulp.dest("public/images/menubar")),
+        pipeline(gulp.src("./node_modules/elegant-circles/svg/full-color/clipboard.svg"),rename("expenses_categories.svg"),gulp.dest("public/images/menubar")),
+        pipeline(gulp.src("./node_modules/elegant-circles/svg/full-color/heart.svg"),rename("giftcards.svg"),gulp.dest("public/images/menubar")),
+        pipeline(gulp.src("./node_modules/elegant-circles/svg/full-color/door.svg"),rename("home.svg"),gulp.dest("public/images/menubar")),
+        pipeline(gulp.src("./node_modules/elegant-circles/svg/full-color/stack.svg"),rename("item_kits.svg"),gulp.dest("public/images/menubar")),
+        pipeline(gulp.src("./node_modules/elegant-circles/svg/full-color/shop.svg"),rename("items.svg"),gulp.dest("public/images/menubar")),
+        pipeline(gulp.src("./node_modules/elegant-circles/svg/full-color/smartphone.svg"),rename("messages.svg"),gulp.dest("public/images/menubar")),
+        pipeline(gulp.src("./node_modules/elegant-circles/svg/full-color/tools.svg"),rename("migrate.svg"),gulp.dest("public/images/menubar")),
+        pipeline(gulp.src("./node_modules/elegant-circles/svg/full-color/door.svg"),rename("office.svg"),gulp.dest("public/images/menubar")),
+        pipeline(gulp.src("./node_modules/elegant-circles/svg/full-color/dolly.svg"),rename("receivings.svg"),gulp.dest("public/images/menubar")),
+        pipeline(gulp.src("./node_modules/elegant-circles/svg/full-color/bar-chart.svg"),rename("reports.svg"),gulp.dest("public/images/menubar")),
+        pipeline(gulp.src("./node_modules/elegant-circles/svg/full-color/cart.svg"),rename("sales.svg"),gulp.dest("public/images/menubar")),
+        pipeline(gulp.src("./node_modules/elegant-circles/svg/full-color/briefcase.svg"),rename("suppliers.svg"),gulp.dest("public/images/menubar")),
+        pipeline(gulp.src('./node_modules/elegant-circles/svg/full-color/money.svg'),rename("taxes.svg"),gulp.dest("public/images/menubar"))
+    ]);
 });
 
 

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -39,10 +39,14 @@ gulp.task('compress', function() {
 
 
 gulp.task('update-licenses', function() {
+    function run_completion(execStream) {
+        return finished(execStream.resume());
+    }
+
     return Promise.all([
-        finished(run('composer licenses --format=json --no-dev > public/license/composer.LICENSES').exec()),
-        finished(run('npx license-report --only=prod --output=json --fields=name --fields=author --fields=homepage --fields=installedVersion --fields=licenseType > public/license/npm-prod.LICENSES').exec()),
-        finished(run('npx license-report --only=dev --output=json --fields=name --fields=author --fields=homepage --fields=installedVersion --fields=licenseType > public/license/npm-dev.LICENSES').exec()),
+        run_completion(run('composer licenses --format=json --no-dev > public/license/composer.LICENSES').exec()),
+        run_completion(run('npx license-report --only=prod --output=json --fields=name --fields=author --fields=homepage --fields=installedVersion --fields=licenseType > public/license/npm-prod.LICENSES').exec()),
+        run_completion(run('npx license-report --only=dev --output=json --fields=name --fields=author --fields=homepage --fields=installedVersion --fields=licenseType > public/license/npm-dev.LICENSES').exec()),
         pipeline(gulp.src('LICENSE'),gulp.dest('public/license'))
     ]);
 });

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -40,9 +40,9 @@ gulp.task('compress', function() {
 
 gulp.task('update-licenses', function() {
     return Promise.all([
-        run('composer licenses --format=json --no-dev > public/license/composer.LICENSES').exec(),
-        run('npx license-report --only=prod --output=json --fields=name --fields=author --fields=homepage --fields=installedVersion --fields=licenseType > public/license/npm-prod.LICENSES').exec(),
-        run('npx license-report --only=dev --output=json --fields=name --fields=author --fields=homepage --fields=installedVersion --fields=licenseType > public/license/npm-dev.LICENSES').exec(),
+        finished(run('composer licenses --format=json --no-dev > public/license/composer.LICENSES').exec()),
+        finished(run('npx license-report --only=prod --output=json --fields=name --fields=author --fields=homepage --fields=installedVersion --fields=licenseType > public/license/npm-prod.LICENSES').exec()),
+        finished(run('npx license-report --only=dev --output=json --fields=name --fields=author --fields=homepage --fields=installedVersion --fields=licenseType > public/license/npm-dev.LICENSES').exec()),
         pipeline(gulp.src('LICENSE'),gulp.dest('public/license'))
     ]);
 });

--- a/package-lock.json
+++ b/package-lock.json
@@ -61,6 +61,9 @@
                 "npm-check-updates": "^22.1.1",
                 "readable-stream": "^4.4.2",
                 "stream-series": "^0.1.1"
+            },
+            "engines": {
+                "node": ">=20"
             }
         },
         "node_modules/@babel/runtime": {

--- a/package.json
+++ b/package.json
@@ -24,6 +24,9 @@
     ],
     "type": "module",
     "main": "index.php",
+    "engines": {
+        "node": ">=20"
+    },
     "scripts": {
         "build": "gulp default",
         "gulp": "gulp"


### PR DESCRIPTION
### Problem
On a fresh clone, `composer install` + `npm ci`/`npm install` + `npm run build` intermittently produces:
- Missing menubar SVG icons
- Missing/partial CSS/JS
- A crash on `/config`:

### Root cause
Several `gulpfile.js` tasks (`update-licenses`, `copy-bootswatch`, `copy-bootswatch5`, `copy-menubar`) fire off multiple async `pipeline(...)` / `run(...).exec()` calls but only `return` the *last* one. Gulp (and `gulp.series`) considers a task complete as soon as its returned promise/stream resolves — the other calls keep running detached in the background with no guarantee they finish before the next task starts or the process exits.

This makes the build a race condition:
- `update-licenses` fires 3 unawaited shell commands (`composer licenses`, `npx license-report --only=prod`, `npx license-report --only=dev`) that redirect output into `public/license/*.LICENSES`. If the process exits before these subprocesses finish writing, the files end up missing or empty.
- `Config.php::_licenses()` detects `npm-prod.LICENSES` exists and attempts `json_decode()` + `foreach` over it — an empty file decodes to `null`, causing the crash.
- `copy-menubar` and `copy-bootswatch`/`copy-bootswatch5` have the same pattern, causing intermittently missing SVG icons and theme CSS.

Because the race outcome depends on shell spawn latency (`gulp-run` uses `cmd.exe` on Windows vs `sh` elsewhere) and machine speed, the bug doesn't reproduce consistently — explaining why it wasn't caught before.

### Fix
- `gulpfile.js`: in `update-licenses`, `copy-bootswatch`, `copy-bootswatch5`, and `copy-menubar`, collect all async calls into an array and `return Promise.all([...])` so the task doesn't resolve until every copy/shell command has actually completed.
- `app/Controllers/Config.php`: guard the `npm-prod.LICENSES` and `npm-dev.LICENSES` `foreach` loops with `is_array($array)` checks, so a missing/empty/corrupt license file degrades gracefully instead of crashing.

### Testing
- [X] Delete `public/resources`, `public/images/menubar`, `public/license`, run `npm run build`, confirm all license files are non-empty valid JSON and all 19 menubar SVGs are present.
- [X] Load `/config` after a build — no crash, license sections render correctly.


closing #4670 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved license information generation by safely handling incomplete or unexpectedly formatted dependency data.
  * Ensured license updates and interface asset copies finish reliably before related tasks complete.

* **Improvements**
  * Improved the reliability of license report processing and interface asset updates, helping prevent incomplete results and ensuring generated files are fully up to date.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->